### PR TITLE
Fixing double return

### DIFF
--- a/src/backend/jag-efiling-api/jag-efiling-api.yaml
+++ b/src/backend/jag-efiling-api/jag-efiling-api.yaml
@@ -69,7 +69,7 @@ components:
         expiryDate:
           type: integer
           format: int64
-        eFilingUrl:
+        efilingUrl:
           type: string
     UserDetail:
       type: object

--- a/src/backend/jag-efiling-api/src/main/java/ca/bc/gov/open/jagefilingapi/submission/SubmissionApiImpl.java
+++ b/src/backend/jag-efiling-api/src/main/java/ca/bc/gov/open/jagefilingapi/submission/SubmissionApiImpl.java
@@ -69,10 +69,8 @@ public class SubmissionApiImpl implements SubmissionApiDelegate {
         if(!cachedSubmission.isPresent())
             return ResponseEntity.badRequest().body(null);
 
-
         logger.warn("Id is modified for testing purpose 0 or 1 is appended to it.");
-
-        response.setEFilingUrl(
+        response.setEfilingUrl(
                 MessageFormat.format(
                                "{0}/{1}{2}",
                                 navigationProperties.getBaseUrl(),

--- a/src/backend/jag-efiling-api/src/test/java/ca/bc/gov/open/jagefilingapi/submission/SubmissionApiImplTest.java
+++ b/src/backend/jag-efiling-api/src/test/java/ca/bc/gov/open/jagefilingapi/submission/SubmissionApiImplTest.java
@@ -87,7 +87,7 @@ public class SubmissionApiImplTest {
         ResponseEntity<GenerateUrlResponse> actual = sut.generateUrl(generateUrlRequest);
 
         assertEquals(HttpStatus.OK, actual.getStatusCode());
-        assertTrue(actual.getBody().getEFilingUrl().startsWith("https://httpbin.org/"));
+        assertTrue(actual.getBody().getEfilingUrl().startsWith("https://httpbin.org/"));
         assertNotNull(actual.getBody().getExpiryDate());
     }
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- fix issue with efilingUrl duplicate now returns:

```
{
    "expiryDate": 1592430754646,
    "efilingUrl": "http://httpbin3.org/ab6dd697-17fa-4be3-87c6-7c854bb5e479"
}
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
