### PR TITLE
Modify submission endpoint to return the bceid account in the account list

### DIFF
--- a/src/backend/efiling-api/jag-efiling-api.yaml
+++ b/src/backend/efiling-api/jag-efiling-api.yaml
@@ -196,11 +196,16 @@ components:
       description: represents a user submitting a package
       type: object
       required:
+        - universalId
         - firstName
         - lastName
         - middleName
         - email
       properties:
+        universalId:
+          type: string
+          format: uuid
+          description: the user universal identifier
         firstName:
           type: string
           description: the user first name

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/account/CsoAccountApiDelegateImpl.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/account/CsoAccountApiDelegateImpl.java
@@ -40,6 +40,7 @@ public class CsoAccountApiDelegateImpl implements CsoAccountApiDelegate {
                 .create());
 
         UserDetails result = new UserDetails();
+        result.setUniversalId(accountDetails.getUniversalId());
         Account csoAccount = new Account();
         csoAccount.setType(Account.TypeEnum.CSO);
         csoAccount.setIdentifier(accountDetails.getAccountId().toString());

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImpl.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImpl.java
@@ -108,6 +108,7 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
                 userDetails.addAccountsItem(account);
             }
 
+            userDetails.setUniversalId(submission.getAccountDetails().getUniversalId());
             userDetails.setFirstName(submission.getAccountDetails().getFirstName());
             userDetails.setLastName(submission.getAccountDetails().getLastName());
             userDetails.setMiddleName(submission.getAccountDetails().getMiddleName());
@@ -115,6 +116,7 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
 
         } else {
 
+            // TODO: remove this
             userDetails.setFirstName("firstName");
             userDetails.setLastName("lastName");
             userDetails.setMiddleName("middleName");

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/account/CsoAccountApiDelegateImplTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/account/CsoAccountApiDelegateImplTest.java
@@ -1,5 +1,6 @@
 package ca.bc.gov.open.jag.efilingapi.account;
 
+import ca.bc.gov.open.jag.efilingapi.TestHelpers;
 import ca.bc.gov.open.jag.efilingapi.api.model.Account;
 import ca.bc.gov.open.jag.efilingapi.api.model.UserDetails;
 import ca.bc.gov.open.jag.efilingcommons.model.AccountDetails;
@@ -35,7 +36,7 @@ public class CsoAccountApiDelegateImplTest {
                 .thenReturn(AccountDetails.builder()
                         .fileRolePresent(true)
                         .accountId(BigDecimal.ONE)
-                        .universalId(UUID.randomUUID())
+                        .universalId(TestHelpers.CASE_1)
                         .lastName(LAST_NAME)
                         .firstName(FIRST_NAME)
                         .middleName(MIDDLE_NAME)
@@ -50,7 +51,6 @@ public class CsoAccountApiDelegateImplTest {
     @DisplayName("201: should return an account with cso")
     public void whenAccountCreatedShouldReturn201() {
 
-
         UserDetails userDetails = new UserDetails();
         userDetails.setLastName(LAST_NAME);
         userDetails.setMiddleName(MIDDLE_NAME);
@@ -60,9 +60,10 @@ public class CsoAccountApiDelegateImplTest {
         account.setType(Account.TypeEnum.BCEID);
         account.setIdentifier(UUID.randomUUID().toString());
         userDetails.addAccountsItem(account);
-        ResponseEntity<UserDetails> actual = sut.createAccount(UUID.randomUUID(), userDetails);
+        ResponseEntity<UserDetails> actual = sut.createAccount(TestHelpers.CASE_1, userDetails);
 
         Assertions.assertEquals(HttpStatus.CREATED, actual.getStatusCode());
+        Assertions.assertEquals(TestHelpers.CASE_1, actual.getBody().getUniversalId());
         Assertions.assertEquals(LAST_NAME, actual.getBody().getLastName());
         Assertions.assertEquals(MIDDLE_NAME, actual.getBody().getMiddleName());
         Assertions.assertEquals(EMAIL, actual.getBody().getEmail());

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/submissionApiDelegateImpl/GetSubmissionTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/submissionApiDelegateImpl/GetSubmissionTest.java
@@ -66,6 +66,7 @@ public class GetSubmissionTest {
                 .accountDetails(
                         AccountDetails
                                 .builder()
+                                .universalId(TestHelpers.CASE_2)
                                 .accountId(BigDecimal.TEN)
                                 .firstName(FIRST_NAME + CASE_2)
                                 .lastName(LAST_NAME + CASE_2)
@@ -101,6 +102,7 @@ public class GetSubmissionTest {
 
         ResponseEntity<GetSubmissionResponse> actual = sut.getSubmission(CASE_2);
         assertEquals(HttpStatus.OK, actual.getStatusCode());
+        assertEquals(TestHelpers.CASE_2, actual.getBody().getUserDetails().getUniversalId());
         assertEquals(EMAIL + CASE_2, actual.getBody().getUserDetails().getEmail());
         assertEquals(FIRST_NAME + CASE_2, actual.getBody().getUserDetails().getFirstName());
         assertEquals(LAST_NAME + CASE_2, actual.getBody().getUserDetails().getLastName());


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [FLA-229](https://justice.gov.bc.ca/jira/browse/FLA-229) - Modify submission endpoint to return the bceid account in the account list

the `userdetails` object has a new field called `universalId` of type `uuid`

![image](https://user-images.githubusercontent.com/51387119/87182724-8b3c6f80-c299-11ea-8e57-15627c0de32f.png)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Running the app locally in demo mode

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
