### PR TITLE
Return of Roleregistry

### DIFF
--- a/src/backend/libs/efiling-account-client/src/main/java/ca/bc/gov/open/jag/efilingaccountclient/CsoAccountDetails.java
+++ b/src/backend/libs/efiling-account-client/src/main/java/ca/bc/gov/open/jag/efilingaccountclient/CsoAccountDetails.java
@@ -4,55 +4,27 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
 
 public class CsoAccountDetails {
-
-
-    public CsoAccountDetails(
-            @JsonProperty("accountId") BigDecimal accountId,
-            @JsonProperty("clientId") BigDecimal clientId) {
-
-        this.accountId = accountId;
-        this.clientId = clientId;
-    }
 
     @JsonCreator
     public CsoAccountDetails(
             @JsonProperty("accountId") BigDecimal accountId,
             @JsonProperty("clientId") BigDecimal clientId,
-            @JsonProperty("roles") List<String> roles) {
+            @JsonProperty("hasEfileRole") boolean hasEfileRole) {
 
-        this(accountId, clientId);
-
-        for (String role: roles) {
-            String toAdd = role.toLowerCase();
-            this.roles.add(toAdd);
-        }
+        this.accountId = accountId;
+        this.clientId = clientId;
+        this.hasEfileRole = hasEfileRole;
     }
 
     private BigDecimal accountId;
     private BigDecimal clientId;
-    private List<String> roles = new ArrayList<>();
+    private boolean hasEfileRole;
 
-    public BigDecimal getAccountId() {
-        return accountId;
-    }
-
+    public BigDecimal getAccountId() { return accountId; }
     public BigDecimal getClientId() {
         return clientId;
     }
-
-    public List<String> getRoles() { return roles; }
-
-    public void addRole(String role) {
-        this.roles.add(role.toLowerCase());
-    }
-
-    public boolean HasRole(String role) {
-        String toFind = role.toLowerCase();
-        return roles.stream().anyMatch(r -> r.equals(toFind));
-    }
-
+    public boolean getHasEfileRole() { return hasEfileRole; }
 }

--- a/src/backend/libs/efiling-account-client/src/main/java/ca/bc/gov/open/jag/efilingaccountclient/DemoAccountServiceImpl.java
+++ b/src/backend/libs/efiling-account-client/src/main/java/ca/bc/gov/open/jag/efilingaccountclient/DemoAccountServiceImpl.java
@@ -10,20 +10,17 @@ import java.util.*;
 public class DemoAccountServiceImpl implements EfilingAccountService {
 
     public static final UUID ACCOUNT_WITH_EFILING_ROLE = UUID.fromString("77da92db-0791-491e-8c58-1a969e67d2fa");
-    public static final UUID ACCOUNT_WITH_ADMIN_ROLE = UUID.fromString("77da92db-0791-491e-8c58-1a969e67d2fb");
+    public static final UUID ACCOUNT_WITHOUT_EFILING_ROLE = UUID.fromString("77da92db-0791-491e-8c58-1a969e67d2fb");
 
     private Map<String, CsoAccountDetails> csoAccounts = new HashMap<>();
 
     public DemoAccountServiceImpl() {
 
-        CsoAccountDetails accountWithEfilingRole = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN);
-        accountWithEfilingRole.addRole("efiling");
-
-        CsoAccountDetails accountWithDifferentRole = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN);
-        accountWithDifferentRole.addRole("admin");
+        CsoAccountDetails accountWithEfilingRole = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN, true);
+        CsoAccountDetails accountWithOutEfilingRole = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN, false);
 
         csoAccounts.put(ACCOUNT_WITH_EFILING_ROLE.toString(), accountWithEfilingRole);
-        csoAccounts.put(ACCOUNT_WITH_ADMIN_ROLE.toString(), accountWithDifferentRole);
+        csoAccounts.put(ACCOUNT_WITHOUT_EFILING_ROLE.toString(), accountWithOutEfilingRole);
 
     }
 

--- a/src/backend/libs/efiling-account-client/src/main/java/ca/bc/gov/open/jag/efilingaccountclient/config/AutoConfiguration.java
+++ b/src/backend/libs/efiling-account-client/src/main/java/ca/bc/gov/open/jag/efilingaccountclient/config/AutoConfiguration.java
@@ -49,8 +49,8 @@ public class AutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean({EfilingAccountService.class})
-    public EfilingAccountService efilingAccountService(AccountFacadeBean accountFacadeBean) {
-        return new CsoAccountServiceImpl(accountFacadeBean);
+    public EfilingAccountService efilingAccountService(AccountFacadeBean accountFacadeBean, RoleRegistryPortType roleRegistryPortType) {
+        return new CsoAccountServiceImpl(accountFacadeBean, roleRegistryPortType);
     }
 
 

--- a/src/backend/libs/efiling-account-client/src/test/java/ca/bc/gov/open/jag/efilingaccountclient/CsoAccountServiceImplTest.java
+++ b/src/backend/libs/efiling-account-client/src/test/java/ca/bc/gov/open/jag/efilingaccountclient/CsoAccountServiceImplTest.java
@@ -46,7 +46,6 @@ public class CsoAccountServiceImplTest {
 
         MockitoAnnotations.initMocks(this);
 
-        CsoAccountDetails details = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN);
         ClientProfile profile =  new ClientProfile();
         profile.setAccountId(BigDecimal.TEN);
         profile.setClientId(BigDecimal.TEN);
@@ -70,7 +69,7 @@ public class CsoAccountServiceImplTest {
         Mockito.when(mockRoleRegistryPortType.getRolesForIdentifier("Courts", "CSO", USERGUIDNOROLE, "CAP")).thenReturn(userRolesWithoutFileRole);
     }
 
-    @DisplayName("getAccountDetails called with empty userGuid should return null")
+    @DisplayName("getAccountDetails called with empty userGuid")
     @Test
     public void testWithEmptyUserGuid() throws NestedEjbException_Exception {
 
@@ -78,7 +77,7 @@ public class CsoAccountServiceImplTest {
         Assertions.assertEquals(null, details);
     }
 
-    @DisplayName("getAccountDetails called with userGuid with file role should return account details")
+    @DisplayName("getAccountDetails called with userGuid with file role")
     @Test
     public void testWithFileRoleEnabled() {
 
@@ -86,6 +85,17 @@ public class CsoAccountServiceImplTest {
         Assertions.assertNotEquals(null, details);
         Assertions.assertEquals(BigDecimal.TEN, details.getAccountId());
         Assertions.assertEquals(BigDecimal.TEN, details.getClientId());
+        Assertions.assertEquals(true, details.getHasEfileRole());
     }
-    //TODO Reimplement test when check is re-added
+
+    @DisplayName("getAccountDetails called with a userGuid that does not have file role")
+    @Test
+    public void testWithFileRoleDisabled() {
+
+        CsoAccountDetails details = sut.getAccountDetails(USERGUIDNOROLE);
+        Assertions.assertNotEquals(null, details);
+        Assertions.assertEquals(BigDecimal.TEN, details.getAccountId());
+        Assertions.assertEquals(BigDecimal.TEN, details.getClientId());
+        Assertions.assertEquals(false, details.getHasEfileRole());
+    }
 }

--- a/src/backend/libs/efiling-account-client/src/test/java/ca/bc/gov/open/jag/efilingaccountclient/DemoAcountServiceImplTest.java
+++ b/src/backend/libs/efiling-account-client/src/test/java/ca/bc/gov/open/jag/efilingaccountclient/DemoAcountServiceImplTest.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 public class DemoAcountServiceImplTest {
 
     public static final UUID ACCOUNT_WITH_EFILING_ROLE = UUID.fromString("77da92db-0791-491e-8c58-1a969e67d2fa");
-    public static final UUID ACCOUNT_WITH_ADMIN_ROLE = UUID.fromString("77da92db-0791-491e-8c58-1a969e67d2fb");
+    public static final UUID ACCOUNT_WITHOUT_EFILING_ROLE = UUID.fromString("77da92db-0791-491e-8c58-1a969e67d2fb");
     public static final UUID ACCOUNT_DOES_NOT_EXISTS = UUID.randomUUID();
 
     DemoAccountServiceImpl sut;
@@ -27,20 +27,18 @@ public class DemoAcountServiceImplTest {
 
         Assertions.assertEquals(BigDecimal.TEN, actual.getAccountId());
         Assertions.assertEquals(BigDecimal.TEN, actual.getClientId());
-        Assertions.assertTrue(actual.HasRole("efiling"));
-
+        Assertions.assertEquals(true, actual.getHasEfileRole());
     }
 
     @Test
     @DisplayName("CASE 2: with account not having efiling role")
     public void withAccountHavingAdminRole() {
 
-        CsoAccountDetails actual = sut.getAccountDetails(ACCOUNT_WITH_ADMIN_ROLE.toString());
+        CsoAccountDetails actual = sut.getAccountDetails(ACCOUNT_WITHOUT_EFILING_ROLE.toString());
 
         Assertions.assertEquals(BigDecimal.TEN, actual.getAccountId());
         Assertions.assertEquals(BigDecimal.TEN, actual.getClientId());
-        Assertions.assertFalse(actual.HasRole("efiling"));
-
+        Assertions.assertEquals(false, actual.getHasEfileRole());
     }
 
     @Test
@@ -48,7 +46,6 @@ public class DemoAcountServiceImplTest {
     public void withNoAccountShouldBeNull() {
 
         Assertions.assertNull(sut.getAccountDetails(ACCOUNT_DOES_NOT_EXISTS.toString()));
-
     }
 
 }

--- a/src/backend/libs/efiling-account-client/src/test/java/ca/bc/gov/open/jag/efilingaccountclient/config/AutoConfigurationTest.java
+++ b/src/backend/libs/efiling-account-client/src/test/java/ca/bc/gov/open/jag/efilingaccountclient/config/AutoConfigurationTest.java
@@ -40,6 +40,6 @@ public class AutoConfigurationTest {
 
         Assertions.assertNotNull(sut.accountFacadeBean());
         Assertions.assertNotNull(sut.roleRegistryPortType());
-        Assertions.assertNotNull(sut.efilingAccountService(null));
+        Assertions.assertNotNull(sut.efilingAccountService(null, null));
     }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Added RoleRegistry calls back in
Changed the ClientDetails to jut have a single boolean to indicate if they have the efiling role.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Local build and unit tests

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
