### PR TITLE
Add ability to pass in custom filing package JSON in demo app

### DIFF
--- a/src/frontend/efiling-demo/package.json
+++ b/src/frontend/efiling-demo/package.json
@@ -25,7 +25,7 @@
     "react-scripts": "3.4.1",
     "react-test-renderer": "^16.12.0",
     "regenerator-runtime": "^0.13.5",
-    "shared-components": "https://github.com/SierraSystems/bcgov-shared-components/releases/download/0.3.4/shared-components-0.3.4.tgz",
+    "shared-components": "https://github.com/SierraSystems/bcgov-shared-components/releases/download/0.3.5/shared-components-0.3.5.tgz",
     "webpack": "4.42.0"
   },
   "scripts": {

--- a/src/frontend/efiling-demo/src/__snapshots__/storyshots.test.js.snap
+++ b/src/frontend/efiling-demo/src/__snapshots__/storyshots.test.js.snap
@@ -734,6 +734,24 @@ exports[`Storyshots Home Default 1`] = `
         />
       </div>
       <br />
+      <div
+        className="text-label"
+      >
+        <label
+          htmlFor="1"
+        >
+          Provide filing package JSON data:
+        </label>
+      </div>
+      <textarea
+        className="text-input"
+        cols="60"
+        id="1"
+        onChange={[Function]}
+        rows="8"
+      />
+      <br />
+      <br />
       <div>
         <button
           className="normal-blue btn"
@@ -745,6 +763,7 @@ exports[`Storyshots Home Default 1`] = `
           E-File my Package
         </button>
       </div>
+      <br />
       <br />
     </div>
   </div>
@@ -930,6 +949,24 @@ exports[`Storyshots Home Mobile 1`] = `
         />
       </div>
       <br />
+      <div
+        className="text-label"
+      >
+        <label
+          htmlFor="1"
+        >
+          Provide filing package JSON data:
+        </label>
+      </div>
+      <textarea
+        className="text-input"
+        cols="60"
+        id="1"
+        onChange={[Function]}
+        rows="8"
+      />
+      <br />
+      <br />
       <div>
         <button
           className="normal-blue btn"
@@ -941,6 +978,7 @@ exports[`Storyshots Home Mobile 1`] = `
           E-File my Package
         </button>
       </div>
+      <br />
       <br />
     </div>
   </div>

--- a/src/frontend/efiling-demo/src/components/page/home/Home.js
+++ b/src/frontend/efiling-demo/src/components/page/home/Home.js
@@ -48,6 +48,8 @@ const input = {
 };
 
 const generatePackageData = (files, filingPackage) => {
+  if (!files || files.length === 0) return {};
+
   const formData = new FormData();
   const documentData = [];
 
@@ -82,11 +84,6 @@ export const eFilePackage = (
   setErrorExists,
   filingPackage
 ) => {
-  if (!files || files.length === 0) {
-    setErrorExists(true);
-    return;
-  }
-
   const { formData, updatedUrlBody } = generatePackageData(
     files,
     filingPackage

--- a/src/frontend/efiling-demo/src/components/page/home/Home.js
+++ b/src/frontend/efiling-demo/src/components/page/home/Home.js
@@ -109,6 +109,8 @@ export const eFilePackage = (
         .catch(() => setErrorExists(true));
     })
     .catch(() => setErrorExists(true));
+
+  return true;
 };
 
 export default function Home({ page: { header } }) {

--- a/src/frontend/efiling-demo/src/components/page/home/Home.js
+++ b/src/frontend/efiling-demo/src/components/page/home/Home.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-curly-newline */
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import axios from "axios";

--- a/src/frontend/efiling-demo/src/components/page/home/Home.js
+++ b/src/frontend/efiling-demo/src/components/page/home/Home.js
@@ -48,8 +48,6 @@ const input = {
 };
 
 const generatePackageData = (files, filingPackage) => {
-  if (!files || files.length === 0) return {};
-
   const formData = new FormData();
   const documentData = [];
 
@@ -84,15 +82,14 @@ export const eFilePackage = (
   setErrorExists,
   filingPackage
 ) => {
+  if (!files || files.length === 0) return false;
+
   const { formData, updatedUrlBody } = generatePackageData(
     files,
     filingPackage
   );
 
-  if (!formData || !updatedUrlBody) {
-    setErrorExists(true);
-    return;
-  }
+  if (!formData || !updatedUrlBody) return false;
 
   axios
     .post("/submission/documents", formData, {
@@ -143,9 +140,15 @@ export default function Home({ page: { header } }) {
           <br />
           <br />
           <Button
-            onClick={() =>
-              eFilePackage(files, accountGuid, setErrorExists, filingPackage)
-            }
+            onClick={() => {
+              const result = eFilePackage(
+                files,
+                accountGuid,
+                setErrorExists,
+                filingPackage
+              );
+              if (!result) setErrorExists(true);
+            }}
             label="E-File my Package"
             styling="normal-blue btn"
             testId="generate-url-btn"

--- a/src/frontend/efiling-demo/src/components/page/home/__snapshots__/Home.test.js.snap
+++ b/src/frontend/efiling-demo/src/components/page/home/__snapshots__/Home.test.js.snap
@@ -89,6 +89,23 @@ exports[`Home Component matches the snapshot 1`] = `
           />
         </div>
         <br />
+        <div
+          class="text-label"
+        >
+          <label
+            for="1"
+          >
+            Provide filing package JSON data:
+          </label>
+        </div>
+        <textarea
+          class="text-input"
+          cols="60"
+          id="1"
+          rows="8"
+        />
+        <br />
+        <br />
         <div>
           <button
             class="normal-blue btn"
@@ -98,6 +115,7 @@ exports[`Home Component matches the snapshot 1`] = `
             E-File my Package
           </button>
         </div>
+        <br />
         <br />
       </div>
     </div>

--- a/src/frontend/efiling-demo/yarn.lock
+++ b/src/frontend/efiling-demo/yarn.lock
@@ -12499,9 +12499,9 @@ shallowequal@^1.1.0:
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
-"shared-components@https://github.com/SierraSystems/bcgov-shared-components/releases/download/0.3.4/shared-components-0.3.4.tgz":
-  version "0.3.4"
-  resolved "https://github.com/SierraSystems/bcgov-shared-components/releases/download/0.3.4/shared-components-0.3.4.tgz#372ac2eca919366e319820154409b61440e812a2"
+"shared-components@https://github.com/SierraSystems/bcgov-shared-components/releases/download/0.3.5/shared-components-0.3.5.tgz":
+  version "0.3.5"
+  resolved "https://github.com/SierraSystems/bcgov-shared-components/releases/download/0.3.5/shared-components-0.3.5.tgz#02fc80da493def8fbc3c255f0258c7f6cd5e6460"
   dependencies:
     "@bcgov/bootstrap-theme" "github:bcgov/bootstrap-theme"
     babel-plugin-transform-export-extensions "^6.22.0"

--- a/src/frontend/efiling-frontend/package.json
+++ b/src/frontend/efiling-frontend/package.json
@@ -23,7 +23,7 @@
     "react-scripts": "3.4.1",
     "react-test-renderer": "^16.12.0",
     "regenerator-runtime": "^0.13.5",
-    "shared-components": "https://github.com/SierraSystems/bcgov-shared-components/releases/download/0.3.4/shared-components-0.3.4.tgz",
+    "shared-components": "https://github.com/SierraSystems/bcgov-shared-components/releases/download/0.3.5/shared-components-0.3.5.tgz",
     "webpack": "4.42.0"
   },
   "scripts": {

--- a/src/frontend/efiling-frontend/yarn.lock
+++ b/src/frontend/efiling-frontend/yarn.lock
@@ -12501,9 +12501,9 @@ shallowequal@^1.1.0:
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
-"shared-components@https://github.com/SierraSystems/bcgov-shared-components/releases/download/0.3.4/shared-components-0.3.4.tgz":
-  version "0.3.4"
-  resolved "https://github.com/SierraSystems/bcgov-shared-components/releases/download/0.3.4/shared-components-0.3.4.tgz#372ac2eca919366e319820154409b61440e812a2"
+"shared-components@https://github.com/SierraSystems/bcgov-shared-components/releases/download/0.3.5/shared-components-0.3.5.tgz":
+  version "0.3.5"
+  resolved "https://github.com/SierraSystems/bcgov-shared-components/releases/download/0.3.5/shared-components-0.3.5.tgz#02fc80da493def8fbc3c255f0258c7f6cd5e6460"
   dependencies:
     "@bcgov/bootstrap-theme" "github:bcgov/bootstrap-theme"
     babel-plugin-transform-export-extensions "^6.22.0"


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Add ability to pass in custom filing package JSON in demo app
- JIRA: https://justice.gov.bc.ca/jira/browse/FLA-289

## Usage

1) you need to provide the filing package JSON in the text area
2) you need to update the values of court level, class, location etc
3) you need to update the documents array of objects to match the name of the files you are uploading and pass in types for those files

## Screenshots

![Screen Shot 2020-07-21 at 2 54 38 PM](https://user-images.githubusercontent.com/55710226/88111111-2f5bcb80-cb62-11ea-8bcb-48f56334b7a7.png)
![Screen Shot 2020-07-21 at 2 54 51 PM](https://user-images.githubusercontent.com/55710226/88111119-308cf880-cb62-11ea-9ba0-c39bf8ac464b.png)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- local
- storybook
- jest
