### PR TITLE
Home component userdetail call update and also storing of navigation details

### DIFF
--- a/src/frontend/efiling-demo/src/components/page/home/Home.js
+++ b/src/frontend/efiling-demo/src/components/page/home/Home.js
@@ -27,7 +27,7 @@ const urlBody = {
       url: "string"
     },
     cancel: {
-      url: "string"
+      url: "http://localhost:3001/efiling-demo"
     }
   }
 };

--- a/src/frontend/efiling-frontend/src/components/composite/csostatus/CSOStatus.js
+++ b/src/frontend/efiling-frontend/src/components/composite/csostatus/CSOStatus.js
@@ -8,7 +8,9 @@ export default function CSOStatus({ accountExists }) {
       {accountExists && <p>Account exists! Proceed</p>}
       {!accountExists && <p>Account does not exist, form will be here</p>}
       <Button
-        onClick={() => {}}
+        onClick={() => {
+          window.open(sessionStorage.getItem("cancelUrl"), "_self");
+        }}
         label="Cancel and return to client"
         styling="normal-white btn"
       />

--- a/src/frontend/efiling-frontend/src/components/page/home/Home.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.js
@@ -14,7 +14,7 @@ export const saveNavigationToSession = ({ cancel, success, error }) => {
   if (error.url) sessionStorage.setItem("errorUrl", error.url);
 };
 
-// make call to submission/{id} to get the user details
+// make call to submission/{id} to get the user and navigation details
 const checkCSOAccountStatus = (
   submissionId,
   setCsoAccountExists,

--- a/src/frontend/efiling-frontend/src/components/page/home/Home.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.js
@@ -8,15 +8,22 @@ import CSOStatus from "../../composite/csostatus/CSOStatus";
 
 import "../page.css";
 
-// make call to submission/{id}/userDetail to get the user details
+export const saveNavigationToSession = ({ cancel, success, error }) => {
+  if (cancel.url) sessionStorage.setItem("cancelUrl", cancel.url);
+  if (success.url) sessionStorage.setItem("successUrl", success.url);
+  if (error.url) sessionStorage.setItem("errorUrl", error.url);
+};
+
+// make call to submission/{id} to get the user details
 const checkCSOAccountStatus = (
   submissionId,
   setCsoAccountExists,
   setShowLoader
 ) => {
   axios
-    .get(`/submission/${submissionId}/userDetail`)
-    .then(({ data: { csoAccountExists } }) => {
+    .get(`/submission/${submissionId}`)
+    .then(({ data: { csoAccountExists, navigation } }) => {
+      saveNavigationToSession(navigation);
       if (csoAccountExists) setCsoAccountExists(true);
       setShowLoader(false);
     })

--- a/src/frontend/efiling-frontend/src/components/page/home/Home.stories.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.stories.js
@@ -19,7 +19,18 @@ const page = { header };
 
 const submissionId = "abc123";
 const mock = new MockAdapter(axios);
-const apiRequest = `/submission/${submissionId}/userDetail`;
+const apiRequest = `/submission/${submissionId}`;
+const navigation = {
+  cancel: {
+    url: "cancelurl.com"
+  },
+  success: {
+    url: "successurl.com"
+  },
+  error: {
+    url: ""
+  }
+};
 
 const LoaderStateData = props => {
   mock.onGet(apiRequest).reply(400);
@@ -27,12 +38,12 @@ const LoaderStateData = props => {
 };
 
 const AccountExistsStateData = props => {
-  mock.onGet(apiRequest).reply(200, { csoAccountExists: true });
+  mock.onGet(apiRequest).reply(200, { csoAccountExists: true, navigation });
   return props.children({ page });
 };
 
 const NoAccountExistsStateData = props => {
-  mock.onGet(apiRequest).reply(200, { csoAccountExists: false });
+  mock.onGet(apiRequest).reply(200, { csoAccountExists: false, navigation });
   return props.children({ page });
 };
 

--- a/src/frontend/shared-components/jest.config.js
+++ b/src/frontend/shared-components/jest.config.js
@@ -19,6 +19,6 @@ module.exports = {
   verbose: true,
   testResultsProcessor: "jest-sonar-reporter",
   collectCoverage: false,
-  coverageReporters: ["text", ["lcov", {"projectRoot": "../../../"}]],
+  coverageReporters: ["text", ["lcov", { projectRoot: "../../../" }]],
   coverageDirectory: "coverage"
 };


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Home component userdetail call update and also storing of navigation details
- add in cancel url to initial call and use it within cancel button

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Local
- Jest
- Story
