### PR TITLE
FLA-220 - Create Account Interface

### DIFF
--- a/src/backend/libs/efiling-account-client/src/main/java/ca/bc/gov/open/jag/efilingaccountclient/CsoAccountServiceImpl.java
+++ b/src/backend/libs/efiling-account-client/src/main/java/ca/bc/gov/open/jag/efilingaccountclient/CsoAccountServiceImpl.java
@@ -10,8 +10,10 @@ import ca.bc.gov.open.jag.efilingaccountclient.mappers.AccountDetailsMapper;
 import ca.bc.gov.open.jag.efilingcommons.exceptions.CSOHasMultipleAccountException;
 import ca.bc.gov.open.jag.efilingcommons.exceptions.EfilingAccountServiceException;
 import ca.bc.gov.open.jag.efilingcommons.model.AccountDetails;
+import ca.bc.gov.open.jag.efilingcommons.model.CreateAccountRequest;
 import ca.bc.gov.open.jag.efilingcommons.service.EfilingAccountService;
 import ca.bceid.webservices.client.v9.*;
+import org.apache.commons.lang3.NotImplementedException;
 
 import java.util.*;
 
@@ -56,6 +58,11 @@ public class CsoAccountServiceImpl implements EfilingAccountService {
         }
 
         return accountDetails;
+    }
+
+    @Override
+    public AccountDetails createAccount(CreateAccountRequest createAccountRequest) {
+        throw new NotImplementedException();
     }
 
     private AccountDetails getCsoDetails(String userGuid)  {

--- a/src/backend/libs/efiling-account-client/src/test/java/ca/bc/gov/open/jag/efilingaccountclient/csoAccountServiceImpl/CreateAccountTest.java
+++ b/src/backend/libs/efiling-account-client/src/test/java/ca/bc/gov/open/jag/efilingaccountclient/csoAccountServiceImpl/CreateAccountTest.java
@@ -1,0 +1,49 @@
+package ca.bc.gov.open.jag.efilingaccountclient.csoAccountServiceImpl;
+
+import brooks.roleregistry_source_roleregistry_ws_provider.roleregistry.RoleRegistryPortType;
+import ca.bc.gov.ag.csows.accounts.AccountFacadeBean;
+import ca.bc.gov.open.jag.efilingaccountclient.CsoAccountServiceImpl;
+import ca.bc.gov.open.jag.efilingaccountclient.mappers.AccountDetailsMapper;
+import ca.bc.gov.open.jag.efilingcommons.model.CreateAccountRequest;
+import ca.bceid.webservices.client.v9.BCeIDServiceSoap;
+import org.apache.commons.lang3.NotImplementedException;
+import org.junit.jupiter.api.*;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Create Account Test Suite")
+public class CreateAccountTest {
+
+    @Mock
+    AccountFacadeBean accountFacadeBeanMock;
+
+    @Mock
+    RoleRegistryPortType roleRegistryPortTypeMock;
+
+    @Mock
+    BCeIDServiceSoap bCeIDServiceSoapMock;
+
+    @Mock
+    AccountDetailsMapper accountDetailsMapperMock;
+
+
+    private CsoAccountServiceImpl sut;
+
+    @BeforeAll
+    public void setUp() {
+
+        MockitoAnnotations.initMocks(this);
+
+        sut = new CsoAccountServiceImpl(accountFacadeBeanMock, roleRegistryPortTypeMock, bCeIDServiceSoapMock, accountDetailsMapperMock);
+    }
+
+    @Test
+    @DisplayName("Not Implemented!")
+    public void notImplemented() {
+
+        Assertions.assertThrows(NotImplementedException.class, () -> sut.createAccount(CreateAccountRequest.builder().create()));
+
+    }
+
+}

--- a/src/backend/libs/efiling-account-client/src/test/java/ca/bc/gov/open/jag/efilingaccountclient/csoAccountServiceImpl/GetAccountDetailsTest.java
+++ b/src/backend/libs/efiling-account-client/src/test/java/ca/bc/gov/open/jag/efilingaccountclient/csoAccountServiceImpl/GetAccountDetailsTest.java
@@ -1,4 +1,4 @@
-package ca.bc.gov.open.jag.efilingaccountclient;
+package ca.bc.gov.open.jag.efilingaccountclient.csoAccountServiceImpl;
 
 import brooks.roleregistry_source_roleregistry_ws_provider.roleregistry.RegisteredRole;
 import brooks.roleregistry_source_roleregistry_ws_provider.roleregistry.RoleRegistry;
@@ -8,6 +8,8 @@ import ca.bc.gov.ag.csows.accounts.AccountFacade;
 import ca.bc.gov.ag.csows.accounts.AccountFacadeBean;
 import ca.bc.gov.ag.csows.accounts.ClientProfile;
 import ca.bc.gov.ag.csows.accounts.NestedEjbException_Exception;
+import ca.bc.gov.open.jag.efilingaccountclient.CsoAccountServiceImpl;
+import ca.bc.gov.open.jag.efilingaccountclient.CsoHelpers;
 import ca.bc.gov.open.jag.efilingaccountclient.mappers.AccountDetailsMapper;
 import ca.bc.gov.open.jag.efilingcommons.exceptions.CSOHasMultipleAccountException;
 import ca.bc.gov.open.jag.efilingcommons.exceptions.EfilingAccountServiceException;
@@ -26,7 +28,8 @@ import java.util.UUID;
 import static org.mockito.ArgumentMatchers.any;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class CsoAccountServiceImplTest {
+@DisplayName("Get Account Details Test Suite")
+public class GetAccountDetailsTest {
 
     private static final UUID USER_GUID_NO_ROLE = UUID.randomUUID();
     private static final UUID USER_GUID_WITH_FILE_ROLE = UUID.randomUUID();
@@ -55,7 +58,7 @@ public class CsoAccountServiceImplTest {
     BCeIDService bCeIDService;
 
     @Mock
-    BCeIDServiceSoap bCeIDServiceSoap;
+    BCeIDServiceSoap bCeIDServiceSoapMock;
 
     @Mock
     AccountDetailsMapper accountDetailsMapperMock;
@@ -68,7 +71,7 @@ public class CsoAccountServiceImplTest {
         initRoleRegistryMocks();
         initBceIdAccountMocks();
 
-        sut = new CsoAccountServiceImpl(accountFacadeBeanMock, roleRegistryPortTypeMock, bCeIDServiceSoap, accountDetailsMapperMock);
+        sut = new CsoAccountServiceImpl(accountFacadeBeanMock, roleRegistryPortTypeMock, bCeIDServiceSoapMock, accountDetailsMapperMock);
     }
 
     private void initAccountFacadeMocks() throws NestedEjbException_Exception {
@@ -144,8 +147,8 @@ public class CsoAccountServiceImplTest {
         bCeIDResponse.setCode(ResponseCode.SUCCESS);
         bCeIDResponse.setAccount(bCeIDAccount);
 
-        Mockito.when(bCeIDService.getBCeIDServiceSoap()).thenReturn(bCeIDServiceSoap);
-        Mockito.when(bCeIDServiceSoap.getAccountDetail(any())).thenReturn(bCeIDResponse);
+        Mockito.when(bCeIDService.getBCeIDServiceSoap()).thenReturn(bCeIDServiceSoapMock);
+        Mockito.when(bCeIDServiceSoapMock.getAccountDetail(any())).thenReturn(bCeIDResponse);
 
         AccountDetails accountDetailsWithNoCso = new AccountDetails(BigDecimal.ZERO, BigDecimal.ZERO, false, "firstName", "lastName", "middleName","email");
         Mockito.when(accountDetailsMapperMock.toAccountDetails(Mockito.any())).thenReturn(accountDetailsWithNoCso);

--- a/src/backend/libs/efiling-commons/src/main/java/ca/bc/gov/open/jag/efilingcommons/model/CreateAccountRequest.java
+++ b/src/backend/libs/efiling-commons/src/main/java/ca/bc/gov/open/jag/efilingcommons/model/CreateAccountRequest.java
@@ -1,0 +1,92 @@
+package ca.bc.gov.open.jag.efilingcommons.model;
+
+/**
+ * Represents a request to create an account
+ */
+public class CreateAccountRequest {
+
+    private String firstName;
+    private String lastName;
+    private String middleName;
+    private String email;
+
+    protected CreateAccountRequest(CreateAccountRequest.Builder builder) {
+
+        this.firstName = builder.firstName;
+        this.lastName = builder.lastName;
+        this.middleName = builder.middleName;
+        this.email = builder.email;
+
+    }
+
+    public static CreateAccountRequest.Builder builder() {
+        return new CreateAccountRequest.Builder();
+    }
+
+    /**
+     * Get the account First Name
+     * @return
+     */
+    public String getFirstName() {
+        return firstName;
+    }
+
+    /**
+     * Get the account Last Name
+     * @return
+     */
+    public String getLastName() {
+        return lastName;
+    }
+
+    /**
+     * Get the account Middle Name
+     * @return
+     */
+    public String getMiddleName() {
+        return middleName;
+    }
+
+    /**
+     * Get the account Email
+     * @return
+     */
+    public String getEmail() {
+        return email;
+    }
+
+    public static class Builder {
+
+        private String firstName;
+        private String lastName;
+        private String middleName;
+        private String email;
+
+        public Builder firstName(String firstName) {
+            this.firstName = firstName;
+            return this;
+        }
+
+        public Builder lastName(String lastName) {
+            this.lastName = lastName;
+            return this;
+        }
+
+        public Builder middleName(String middleName) {
+            this.middleName = middleName;
+            return this;
+        }
+
+        public Builder email(String email) {
+            this.email = email;
+            return this;
+        }
+
+
+        public CreateAccountRequest create() {
+            return new CreateAccountRequest(this);
+        }
+
+    }
+
+}

--- a/src/backend/libs/efiling-commons/src/main/java/ca/bc/gov/open/jag/efilingcommons/model/CreateAccountRequest.java
+++ b/src/backend/libs/efiling-commons/src/main/java/ca/bc/gov/open/jag/efilingcommons/model/CreateAccountRequest.java
@@ -1,10 +1,13 @@
 package ca.bc.gov.open.jag.efilingcommons.model;
 
+import java.util.UUID;
+
 /**
  * Represents a request to create an account
  */
 public class CreateAccountRequest {
 
+    private UUID universalId;
     private String firstName;
     private String lastName;
     private String middleName;
@@ -12,6 +15,7 @@ public class CreateAccountRequest {
 
     protected CreateAccountRequest(CreateAccountRequest.Builder builder) {
 
+        this.universalId = builder.universalId;
         this.firstName = builder.firstName;
         this.lastName = builder.lastName;
         this.middleName = builder.middleName;
@@ -57,10 +61,16 @@ public class CreateAccountRequest {
 
     public static class Builder {
 
+        private UUID universalId;
         private String firstName;
         private String lastName;
         private String middleName;
         private String email;
+
+        public Builder universalId(UUID universalId) {
+            this.universalId = universalId;
+            return this;
+        }
 
         public Builder firstName(String firstName) {
             this.firstName = firstName;

--- a/src/backend/libs/efiling-commons/src/main/java/ca/bc/gov/open/jag/efilingcommons/service/EfilingAccountService.java
+++ b/src/backend/libs/efiling-commons/src/main/java/ca/bc/gov/open/jag/efilingcommons/service/EfilingAccountService.java
@@ -6,12 +6,23 @@ import ca.bc.gov.open.jag.efilingcommons.model.CreateAccountRequest;
 import java.util.UUID;
 
 /**
- * Interface for getting CSO account details based on a user GUID
+ * Interface for getting account details based on a user GUID
  */
 public interface EfilingAccountService {
 
+    /**
+     * Get the account details
+     * @param userGuid
+     * @param bceidAccountType
+     * @return
+     */
     AccountDetails getAccountDetails(UUID userGuid, String bceidAccountType);
 
+    /**
+     * Creates a new account
+     * @param createAccountRequest
+     * @return
+     */
     AccountDetails createAccount(CreateAccountRequest createAccountRequest);
 
 }

--- a/src/backend/libs/efiling-commons/src/main/java/ca/bc/gov/open/jag/efilingcommons/service/EfilingAccountService.java
+++ b/src/backend/libs/efiling-commons/src/main/java/ca/bc/gov/open/jag/efilingcommons/service/EfilingAccountService.java
@@ -1,6 +1,7 @@
 package ca.bc.gov.open.jag.efilingcommons.service;
 
 import ca.bc.gov.open.jag.efilingcommons.model.AccountDetails;
+import ca.bc.gov.open.jag.efilingcommons.model.CreateAccountRequest;
 
 import java.util.UUID;
 
@@ -10,5 +11,7 @@ import java.util.UUID;
 public interface EfilingAccountService {
 
     AccountDetails getAccountDetails(UUID userGuid, String bceidAccountType);
+
+    AccountDetails createAccount(CreateAccountRequest createAccountRequest);
 
 }

--- a/src/backend/libs/efiling-commons/src/test/java/ca/bc/gov/open/jag/efilingcommons/model/CreateAccountRequestTest.java
+++ b/src/backend/libs/efiling-commons/src/test/java/ca/bc/gov/open/jag/efilingcommons/model/CreateAccountRequestTest.java
@@ -1,0 +1,21 @@
+package ca.bc.gov.open.jag.efilingcommons.model;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class CreateAccountRequestTest {
+
+    @Test
+    public void shouldBuildACreateAccountRequest() {
+
+
+        CreateAccountRequest actual = CreateAccountRequest.builder()
+                .firstName("firstName")
+                .middleName("middleName")
+                .lastName("lastName")
+                .create();
+        
+    }
+
+}

--- a/src/backend/libs/efiling-demo-starter/src/main/java/ca/bc/gov/open/jag/efiling/demo/EfilingAccountServiceDemoImpl.java
+++ b/src/backend/libs/efiling-demo-starter/src/main/java/ca/bc/gov/open/jag/efiling/demo/EfilingAccountServiceDemoImpl.java
@@ -2,7 +2,9 @@ package ca.bc.gov.open.jag.efiling.demo;
 
 
 import ca.bc.gov.open.jag.efilingcommons.model.AccountDetails;
+import ca.bc.gov.open.jag.efilingcommons.model.CreateAccountRequest;
 import ca.bc.gov.open.jag.efilingcommons.service.EfilingAccountService;
+import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -29,5 +31,10 @@ public class EfilingAccountServiceDemoImpl implements EfilingAccountService {
 
     public AccountDetails getAccountDetails(UUID userGuid, String bceidAccountType) {
         return csoAccounts.get(userGuid);
+    }
+
+    @Override
+    public AccountDetails createAccount(CreateAccountRequest createAccountRequest) {
+        throw new NotImplementedException();
     }
 }

--- a/src/backend/libs/efiling-demo-starter/src/test/java/ca/bc/gov/open/jag/efiling/demo/EfilingAccountServiceDemoImplTest.java
+++ b/src/backend/libs/efiling-demo-starter/src/test/java/ca/bc/gov/open/jag/efiling/demo/EfilingAccountServiceDemoImplTest.java
@@ -1,6 +1,8 @@
 package ca.bc.gov.open.jag.efiling.demo;
 
 import ca.bc.gov.open.jag.efilingcommons.model.AccountDetails;
+import ca.bc.gov.open.jag.efilingcommons.model.CreateAccountRequest;
+import org.apache.commons.lang3.NotImplementedException;
 import org.junit.jupiter.api.*;
 
 import java.math.BigDecimal;
@@ -42,4 +44,11 @@ public class EfilingAccountServiceDemoImplTest {
         Assertions.assertEquals(false, actual.isFileRolePresent());
     }
 
+    @Test
+    @DisplayName("Not Implemented!")
+    public void notImplemented() {
+
+        Assertions.assertThrows(NotImplementedException.class, () -> sut.createAccount(CreateAccountRequest.builder().create()));
+
+    }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [FLA-220](https://justice.gov.bc.ca/jira/browse/FLA-220) Define Account CSO Interface

The interface has a new method to create an account.

```java
public interface EfilingAccountService {

    /**
     * Get the account details
     * @param userGuid
     * @param bceidAccountType
     * @return
     */
    AccountDetails getAccountDetails(UUID userGuid, String bceidAccountType);

    /**
     * Creates a new account
     * @param createAccountRequest
     * @return
     */
    AccountDetails createAccount(CreateAccountRequest createAccountRequest);

}

```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Added unit tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
