### PR TITLE
Adding Role Registry Back In

### DIFF
--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/error/ErrorResponse.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/error/ErrorResponse.java
@@ -2,7 +2,8 @@ package ca.bc.gov.open.jag.efilingapi.error;
 
 public enum ErrorResponse {
     INVALIDROLE("INVROLE", "User does not have a valid role for this request."),
-    ACCOUNTEXCEPTION("MLTACCNT", "Client has multiple CSO profiles");
+    ACCOUNTEXCEPTION("MLTACCNT", "Client has multiple CSO profiles"),
+    GETPROFILESEXCEPTION("CSOERROR", "Calling CSO accountFacade.getProfiles caused an exception.");
 
     private final String errorCode;
     private final String errorMessage;

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImpl.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImpl.java
@@ -75,7 +75,7 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
 
         logger.info("Successfully got cso account information");
 
-        if (csoAccountDetails != null && !csoAccountDetails.HasRole(EFILING_ROLE)) {
+        if (csoAccountDetails != null && !csoAccountDetails.getHasEfileRole()) {
             logger.info("User does not have efiling role, therefore request is rejected.");
             return new ResponseEntity(buildEfilingError(ErrorResponse.INVALIDROLE), HttpStatus.FORBIDDEN);
         }

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImpl.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImpl.java
@@ -75,7 +75,7 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
             return new ResponseEntity(buildEfilingError(ErrorResponse.ACCOUNTEXCEPTION), HttpStatus.BAD_REQUEST);
         }
         catch (NestedEjbException_Exception e) {
-            return new ResponseEntity(buildEfilingError(ErrorResponse.GETPROFILESEXCEPTION), HttpStatus.BAD_REQUEST);
+            return new ResponseEntity(buildEfilingError(ErrorResponse.GETPROFILESEXCEPTION), HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
         logger.info("Successfully got cso account information");

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImpl.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImpl.java
@@ -1,5 +1,6 @@
 package ca.bc.gov.open.jag.efilingapi.submission;
 
+import ca.bc.gov.ag.csows.accounts.NestedEjbException_Exception;
 import ca.bc.gov.open.jag.efilingaccountclient.CsoAccountDetails;
 import ca.bc.gov.open.jag.efilingaccountclient.EfilingAccountService;
 import ca.bc.gov.open.jag.efilingaccountclient.exception.CSOHasMultipleAccountException;
@@ -69,8 +70,12 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
 
         try {
             csoAccountDetails = efilingAccountService.getAccountDetails(generateUrlRequest.getUserId());
-        } catch (CSOHasMultipleAccountException e)   {
+        }
+        catch (CSOHasMultipleAccountException e)   {
             return new ResponseEntity(buildEfilingError(ErrorResponse.ACCOUNTEXCEPTION), HttpStatus.BAD_REQUEST);
+        }
+        catch (NestedEjbException_Exception e) {
+            return new ResponseEntity(buildEfilingError(ErrorResponse.GETPROFILESEXCEPTION), HttpStatus.BAD_REQUEST);
         }
 
         logger.info("Successfully got cso account information");

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImplTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImplTest.java
@@ -4,15 +4,15 @@ package ca.bc.gov.open.jag.efilingapi.submission;
 import ca.bc.gov.open.jag.efilingaccountclient.CsoAccountDetails;
 import ca.bc.gov.open.jag.efilingaccountclient.EfilingAccountService;
 import ca.bc.gov.open.jag.efilingaccountclient.exception.CSOHasMultipleAccountException;
+import ca.bc.gov.open.jag.efilingapi.TestHelpers;
 import ca.bc.gov.open.jag.efilingapi.api.model.*;
+import ca.bc.gov.open.jag.efilingapi.config.NavigationProperties;
+import ca.bc.gov.open.jag.efilingapi.fee.FeeService;
 import ca.bc.gov.open.jag.efilingapi.fee.models.Fee;
 import ca.bc.gov.open.jag.efilingapi.fee.models.FeeRequest;
 import ca.bc.gov.open.jag.efilingapi.submission.mappers.SubmissionMapper;
 import ca.bc.gov.open.jag.efilingapi.submission.models.Submission;
 import ca.bc.gov.open.jag.efilingapi.submission.service.SubmissionService;
-import ca.bc.gov.open.jag.efilingapi.TestHelpers;
-import ca.bc.gov.open.jag.efilingapi.config.NavigationProperties;
-import ca.bc.gov.open.jag.efilingapi.fee.FeeService;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,8 +26,6 @@ import org.springframework.http.ResponseEntity;
 
 import java.math.BigDecimal;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -92,10 +90,8 @@ public class SubmissionApiDelegateImplTest {
         when(feeServiceMock.getFee(any(FeeRequest.class))).thenReturn(new Fee(BigDecimal.TEN));
 
         DocumentProperties documentProperties = new DocumentProperties();
-        List<String> efilingRole = new ArrayList<>();
-        efilingRole.add("efiling");
 
-        CsoAccountDetails csoAccountDetails = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN, efilingRole);
+        CsoAccountDetails csoAccountDetails = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN, true);
         Submission submissionWithCsoAccount = new Submission(CASE_6, documentProperties, TestHelpers.createNavigation(SUCCESSURL, CANCELURL, ERRORURL), new Fee(BigDecimal.TEN), csoAccountDetails);
 
         when(submissionServiceMock.getByKey(Mockito.eq(CASE_5)))
@@ -104,9 +100,7 @@ public class SubmissionApiDelegateImplTest {
         when(submissionServiceMock.getByKey(Mockito.eq(CASE_6)))
                 .thenReturn(Optional.of(submissionWithCsoAccount));
 
-        List<String> otherRole = new ArrayList<>();
-        efilingRole.add("other");
-        CsoAccountDetails csoAccountDetailsNoEfilingRole = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN, otherRole);
+        CsoAccountDetails csoAccountDetailsNoEfilingRole = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN, false);
         Submission submissionWithCsoAccountNoEfilingRole = new Submission(CASE_7, documentProperties, TestHelpers.createNavigation(SUCCESSURL, CANCELURL, ERRORURL), new Fee(BigDecimal.TEN), csoAccountDetailsNoEfilingRole);
         when(submissionServiceMock.getByKey(Mockito.eq(CASE_7)))
                 .thenReturn(Optional.of(submissionWithCsoAccountNoEfilingRole));
@@ -126,9 +120,7 @@ public class SubmissionApiDelegateImplTest {
     public void withValidPayloadShouldReturnOk() {
 
         when(submissionServiceMock.put(any())).thenReturn(Optional.of(Submission.builder().create()));
-        List<String> efilingRole = new ArrayList<>();
-        efilingRole.add("efiling");
-        CsoAccountDetails csoAccountDetails = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN, efilingRole);
+        CsoAccountDetails csoAccountDetails = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN, true);
 
         when(efilingAccountServiceMock.getAccountDetails(any())).thenReturn(csoAccountDetails);
         GenerateUrlRequest generateUrlRequest = new GenerateUrlRequest();
@@ -148,9 +140,7 @@ public class SubmissionApiDelegateImplTest {
     public void withValidPayloadButNoRoleShouldReturnForbidden() {
 
         when(submissionServiceMock.put(any())).thenReturn(Optional.of(Submission.builder().create()));
-        List<String> efilingRole = new ArrayList<>();
-        efilingRole.add("NOTefiling");
-        CsoAccountDetails csoAccountDetails = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN, efilingRole);
+        CsoAccountDetails csoAccountDetails = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN, false);
 
         when(efilingAccountServiceMock.getAccountDetails(any())).thenReturn(csoAccountDetails);
         GenerateUrlRequest generateUrlRequest = new GenerateUrlRequest();
@@ -172,9 +162,7 @@ public class SubmissionApiDelegateImplTest {
     public void withClientIdHavingMultipleAccount() {
 
         when(submissionServiceMock.put(any())).thenReturn(Optional.empty());
-        List<String> efilingRole = new ArrayList<>();
-        efilingRole.add("efiling");
-        CsoAccountDetails csoAccountDetails = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN, efilingRole);
+        CsoAccountDetails csoAccountDetails = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN, true);
 
         when(efilingAccountServiceMock.getAccountDetails(Mockito.eq(CASE_9.toString()))).thenThrow(new CSOHasMultipleAccountException(CASE_9.toString()));
         GenerateUrlRequest generateUrlRequest = new GenerateUrlRequest();
@@ -196,9 +184,7 @@ public class SubmissionApiDelegateImplTest {
     public void withValidPayloadButRedisReturnNothingShouldReturnBadRequest() {
 
         when(submissionServiceMock.put(any())).thenReturn(Optional.empty());
-        List<String> efilingRole = new ArrayList<>();
-        efilingRole.add("efiling");
-        CsoAccountDetails csoAccountDetails = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN, efilingRole);
+        CsoAccountDetails csoAccountDetails = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN, true);
 
         when(efilingAccountServiceMock.getAccountDetails(any())).thenReturn(csoAccountDetails);
         GenerateUrlRequest generateUrlRequest = new GenerateUrlRequest();

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImplTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImplTest.java
@@ -1,6 +1,7 @@
 package ca.bc.gov.open.jag.efilingapi.submission;
 
 
+import ca.bc.gov.ag.csows.accounts.NestedEjbException_Exception;
 import ca.bc.gov.open.jag.efilingaccountclient.CsoAccountDetails;
 import ca.bc.gov.open.jag.efilingaccountclient.EfilingAccountService;
 import ca.bc.gov.open.jag.efilingaccountclient.exception.CSOHasMultipleAccountException;
@@ -117,7 +118,7 @@ public class SubmissionApiDelegateImplTest {
 
     @Test
     @DisplayName("CASE1: when payload is valid")
-    public void withValidPayloadShouldReturnOk() {
+    public void withValidPayloadShouldReturnOk() throws NestedEjbException_Exception {
 
         when(submissionServiceMock.put(any())).thenReturn(Optional.of(Submission.builder().create()));
         CsoAccountDetails csoAccountDetails = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN, true);
@@ -137,7 +138,7 @@ public class SubmissionApiDelegateImplTest {
 
     @Test
     @DisplayName("CASE2: when payload is valid but no efiling role return forbidden")
-    public void withValidPayloadButNoRoleShouldReturnForbidden() {
+    public void withValidPayloadButNoRoleShouldReturnForbidden() throws NestedEjbException_Exception {
 
         when(submissionServiceMock.put(any())).thenReturn(Optional.of(Submission.builder().create()));
         CsoAccountDetails csoAccountDetails = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN, false);
@@ -159,7 +160,7 @@ public class SubmissionApiDelegateImplTest {
 
     @Test
     @DisplayName("With clientid having multiple account should return error")
-    public void withClientIdHavingMultipleAccount() {
+    public void withClientIdHavingMultipleAccount() throws NestedEjbException_Exception {
 
         when(submissionServiceMock.put(any())).thenReturn(Optional.empty());
         CsoAccountDetails csoAccountDetails = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN, true);
@@ -181,7 +182,7 @@ public class SubmissionApiDelegateImplTest {
 
     @Test
     @DisplayName("CASE3: when payload is valid but redis return nothing")
-    public void withValidPayloadButRedisReturnNothingShouldReturnBadRequest() {
+    public void withValidPayloadButRedisReturnNothingShouldReturnBadRequest() throws NestedEjbException_Exception {
 
         when(submissionServiceMock.put(any())).thenReturn(Optional.empty());
         CsoAccountDetails csoAccountDetails = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN, true);

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/models/SubmissionTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/models/SubmissionTest.java
@@ -10,8 +10,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -31,10 +29,7 @@ public class SubmissionTest {
     @DisplayName("CASE 1: testing constructor")
     public void testingConstructor() {
         Fee fee = new Fee(BigDecimal.TEN);
-
-        List<String> roles = new ArrayList<>();
-        roles.add("test");
-        CsoAccountDetails csoAccountDetails = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN, roles);
+        CsoAccountDetails csoAccountDetails = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN, false);
 
         Submission actual = new Submission(
                 UUID.randomUUID(),

--- a/src/backend/libs/efiling-account-client/src/main/java/ca/bc/gov/open/jag/efilingaccountclient/CsoAccountDetails.java
+++ b/src/backend/libs/efiling-account-client/src/main/java/ca/bc/gov/open/jag/efilingaccountclient/CsoAccountDetails.java
@@ -4,55 +4,27 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
 
 public class CsoAccountDetails {
-
-
-    public CsoAccountDetails(
-            @JsonProperty("accountId") BigDecimal accountId,
-            @JsonProperty("clientId") BigDecimal clientId) {
-
-        this.accountId = accountId;
-        this.clientId = clientId;
-    }
 
     @JsonCreator
     public CsoAccountDetails(
             @JsonProperty("accountId") BigDecimal accountId,
             @JsonProperty("clientId") BigDecimal clientId,
-            @JsonProperty("roles") List<String> roles) {
+            @JsonProperty("hasEfileRole") boolean hasEfileRole) {
 
-        this(accountId, clientId);
-
-        for (String role: roles) {
-            String toAdd = role.toLowerCase();
-            this.roles.add(toAdd);
-        }
+        this.accountId = accountId;
+        this.clientId = clientId;
+        this.hasEfileRole = hasEfileRole;
     }
 
     private BigDecimal accountId;
     private BigDecimal clientId;
-    private List<String> roles = new ArrayList<>();
+    private boolean hasEfileRole;
 
-    public BigDecimal getAccountId() {
-        return accountId;
-    }
-
+    public BigDecimal getAccountId() { return accountId; }
     public BigDecimal getClientId() {
         return clientId;
     }
-
-    public List<String> getRoles() { return roles; }
-
-    public void addRole(String role) {
-        this.roles.add(role.toLowerCase());
-    }
-
-    public boolean HasRole(String role) {
-        String toFind = role.toLowerCase();
-        return roles.stream().anyMatch(r -> r.equals(toFind));
-    }
-
+    public boolean getHasEfileRole() { return hasEfileRole; }
 }

--- a/src/backend/libs/efiling-account-client/src/main/java/ca/bc/gov/open/jag/efilingaccountclient/CsoAccountServiceImpl.java
+++ b/src/backend/libs/efiling-account-client/src/main/java/ca/bc/gov/open/jag/efilingaccountclient/CsoAccountServiceImpl.java
@@ -7,8 +7,6 @@ import ca.bc.gov.ag.csows.accounts.AccountFacadeBean;
 import ca.bc.gov.ag.csows.accounts.ClientProfile;
 import ca.bc.gov.ag.csows.accounts.NestedEjbException_Exception;
 import ca.bc.gov.open.jag.efilingaccountclient.exception.CSOHasMultipleAccountException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 import java.util.List;
@@ -17,7 +15,6 @@ public class CsoAccountServiceImpl implements EfilingAccountService {
 
     private AccountFacadeBean accountFacadeBean;
     private RoleRegistryPortType roleRegistryPortType;
-    private static final Logger LOGGER = LoggerFactory.getLogger(CsoAccountServiceImpl.class);
 
     public CsoAccountServiceImpl(AccountFacadeBean accountFacadeBean, RoleRegistryPortType roleRegistryPortType) {
 

--- a/src/backend/libs/efiling-account-client/src/main/java/ca/bc/gov/open/jag/efilingaccountclient/CsoAccountServiceImpl.java
+++ b/src/backend/libs/efiling-account-client/src/main/java/ca/bc/gov/open/jag/efilingaccountclient/CsoAccountServiceImpl.java
@@ -26,28 +26,19 @@ public class CsoAccountServiceImpl implements EfilingAccountService {
     }
 
     @Override
-    public CsoAccountDetails getAccountDetails(String userGuid) {
+    public CsoAccountDetails getAccountDetails(String userGuid) throws NestedEjbException_Exception {
 
         if (StringUtils.isEmpty(userGuid)) return null;
 
         CsoAccountDetails csoAccountDetails = null;
-        boolean hasEfileRole = HasFileRole(userGuid);
-
-        try {
-
-            List<ClientProfile> profiles = accountFacadeBean.findProfiles(userGuid);
-            //An account must only one profile associated to proceed
-            if (profiles.size() == 1) {
-                ClientProfile profile = profiles.get(0);
-                csoAccountDetails = new CsoAccountDetails(profile.getAccountId(), profile.getClientId(), hasEfileRole);
-            }
-            else if (profiles.size() > 1) {
-                throw new CSOHasMultipleAccountException(profiles.get(0).getClientId().toString());
-            }
-
-        } catch (NestedEjbException_Exception e) {
-
-            LOGGER.error("Error calling findProfiles: ", e);
+        List<ClientProfile> profiles = accountFacadeBean.findProfiles(userGuid);
+        //An account must only one profile associated to proceed
+        if (profiles.size() == 1) {
+            ClientProfile profile = profiles.get(0);
+            csoAccountDetails = new CsoAccountDetails(profile.getAccountId(), profile.getClientId(), HasFileRole(userGuid));
+        }
+        else if (profiles.size() > 1) {
+            throw new CSOHasMultipleAccountException(profiles.get(0).getClientId().toString());
         }
 
         return csoAccountDetails;

--- a/src/backend/libs/efiling-account-client/src/main/java/ca/bc/gov/open/jag/efilingaccountclient/DemoAccountServiceImpl.java
+++ b/src/backend/libs/efiling-account-client/src/main/java/ca/bc/gov/open/jag/efilingaccountclient/DemoAccountServiceImpl.java
@@ -10,20 +10,17 @@ import java.util.*;
 public class DemoAccountServiceImpl implements EfilingAccountService {
 
     public static final UUID ACCOUNT_WITH_EFILING_ROLE = UUID.fromString("77da92db-0791-491e-8c58-1a969e67d2fa");
-    public static final UUID ACCOUNT_WITH_ADMIN_ROLE = UUID.fromString("77da92db-0791-491e-8c58-1a969e67d2fb");
+    public static final UUID ACCOUNT_WITHOUT_EFILING_ROLE = UUID.fromString("77da92db-0791-491e-8c58-1a969e67d2fb");
 
     private Map<String, CsoAccountDetails> csoAccounts = new HashMap<>();
 
     public DemoAccountServiceImpl() {
 
-        CsoAccountDetails accountWithEfilingRole = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN);
-        accountWithEfilingRole.addRole("efiling");
-
-        CsoAccountDetails accountWithDifferentRole = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN);
-        accountWithDifferentRole.addRole("admin");
+        CsoAccountDetails accountWithEfilingRole = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN, true);
+        CsoAccountDetails accountWithOutEfilingRole = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN, false);
 
         csoAccounts.put(ACCOUNT_WITH_EFILING_ROLE.toString(), accountWithEfilingRole);
-        csoAccounts.put(ACCOUNT_WITH_ADMIN_ROLE.toString(), accountWithDifferentRole);
+        csoAccounts.put(ACCOUNT_WITHOUT_EFILING_ROLE.toString(), accountWithOutEfilingRole);
 
     }
 

--- a/src/backend/libs/efiling-account-client/src/main/java/ca/bc/gov/open/jag/efilingaccountclient/EfilingAccountService.java
+++ b/src/backend/libs/efiling-account-client/src/main/java/ca/bc/gov/open/jag/efilingaccountclient/EfilingAccountService.java
@@ -1,9 +1,11 @@
 package ca.bc.gov.open.jag.efilingaccountclient;
 
+import ca.bc.gov.ag.csows.accounts.NestedEjbException_Exception;
+
 /**
  * Interface for getting CSO account details based on a user GUID
  */
 public interface EfilingAccountService {
 
-    CsoAccountDetails getAccountDetails(String userGuid);
+    CsoAccountDetails getAccountDetails(String userGuid) throws NestedEjbException_Exception;
 }

--- a/src/backend/libs/efiling-account-client/src/main/java/ca/bc/gov/open/jag/efilingaccountclient/config/AutoConfiguration.java
+++ b/src/backend/libs/efiling-account-client/src/main/java/ca/bc/gov/open/jag/efilingaccountclient/config/AutoConfiguration.java
@@ -49,8 +49,8 @@ public class AutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean({EfilingAccountService.class})
-    public EfilingAccountService efilingAccountService(AccountFacadeBean accountFacadeBean) {
-        return new CsoAccountServiceImpl(accountFacadeBean);
+    public EfilingAccountService efilingAccountService(AccountFacadeBean accountFacadeBean, RoleRegistryPortType roleRegistryPortType) {
+        return new CsoAccountServiceImpl(accountFacadeBean, roleRegistryPortType);
     }
 
 

--- a/src/backend/libs/efiling-account-client/src/test/java/ca/bc/gov/open/jag/efilingaccountclient/CsoAccountServiceImplTest.java
+++ b/src/backend/libs/efiling-account-client/src/test/java/ca/bc/gov/open/jag/efilingaccountclient/CsoAccountServiceImplTest.java
@@ -79,7 +79,7 @@ public class CsoAccountServiceImplTest {
 
     @DisplayName("getAccountDetails called with userGuid with file role")
     @Test
-    public void testWithFileRoleEnabled() {
+    public void testWithFileRoleEnabled() throws NestedEjbException_Exception {
 
         CsoAccountDetails details = sut.getAccountDetails(USERGUIDWITHFILEROLE);
         Assertions.assertNotEquals(null, details);
@@ -90,7 +90,7 @@ public class CsoAccountServiceImplTest {
 
     @DisplayName("getAccountDetails called with a userGuid that does not have file role")
     @Test
-    public void testWithFileRoleDisabled() {
+    public void testWithFileRoleDisabled() throws NestedEjbException_Exception {
 
         CsoAccountDetails details = sut.getAccountDetails(USERGUIDNOROLE);
         Assertions.assertNotEquals(null, details);

--- a/src/backend/libs/efiling-account-client/src/test/java/ca/bc/gov/open/jag/efilingaccountclient/CsoAccountServiceImplTest.java
+++ b/src/backend/libs/efiling-account-client/src/test/java/ca/bc/gov/open/jag/efilingaccountclient/CsoAccountServiceImplTest.java
@@ -46,7 +46,6 @@ public class CsoAccountServiceImplTest {
 
         MockitoAnnotations.initMocks(this);
 
-        CsoAccountDetails details = new CsoAccountDetails(BigDecimal.TEN, BigDecimal.TEN);
         ClientProfile profile =  new ClientProfile();
         profile.setAccountId(BigDecimal.TEN);
         profile.setClientId(BigDecimal.TEN);
@@ -70,7 +69,7 @@ public class CsoAccountServiceImplTest {
         Mockito.when(mockRoleRegistryPortType.getRolesForIdentifier("Courts", "CSO", USERGUIDNOROLE, "CAP")).thenReturn(userRolesWithoutFileRole);
     }
 
-    @DisplayName("getAccountDetails called with empty userGuid should return null")
+    @DisplayName("getAccountDetails called with empty userGuid")
     @Test
     public void testWithEmptyUserGuid() throws NestedEjbException_Exception {
 
@@ -78,7 +77,7 @@ public class CsoAccountServiceImplTest {
         Assertions.assertEquals(null, details);
     }
 
-    @DisplayName("getAccountDetails called with userGuid with file role should return account details")
+    @DisplayName("getAccountDetails called with userGuid with file role")
     @Test
     public void testWithFileRoleEnabled() {
 
@@ -86,6 +85,17 @@ public class CsoAccountServiceImplTest {
         Assertions.assertNotEquals(null, details);
         Assertions.assertEquals(BigDecimal.TEN, details.getAccountId());
         Assertions.assertEquals(BigDecimal.TEN, details.getClientId());
+        Assertions.assertEquals(true, details.getHasEfileRole());
     }
-    //TODO Reimplement test when check is re-added
+
+    @DisplayName("getAccountDetails called with a userGuid that does not have file role")
+    @Test
+    public void testWithFileRoleDisabled() {
+
+        CsoAccountDetails details = sut.getAccountDetails(USERGUIDNOROLE);
+        Assertions.assertNotEquals(null, details);
+        Assertions.assertEquals(BigDecimal.TEN, details.getAccountId());
+        Assertions.assertEquals(BigDecimal.TEN, details.getClientId());
+        Assertions.assertEquals(false, details.getHasEfileRole());
+    }
 }

--- a/src/backend/libs/efiling-account-client/src/test/java/ca/bc/gov/open/jag/efilingaccountclient/DemoAcountServiceImplTest.java
+++ b/src/backend/libs/efiling-account-client/src/test/java/ca/bc/gov/open/jag/efilingaccountclient/DemoAcountServiceImplTest.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 public class DemoAcountServiceImplTest {
 
     public static final UUID ACCOUNT_WITH_EFILING_ROLE = UUID.fromString("77da92db-0791-491e-8c58-1a969e67d2fa");
-    public static final UUID ACCOUNT_WITH_ADMIN_ROLE = UUID.fromString("77da92db-0791-491e-8c58-1a969e67d2fb");
+    public static final UUID ACCOUNT_WITHOUT_EFILING_ROLE = UUID.fromString("77da92db-0791-491e-8c58-1a969e67d2fb");
     public static final UUID ACCOUNT_DOES_NOT_EXISTS = UUID.randomUUID();
 
     DemoAccountServiceImpl sut;
@@ -27,20 +27,18 @@ public class DemoAcountServiceImplTest {
 
         Assertions.assertEquals(BigDecimal.TEN, actual.getAccountId());
         Assertions.assertEquals(BigDecimal.TEN, actual.getClientId());
-        Assertions.assertTrue(actual.HasRole("efiling"));
-
+        Assertions.assertEquals(true, actual.getHasEfileRole());
     }
 
     @Test
     @DisplayName("CASE 2: with account not having efiling role")
     public void withAccountHavingAdminRole() {
 
-        CsoAccountDetails actual = sut.getAccountDetails(ACCOUNT_WITH_ADMIN_ROLE.toString());
+        CsoAccountDetails actual = sut.getAccountDetails(ACCOUNT_WITHOUT_EFILING_ROLE.toString());
 
         Assertions.assertEquals(BigDecimal.TEN, actual.getAccountId());
         Assertions.assertEquals(BigDecimal.TEN, actual.getClientId());
-        Assertions.assertFalse(actual.HasRole("efiling"));
-
+        Assertions.assertEquals(false, actual.getHasEfileRole());
     }
 
     @Test
@@ -48,7 +46,6 @@ public class DemoAcountServiceImplTest {
     public void withNoAccountShouldBeNull() {
 
         Assertions.assertNull(sut.getAccountDetails(ACCOUNT_DOES_NOT_EXISTS.toString()));
-
     }
 
 }

--- a/src/backend/libs/efiling-account-client/src/test/java/ca/bc/gov/open/jag/efilingaccountclient/config/AutoConfigurationTest.java
+++ b/src/backend/libs/efiling-account-client/src/test/java/ca/bc/gov/open/jag/efilingaccountclient/config/AutoConfigurationTest.java
@@ -40,6 +40,6 @@ public class AutoConfigurationTest {
 
         Assertions.assertNotNull(sut.accountFacadeBean());
         Assertions.assertNotNull(sut.roleRegistryPortType());
-        Assertions.assertNotNull(sut.efilingAccountService(null));
+        Assertions.assertNotNull(sut.efilingAccountService(null, null));
     }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

RoleRegistry added back in to the account service
Refactored the CsoAccountDetails to have just a boolean for efiling role.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Local build and unit tests

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
