### PR TITLE
Address feedback on shared components docs

### DIFF
--- a/src/frontend/shared-components/src/components/confirmation-popup/ConfirmationPopup.mdx
+++ b/src/frontend/shared-components/src/components/confirmation-popup/ConfirmationPopup.mdx
@@ -30,6 +30,8 @@ an action that may lead to unexpected behaviour if it occurs without confirmatio
 | confirmButton | object | true     | object describing the confirmation button that appears within the popup |         |
 | cancelButton  | object | true     | object describing the cancel button that appears within the popup       |         |
 
+### Modal API
+
 The modal object has its own properties that need to be present within it, as shown below:
 
 | Prop  | Type     | Required | Description                                                  | Default |
@@ -37,6 +39,8 @@ The modal object has its own properties that need to be present within it, as sh
 | show  | boolean  | true     | value representing whether the popup should be shown or not  |         |
 | title | string   | true     | value for the heading of the popup                           |         |
 | body  | function | true     | function rendering some jsx to display within the popup body |         |
+
+### Button API
 
 The mainButton, confirmButton, and cancelButton have their own properties as well, as shown below:
 
@@ -75,7 +79,7 @@ const modal = {
 const onButtonClick = () => store.set({ show: !store.get("show") });
 
 const mainButton = {
-  label: "main label",
+  label: "Click Me",
   styling: "normal-white btn",
   onClick: onButtonClick
 };

--- a/src/frontend/shared-components/src/components/confirmation-popup/ConfirmationPopup.stories.js
+++ b/src/frontend/shared-components/src/components/confirmation-popup/ConfirmationPopup.stories.js
@@ -38,7 +38,7 @@ const modal = {
 const onButtonClick = () => store.set({ show: !store.get("show") });
 
 const mainButton = {
-  label: "Cancel",
+  label: "Click Me",
   styling: "normal-white btn",
   onClick: onButtonClick
 };

--- a/src/frontend/shared-components/src/components/confirmation-popup/__snapshots__/ConfirmationPopup.stories.storyshot
+++ b/src/frontend/shared-components/src/components/confirmation-popup/__snapshots__/ConfirmationPopup.stories.storyshot
@@ -7,7 +7,7 @@ exports[`Storyshots Confirmation Popup Default 1`] = `
       "callbacks": Array [
         Object {
           "callback": [Function],
-          "subscription": "4e9ae9ef-4fed-4c33-b0b0-a3f67a5b83da",
+          "subscription": "b883404c-5e03-4ab5-b7b4-1d8f1821f9e7",
         },
       ],
       "state": Object {
@@ -34,7 +34,7 @@ exports[`Storyshots Confirmation Popup Default 1`] = `
     key="popup"
     mainButton={
       Object {
-        "label": "Cancel",
+        "label": "Click Me",
         "onClick": [Function],
         "styling": "normal-white btn",
       }
@@ -49,7 +49,7 @@ exports[`Storyshots Confirmation Popup Default 1`] = `
   >
     <Button
       disabled={false}
-      label="Cancel"
+      label="Click Me"
       onClick={[Function]}
       styling="normal-white btn"
     >
@@ -60,7 +60,7 @@ exports[`Storyshots Confirmation Popup Default 1`] = `
           onClick={[Function]}
           type="button"
         >
-          Cancel
+          Click Me
         </button>
       </div>
     </Button>
@@ -131,11 +131,11 @@ exports[`Storyshots Confirmation Popup Mobile 1`] = `
       "callbacks": Array [
         Object {
           "callback": [Function],
-          "subscription": "4e9ae9ef-4fed-4c33-b0b0-a3f67a5b83da",
+          "subscription": "b883404c-5e03-4ab5-b7b4-1d8f1821f9e7",
         },
         Object {
           "callback": [Function],
-          "subscription": "0a4b1f17-a0fa-4668-9eba-f0591145c975",
+          "subscription": "71a88f05-1e5f-4478-b287-d303fc7d195c",
         },
       ],
       "state": Object {
@@ -162,7 +162,7 @@ exports[`Storyshots Confirmation Popup Mobile 1`] = `
     key="popup"
     mainButton={
       Object {
-        "label": "Cancel",
+        "label": "Click Me",
         "onClick": [Function],
         "styling": "normal-white btn",
       }
@@ -177,7 +177,7 @@ exports[`Storyshots Confirmation Popup Mobile 1`] = `
   >
     <Button
       disabled={false}
-      label="Cancel"
+      label="Click Me"
       onClick={[Function]}
       styling="normal-white btn"
     >
@@ -188,7 +188,7 @@ exports[`Storyshots Confirmation Popup Mobile 1`] = `
           onClick={[Function]}
           type="button"
         >
-          Cancel
+          Click Me
         </button>
       </div>
     </Button>

--- a/src/frontend/shared-components/src/components/display-box/DisplayBox.css
+++ b/src/frontend/shared-components/src/components/display-box/DisplayBox.css
@@ -10,6 +10,7 @@
 
 .display-element {
   width: 100%;
+  padding-top: 3px;
 }
 
 .grey-background {

--- a/src/frontend/shared-components/src/components/header/Header.mdx
+++ b/src/frontend/shared-components/src/components/header/Header.mdx
@@ -22,6 +22,8 @@ When the product or service is not owned by the Government of British Columbia
 | ------ | ------ | -------- | ---------------------------------------- | ------- |
 | header | object | true     | object with details regarding the header |         |
 
+### Header API
+
 The header object has its own properties that need to be present within it, as shown below:
 
 | Prop    | Type   | Required | Description                   |

--- a/src/frontend/shared-components/src/components/input/Input.css
+++ b/src/frontend/shared-components/src/components/input/Input.css
@@ -14,7 +14,7 @@
 }
 
 .editable-white {
-  padding: 1px 0px 1px 0px;
+  padding: 1px 0px 1px 10px;
   box-sizing: border-box;
   top: 30px;
   width: 100%;
@@ -30,6 +30,7 @@
 }
 
 .non-editable-grey {
+  padding: 1px 0px 1px 10px;
   top: 30px;
   width: 100%;
   height: 40px;

--- a/src/frontend/shared-components/src/components/input/Input.mdx
+++ b/src/frontend/shared-components/src/components/input/Input.mdx
@@ -24,6 +24,8 @@ Text inputs allow users to enter a single line of text.
 | input    | object   | true     | object with input field details                       |         |
 | onChange | function | true     | function to execute when value in input field changes |         |
 
+### Input API
+
 The input object has its own properties that need to be present within it, as shown below:
 
 | Prop        | Type    | Required | Description                                                                                    | Default |

--- a/src/frontend/shared-components/src/components/table/Table.mdx
+++ b/src/frontend/shared-components/src/components/table/Table.mdx
@@ -15,6 +15,8 @@ The table lets you aggregate a huge amount of data and present it in a clear and
 | elements | array of objects | false    | content of the table                                    | []      |
 | styling  | string           | false    | represents the styling you wish to apply for your table | ""      |
 
+### Elements API
+
 The elements array contains objects of the following structure:
 
 | Prop  | Type          | Required | Description                                  | Default |


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Address feedback on shared components docs

Specifically:

- subheading for sub-api
- confirmationpopup -> "click me" instead of cancel
- input field padding on left
- alert -> move down a bit

## Type of change

- [x] Refactoring / Documentation

## How Has This Been Tested?

- local
- storybook
- tests