### PR TITLE
Alert custom icon

### DIFF
--- a/src/frontend/efiling-frontend/src/components/page/cso-account/CSOAccount.js
+++ b/src/frontend/efiling-frontend/src/components/page/cso-account/CSOAccount.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/require-default-props */
 import React, { useState, useEffect } from "react";
-import { MdPerson } from "react-icons/md";
+import { MdPerson, MdError } from "react-icons/md";
 
 import ConfirmationPopup, {
   TermsOfUse,
@@ -52,7 +52,9 @@ export default function CSOAccount({ confirmationPopup, applicantInfo }) {
         <div className="non-printable">
           <h2>Create a Court Services Online (CSO) Account</h2>
           <Alert
+            icon={<MdError size={32} />}
             type="warning"
+            styling="warning-background"
             element="You need a CSO account to use E-File Submission. Create one now to continue."
           />
           <br />

--- a/src/frontend/efiling-frontend/src/components/page/home/Home.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.js
@@ -16,13 +16,13 @@ export const saveNavigationToSession = ({ cancel, success, error }) => {
   if (error.url) sessionStorage.setItem("errorUrl", error.url);
 };
 
-const addUserInfo = (bceID, firstName, middleName, lastName, emailAddress) => {
+const addUserInfo = ({ bceid, firstName, middleName, lastName, email }) => {
   return {
-    bceID,
+    bceid,
     firstName,
     middleName,
     lastName,
-    emailAddress
+    email
   };
 };
 
@@ -45,13 +45,7 @@ const checkCSOAccountStatus = (
         if (csoAccountExists) setCsoAccountExists(true);
       }
 
-      const applicantInfo = addUserInfo(
-        userDetails.bceid,
-        userDetails.firstName,
-        userDetails.middleName,
-        userDetails.lastName,
-        userDetails.email
-      );
+      const applicantInfo = addUserInfo(userDetails);
 
       setApplicantInfo(applicantInfo);
 

--- a/src/frontend/efiling-frontend/src/modules/applicantInfoTestData.js
+++ b/src/frontend/efiling-frontend/src/modules/applicantInfoTestData.js
@@ -1,8 +1,8 @@
 const applicantInfo = {
-  bceID: "bobross42",
+  bceid: "bobross42",
   firstName: "Bob",
   lastName: "Ross",
-  emailAddress: "bob.ross@example.com"
+  email: "bob.ross@example.com"
 };
 
 export function getApplicantInfo() {

--- a/src/frontend/efiling-frontend/src/modules/translateApplicantInfo.js
+++ b/src/frontend/efiling-frontend/src/modules/translateApplicantInfo.js
@@ -1,15 +1,15 @@
 export function translateApplicantInfo({
-  bceID,
+  bceid,
   firstName,
   middleName,
   lastName,
-  emailAddress
+  email
 }) {
   const fullName = [firstName, middleName, lastName];
   return [
     {
       name: "BCeID:",
-      value: bceID
+      value: bceid
     },
     {
       name: "Full Name:",
@@ -17,7 +17,7 @@ export function translateApplicantInfo({
     },
     {
       name: "Email Address:",
-      value: emailAddress
+      value: email
     }
   ];
 }

--- a/src/frontend/efiling-frontend/src/types/propTypes.js
+++ b/src/frontend/efiling-frontend/src/types/propTypes.js
@@ -28,10 +28,10 @@ export const propTypes = {
     }).isRequired
   }).isRequired,
   applicantInfo: PropTypes.shape({
-    bceID: PropTypes.string.isRequired,
+    bceid: PropTypes.string.isRequired,
     firstName: PropTypes.string.isRequired,
     middleName: PropTypes.string,
     lastName: PropTypes.string.isRequired,
-    emailAddress: PropTypes.string.isRequired
+    email: PropTypes.string.isRequired
   }).isRequired
 };

--- a/src/frontend/shared-components/src/components/alert/Alert.css
+++ b/src/frontend/shared-components/src/components/alert/Alert.css
@@ -1,0 +1,27 @@
+.success-background {
+  background-color: #e7f7ea;
+  border-top: 1px solid;
+  border-bottom: 1px solid;
+  border-color: #2e8540;
+}
+
+.warning-background {
+  background-color: rgb(252, 247, 228);
+  border-top: 1px solid;
+  border-bottom: 1px solid;
+  border-color: rgb(252, 186, 25);
+}
+
+.error-background {
+  background-color: #f8dee0;
+  border-top: 1px solid;
+  border-bottom: 1px solid;
+  border-color: #d8292f;
+}
+
+.info-background {
+  background-color: #d9eaf7;
+  border-top: 1px solid;
+  border-bottom: 1px solid;
+  border-color: #313132;
+}

--- a/src/frontend/shared-components/src/components/alert/Alert.js
+++ b/src/frontend/shared-components/src/components/alert/Alert.js
@@ -1,54 +1,31 @@
 import React from "react";
-import { MdError, MdCancel, MdCheckBox, MdInfo } from "react-icons/md";
 import PropTypes from "prop-types";
 
 import { DisplayBox } from "../display-box/DisplayBox";
 
-const success = (
-  <div style={{ color: "#2E8540" }}>
-    <MdCheckBox size={32} />
-  </div>
-);
-const warning = (
-  <div style={{ color: "rgb(252, 186, 25)" }}>
-    <MdError size={32} />
-  </div>
-);
-const error = (
-  <div style={{ color: "#D8292F" }}>
-    <MdCancel size={32} />
-  </div>
-);
-const info = <MdInfo size={32} />;
+const generateIcon = (icon, type) => {
+  const success = <div style={{ color: "#2E8540" }}>{icon}</div>;
+  const warning = <div style={{ color: "rgb(252, 186, 25)" }}>{icon}</div>;
+  const error = <div style={{ color: "#D8292F" }}>{icon}</div>;
+  const info = <>{icon}</>;
 
-export const Alert = ({ type, element }) => {
+  if (type === "success") return success;
+  if (type === "warning") return warning;
+  if (type === "error") return error;
+  return info;
+};
+
+export const Alert = ({ type, styling, element, icon }) => {
+  const generatedIcon = generateIcon(icon, type);
+
   return (
-    <>
-      {type === "success" && (
-        <DisplayBox
-          styling="success-background"
-          icon={success}
-          element={element}
-        />
-      )}
-      {type === "warning" && (
-        <DisplayBox
-          styling="warning-background"
-          icon={warning}
-          element={element}
-        />
-      )}
-      {type === "error" && (
-        <DisplayBox styling="error-background" icon={error} element={element} />
-      )}
-      {type === "info" && (
-        <DisplayBox styling="info-background" icon={info} element={element} />
-      )}
-    </>
+    <DisplayBox styling={styling} icon={generatedIcon} element={element} />
   );
 };
 
 Alert.propTypes = {
   type: PropTypes.string.isRequired,
-  element: PropTypes.string.isRequired
+  element: PropTypes.string.isRequired,
+  icon: PropTypes.element.isRequired,
+  styling: PropTypes.string.isRequired
 };

--- a/src/frontend/shared-components/src/components/alert/Alert.js
+++ b/src/frontend/shared-components/src/components/alert/Alert.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import { DisplayBox } from "../display-box/DisplayBox";
+import "./Alert.css";
 
 const generateIcon = (icon, type) => {
   const success = <div style={{ color: "#2E8540" }}>{icon}</div>;

--- a/src/frontend/shared-components/src/components/alert/Alert.mdx
+++ b/src/frontend/shared-components/src/components/alert/Alert.mdx
@@ -40,7 +40,7 @@ Used for success messages, typically for after an action is successfully perform
 <Story name="Success" id="alert--success"></Story>
 
 ```bash
-<Alert type="success" element="This is a success message!" />
+<Alert icon={<MdCheckBox size={32} />} type="success" styling="success-background" element="This is a success message!" />
 ```
 
 ## Warning Alert
@@ -50,7 +50,7 @@ Used for warning messages, typically for explicitly informing a user of somethin
 <Story name="Warning" id="alert--warning"></Story>
 
 ```bash
-<Alert type="warning" element="This is a warning message!" />
+<Alert icon={<MdError size={32} />} type="warning" styling="warning-background" element="This is a warning message!" />
 ```
 
 ## Info Alert
@@ -60,7 +60,7 @@ Used for informative messages.
 <Story name="Info" id="alert--info"></Story>
 
 ```bash
-<Alert type="info" element="This is an info message!" />
+<Alert icon={<MdInfo size={32} />} type="info" styling="info-background" element="This is an info message!" />
 ```
 
 ## Error Alert
@@ -70,5 +70,5 @@ Used for error messages, when something has gone wrong unexpectedly and the user
 <Story name="Error" id="alert--error"></Story>
 
 ```bash
-<Alert type="error" element="This is an error message!" />
+<Alert icon={<MdCancel size={32} />} type="error" styling="error-background" element="This is an error message!" />
 ```

--- a/src/frontend/shared-components/src/components/alert/Alert.stories.js
+++ b/src/frontend/shared-components/src/components/alert/Alert.stories.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { MdError, MdCancel, MdCheckBox, MdInfo } from "react-icons/md";
 import mdx from "./Alert.mdx";
 
 import { Alert } from "./Alert";
@@ -14,23 +15,48 @@ export default {
 };
 
 export const Success = () => (
-  <Alert type="success" element="This is a success message!" />
+  <Alert
+    icon={<MdCheckBox size={32} />}
+    type="success"
+    styling="success-background"
+    element="This is a success message!"
+  />
 );
 
 export const Warning = () => (
-  <Alert type="warning" element="This is a warning message!" />
+  <Alert
+    icon={<MdError size={32} />}
+    type="warning"
+    styling="warning-background"
+    element="This is a warning message!"
+  />
 );
 
 export const Error = () => (
-  <Alert type="error" element="This is an error message!" />
+  <Alert
+    icon={<MdCancel size={32} />}
+    type="error"
+    styling="error-background"
+    element="This is an error message!"
+  />
 );
 
 export const Info = () => (
-  <Alert type="info" element="This is an info message!" />
+  <Alert
+    icon={<MdInfo size={32} />}
+    type="info"
+    styling="info-background"
+    element="This is an info message!"
+  />
 );
 
 export const Mobile = () => (
-  <Alert type="success" element="This is a success message!" />
+  <Alert
+    icon={<MdCheckBox size={32} />}
+    type="success"
+    styling="success-background"
+    element="This is a success message!"
+  />
 );
 
 const mobileViewport = {

--- a/src/frontend/shared-components/src/components/alert/Alert.test.js
+++ b/src/frontend/shared-components/src/components/alert/Alert.test.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { MdInfo } from "react-icons/md";
 
 import testBasicSnapshot from "../../TestHelper";
 import { Alert } from "./Alert";
@@ -6,23 +7,45 @@ import { Alert } from "./Alert";
 describe("Alert Component", () => {
   test("Matches the 'success' snapshot", () => {
     testBasicSnapshot(
-      <Alert type="success" element="This is a success message!" />
+      <Alert
+        icon={<MdInfo size={32} />}
+        type="success"
+        styling="success-background"
+        element="This is a success message!"
+      />
     );
   });
 
   test("Matches the 'warning' snapshot", () => {
     testBasicSnapshot(
-      <Alert type="warning" element="This is a warning message!" />
+      <Alert
+        styling="warning-background"
+        type="warning"
+        element="This is a warning message!"
+        icon={<MdInfo size={32} />}
+      />
     );
   });
 
   test("Matches the 'error' snapshot", () => {
     testBasicSnapshot(
-      <Alert type="error" element="This is an error message!" />
+      <Alert
+        type="error"
+        element="This is an error message!"
+        icon={<MdInfo size={32} />}
+        styling="error-background"
+      />
     );
   });
 
   test("Matches the 'info' snapshot", () => {
-    testBasicSnapshot(<Alert type="info" element="This is an info message!" />);
+    testBasicSnapshot(
+      <Alert
+        styling="info-background"
+        type="info"
+        element="This is an info message!"
+        icon={<MdInfo size={32} />}
+      />
+    );
   });
 });

--- a/src/frontend/shared-components/src/components/alert/Alert.test.js
+++ b/src/frontend/shared-components/src/components/alert/Alert.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { MdInfo } from "react-icons/md";
+import { MdError, MdCancel, MdCheckBox, MdInfo } from "react-icons/md";
 
 import testBasicSnapshot from "../../TestHelper";
 import { Alert } from "./Alert";
@@ -8,7 +8,7 @@ describe("Alert Component", () => {
   test("Matches the 'success' snapshot", () => {
     testBasicSnapshot(
       <Alert
-        icon={<MdInfo size={32} />}
+        icon={<MdCheckBox size={32} />}
         type="success"
         styling="success-background"
         element="This is a success message!"
@@ -22,7 +22,7 @@ describe("Alert Component", () => {
         styling="warning-background"
         type="warning"
         element="This is a warning message!"
-        icon={<MdInfo size={32} />}
+        icon={<MdError size={32} />}
       />
     );
   });
@@ -32,7 +32,7 @@ describe("Alert Component", () => {
       <Alert
         type="error"
         element="This is an error message!"
-        icon={<MdInfo size={32} />}
+        icon={<MdCancel size={32} />}
         styling="error-background"
       />
     );

--- a/src/frontend/shared-components/src/components/alert/__snapshots__/Alert.stories.storyshot
+++ b/src/frontend/shared-components/src/components/alert/__snapshots__/Alert.stories.storyshot
@@ -3,6 +3,12 @@
 exports[`Storyshots Alert Error 1`] = `
 <Alert
   element="This is an error message!"
+  icon={
+    <MdCancel
+      size={32}
+    />
+  }
+  styling="error-background"
   type="error"
 >
   <DisplayBox
@@ -83,14 +89,22 @@ exports[`Storyshots Alert Error 1`] = `
 exports[`Storyshots Alert Info 1`] = `
 <Alert
   element="This is an info message!"
+  icon={
+    <MdInfo
+      size={32}
+    />
+  }
+  styling="info-background"
   type="info"
 >
   <DisplayBox
     element="This is an info message!"
     icon={
-      <MdInfo
-        size={32}
-      />
+      <React.Fragment>
+        <MdInfo
+          size={32}
+        />
+      </React.Fragment>
     }
     styling="info-background"
   >
@@ -147,6 +161,12 @@ exports[`Storyshots Alert Info 1`] = `
 exports[`Storyshots Alert Mobile 1`] = `
 <Alert
   element="This is a success message!"
+  icon={
+    <MdCheckBox
+      size={32}
+    />
+  }
+  styling="success-background"
   type="success"
 >
   <DisplayBox
@@ -227,6 +247,12 @@ exports[`Storyshots Alert Mobile 1`] = `
 exports[`Storyshots Alert Success 1`] = `
 <Alert
   element="This is a success message!"
+  icon={
+    <MdCheckBox
+      size={32}
+    />
+  }
+  styling="success-background"
   type="success"
 >
   <DisplayBox
@@ -307,6 +333,12 @@ exports[`Storyshots Alert Success 1`] = `
 exports[`Storyshots Alert Warning 1`] = `
 <Alert
   element="This is a warning message!"
+  icon={
+    <MdError
+      size={32}
+    />
+  }
+  styling="warning-background"
   type="warning"
 >
   <DisplayBox

--- a/src/frontend/shared-components/src/components/display-box/DisplayBox.css
+++ b/src/frontend/shared-components/src/components/display-box/DisplayBox.css
@@ -27,34 +27,6 @@
   border-color: lightgrey;
 }
 
-.success-background {
-  background-color: #e7f7ea;
-  border-top: 1px solid;
-  border-bottom: 1px solid;
-  border-color: #2e8540;
-}
-
-.warning-background {
-  background-color: rgb(252, 247, 228);
-  border-top: 1px solid;
-  border-bottom: 1px solid;
-  border-color: rgb(252, 186, 25);
-}
-
-.error-background {
-  background-color: #f8dee0;
-  border-top: 1px solid;
-  border-bottom: 1px solid;
-  border-color: #d8292f;
-}
-
-.info-background {
-  background-color: #d9eaf7;
-  border-top: 1px solid;
-  border-bottom: 1px solid;
-  border-color: #313132;
-}
-
 .react-icons {
   vertical-align: middle;
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- ability to have custom icon for alert component
- JIRA: FLA-247 (https://justice.gov.bc.ca/jira/browse/FLA-247)

```
<Alert
    styling="warning-background"
    type="warning"  
    element="This is a warning message!"
    icon={<MdError size={32} />}
/>
```

- Also added some refactoring to simplify code and make it more consistent in all places

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation

## How Has This Been Tested?

- local, jest, storybook