### PR TITLE
Consume mimetype (smallest FE PR in the history)

### DIFF
--- a/src/frontend/efiling-frontend/src/components/page/package-confirmation/PackageConfirmation.js
+++ b/src/frontend/efiling-frontend/src/components/page/package-confirmation/PackageConfirmation.js
@@ -40,7 +40,7 @@ const openFile = (file, submissionId) => {
     })
     .then(response => {
       // TODO: do not use hard coded type
-      const fileData = new Blob([response.data], { type: "application/pdf" });
+      const fileData = new Blob([response.data], { type: file.mimeType });
       const fileUrl = URL.createObjectURL(fileData);
 
       window.open(fileUrl);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- consume mimeType
- Pull in mime-type instead of hard coded value for document
- JIRA: https://justice.gov.bc.ca/jira/browse/FLA-292

- we can now display multiple document types, not just pdf

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- local
- jest
- storybook