### PR TITLE
Get BCeID username, firstname, lastname, email and populate on frontend

### DIFF
--- a/src/frontend/efiling-frontend/package.json
+++ b/src/frontend/efiling-frontend/package.json
@@ -13,6 +13,7 @@
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
     "history": "^5.0.0",
+    "jsonwebtoken": "^8.5.1",
     "keycloak-js": "^7.0.1",
     "prop-types": "^15.7.2",
     "query-string": "^6.11.1",

--- a/src/frontend/efiling-frontend/src/components/page/cso-account/CSOAccount.js
+++ b/src/frontend/efiling-frontend/src/components/page/cso-account/CSOAccount.js
@@ -17,8 +17,6 @@ import { translateApplicantInfo } from "../../../modules/translateApplicantInfo"
 import { errorRedirect } from "../../../modules/errorRedirect";
 import { propTypes } from "../../../types/propTypes";
 
-const sideCard = getSidecardData().aboutCso;
-
 const content = getContent();
 
 export default function CSOAccount({
@@ -26,6 +24,7 @@ export default function CSOAccount({
   applicantInfo,
   setCsoAccountStatus,
 }) {
+  const sideCard = getSidecardData().aboutCso;
   const [termsAccepted, acceptTerms] = useState(false);
   const [continueBtnEnabled, setContinueBtnEnabled] = useState(false);
 

--- a/src/frontend/efiling-frontend/src/components/page/cso-account/CSOAccount.test.js
+++ b/src/frontend/efiling-frontend/src/components/page/cso-account/CSOAccount.test.js
@@ -11,6 +11,7 @@ import MockAdapter from "axios-mock-adapter";
 
 import { getTestData } from "../../../modules/confirmationPopupTestData";
 import { getApplicantInfo } from "../../../modules/applicantInfoTestData";
+import { generateJWTToken } from "../../../modules/authenticationHelper";
 
 import CSOAccount from "./CSOAccount";
 
@@ -23,6 +24,9 @@ describe("CSOAccount Component", () => {
 
   const mock = new MockAdapter(axios);
   const API_REQUEST = "/csoAccount";
+
+  const token = generateJWTToken({ preferred_username: "username@bceid" });
+  localStorage.setItem("jwt", token);
 
   test("Matches the snapshot", () => {
     const { asFragment } = render(

--- a/src/frontend/efiling-frontend/src/components/page/cso-account/__snapshots__/CSOAccount.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/components/page/cso-account/__snapshots__/CSOAccount.stories.storyshot
@@ -109,7 +109,7 @@ exports[`Storyshots CSOAccount Default 1`] = `
                   <div
                     class="bcgov-table-value "
                   >
-                    Bob  Ross
+                    Bob Ross
                   </div>
                 </div>
                 <div
@@ -1050,7 +1050,7 @@ exports[`Storyshots CSOAccount Mobile 1`] = `
                   <div
                     class="bcgov-table-value "
                   >
-                    Bob  Ross
+                    Bob Ross
                   </div>
                 </div>
                 <div

--- a/src/frontend/efiling-frontend/src/components/page/cso-account/__snapshots__/CSOAccount.test.js.snap
+++ b/src/frontend/efiling-frontend/src/components/page/cso-account/__snapshots__/CSOAccount.test.js.snap
@@ -109,7 +109,7 @@ exports[`CSOAccount Component Matches the snapshot 1`] = `
                   <div
                     class="bcgov-table-value "
                   >
-                    Bob  Ross
+                    Bob Ross
                   </div>
                 </div>
                 <div

--- a/src/frontend/efiling-frontend/src/components/page/home/Home.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.js
@@ -25,21 +25,21 @@ export const saveDataToSessionStorage = (
   sessionStorage.setItem("universalId", universalId);
 };
 
-const addUserInfo = ({ firstName, middleName, lastName, email }) => {
-  let username = getJWTData().preferred_username;
+const addUserInfo = () => {
+  const { preferred_username, given_name, family_name, email } = getJWTData();
+  let username = preferred_username;
   username = username.substring(0, username.indexOf("@"));
 
   return {
     bceid: username,
-    firstName,
-    middleName,
-    lastName,
+    firstName: given_name,
+    lastName: family_name,
     email,
   };
 };
 
-const setRequiredState = (userDetails, setApplicantInfo, setShowLoader) => {
-  const applicantInfo = addUserInfo(userDetails);
+const setRequiredState = (setApplicantInfo, setShowLoader) => {
+  const applicantInfo = addUserInfo();
 
   setApplicantInfo(applicantInfo);
   setShowLoader(false);
@@ -71,7 +71,7 @@ const checkCSOAccountStatus = (
         setCsoAccountStatus({ isNew: false, exists: true });
       }
 
-      setRequiredState(userDetails, setApplicantInfo, setShowLoader);
+      setRequiredState(setApplicantInfo, setShowLoader);
     })
     .catch((error) => {
       errorRedirect(sessionStorage.getItem("errorUrl"), error);

--- a/src/frontend/efiling-frontend/src/components/page/home/Home.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import queryString from "query-string";

--- a/src/frontend/efiling-frontend/src/components/page/home/Home.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.js
@@ -7,6 +7,7 @@ import { MdCancel } from "react-icons/md";
 
 import { Header, Footer, Loader, Alert } from "shared-components";
 import { errorRedirect } from "../../../modules/errorRedirect";
+import { getJWTData } from "../../../modules/authenticationHelper";
 import PackageConfirmation from "../package-confirmation/PackageConfirmation";
 import CSOAccount from "../cso-account/CSOAccount";
 import { propTypes } from "../../../types/propTypes";
@@ -24,9 +25,12 @@ export const saveDataToSessionStorage = (
   sessionStorage.setItem("universalId", universalId);
 };
 
-const addUserInfo = ({ bceid, firstName, middleName, lastName, email }) => {
+const addUserInfo = ({ firstName, middleName, lastName, email }) => {
+  let username = getJWTData().preferred_username;
+  username = username.substring(0, username.indexOf("@"));
+
   return {
-    bceid,
+    bceid: username,
     firstName,
     middleName,
     lastName,

--- a/src/frontend/efiling-frontend/src/components/page/home/Home.stories.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.stories.js
@@ -8,6 +8,7 @@ import { getUserDetails } from "../../../modules/userDetails";
 import { getDocumentsData } from "../../../modules/documentTestData";
 import { getCourtData } from "../../../modules/courtTestData";
 import { getNavigationData } from "../../../modules/navigationTestData";
+import { generateJWTToken } from "../../../modules/authenticationHelper";
 
 import Home from "./Home";
 
@@ -33,9 +34,19 @@ const court = getCourtData();
 const submissionFeeAmount = 25.5;
 const userDetails = getUserDetails();
 
-sessionStorage.setItem("errorUrl", "error.com");
+const setRequiredStorage = () => {
+  sessionStorage.setItem("errorUrl", "error.com");
+  const token = generateJWTToken({
+    preferred_username: "username@bceid",
+    given_name: "User",
+    family_name: "Name",
+    email: "username@example.com",
+  });
+  localStorage.setItem("jwt", token);
+};
 
 const LoaderStateData = (props) => {
+  setRequiredStorage();
   const mock = new MockAdapter(axios);
   window.open = () => {};
   mock.onGet(apiRequest).reply(400, { message: "There was an error" });
@@ -43,6 +54,7 @@ const LoaderStateData = (props) => {
 };
 
 const AccountExistsStateData = (props) => {
+  setRequiredStorage();
   const mock = new MockAdapter(axios);
   mock.onGet(apiRequest).reply(200, { userDetails, navigation });
   mock
@@ -52,6 +64,7 @@ const AccountExistsStateData = (props) => {
 };
 
 const NoAccountExistsStateData = (props) => {
+  setRequiredStorage();
   const mock = new MockAdapter(axios);
   mock.onGet(apiRequest).reply(200, {
     userDetails: { ...userDetails, accounts: null },

--- a/src/frontend/efiling-frontend/src/components/page/home/Home.test.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.test.js
@@ -11,6 +11,7 @@ import { getUserDetails } from "../../../modules/userDetails";
 import { getDocumentsData } from "../../../modules/documentTestData";
 import { getNavigationData } from "../../../modules/navigationTestData";
 import { getCourtData } from "../../../modules/courtTestData";
+import { generateJWTToken } from "../../../modules/authenticationHelper";
 
 const header = {
   name: "eFiling Frontend",
@@ -32,6 +33,9 @@ describe("Home", () => {
   const userDetails = getUserDetails();
 
   window.open = jest.fn();
+
+  const token = generateJWTToken({ preferred_username: "username@bceid" });
+  localStorage.setItem("jwt", token);
 
   let mock;
   beforeEach(() => {

--- a/src/frontend/efiling-frontend/src/components/page/home/Home.test.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.test.js
@@ -34,7 +34,12 @@ describe("Home", () => {
 
   window.open = jest.fn();
 
-  const token = generateJWTToken({ preferred_username: "username@bceid" });
+  const token = generateJWTToken({
+    preferred_username: "username@bceid",
+    given_name: "User",
+    family_name: "Name",
+    email: "username@example.com",
+  });
   localStorage.setItem("jwt", token);
 
   let mock;

--- a/src/frontend/efiling-frontend/src/components/page/home/__snapshots__/Home.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/components/page/home/__snapshots__/Home.stories.storyshot
@@ -425,7 +425,7 @@ exports[`Storyshots Home Account Exists 1`] = `
                       </b>
                        is linked to your Basic BCeID account 
                       <b>
-                        blah2
+                        username
                       </b>
                        and will be used to file documents. 
                       <a
@@ -1039,7 +1039,7 @@ exports[`Storyshots Home Account Exists Mobile 1`] = `
                       </b>
                        is linked to your Basic BCeID account 
                       <b>
-                        blah2
+                        username
                       </b>
                        and will be used to file documents. 
                       <a
@@ -1698,7 +1698,7 @@ exports[`Storyshots Home No Account Exists 1`] = `
                     <div
                       class="bcgov-table-value "
                     >
-                      bobross42
+                      username
                     </div>
                   </div>
                   <div
@@ -2764,7 +2764,7 @@ exports[`Storyshots Home No Account Exists Mobile 1`] = `
                     <div
                       class="bcgov-table-value "
                     >
-                      bobross42
+                      username
                     </div>
                   </div>
                   <div

--- a/src/frontend/efiling-frontend/src/components/page/home/__snapshots__/Home.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/components/page/home/__snapshots__/Home.stories.storyshot
@@ -1712,7 +1712,7 @@ exports[`Storyshots Home No Account Exists 1`] = `
                     <div
                       class="bcgov-table-value "
                     >
-                      Bob Norman Ross
+                      User Name
                     </div>
                   </div>
                   <div
@@ -1726,7 +1726,7 @@ exports[`Storyshots Home No Account Exists 1`] = `
                     <div
                       class="bcgov-table-value "
                     >
-                      bob.ross@example.com
+                      username@example.com
                     </div>
                   </div>
                 </div>
@@ -2778,7 +2778,7 @@ exports[`Storyshots Home No Account Exists Mobile 1`] = `
                     <div
                       class="bcgov-table-value "
                     >
-                      Bob Norman Ross
+                      User Name
                     </div>
                   </div>
                   <div
@@ -2792,7 +2792,7 @@ exports[`Storyshots Home No Account Exists Mobile 1`] = `
                     <div
                       class="bcgov-table-value "
                     >
-                      bob.ross@example.com
+                      username@example.com
                     </div>
                   </div>
                 </div>

--- a/src/frontend/efiling-frontend/src/components/page/home/__snapshots__/Home.test.js.snap
+++ b/src/frontend/efiling-frontend/src/components/page/home/__snapshots__/Home.test.js.snap
@@ -484,7 +484,7 @@ exports[`Home Component matches the snapshot when user cso account does not exis
                     <div
                       class="bcgov-table-value "
                     >
-                      Bob Norman Ross
+                      User Name
                     </div>
                   </div>
                   <div
@@ -498,7 +498,7 @@ exports[`Home Component matches the snapshot when user cso account does not exis
                     <div
                       class="bcgov-table-value "
                     >
-                      bob.ross@example.com
+                      username@example.com
                     </div>
                   </div>
                 </div>

--- a/src/frontend/efiling-frontend/src/components/page/home/__snapshots__/Home.test.js.snap
+++ b/src/frontend/efiling-frontend/src/components/page/home/__snapshots__/Home.test.js.snap
@@ -470,7 +470,7 @@ exports[`Home Component matches the snapshot when user cso account does not exis
                     <div
                       class="bcgov-table-value "
                     >
-                      bobross42
+                      username
                     </div>
                   </div>
                   <div
@@ -1829,7 +1829,7 @@ exports[`Home Component matches the snapshot when user cso account exists 1`] = 
                       </b>
                        is linked to your Basic BCeID account 
                       <b>
-                        blah2
+                        username
                       </b>
                        and will be used to file documents. 
                       <a

--- a/src/frontend/efiling-frontend/src/components/page/package-confirmation/PackageConfirmation.stories.js
+++ b/src/frontend/efiling-frontend/src/components/page/package-confirmation/PackageConfirmation.stories.js
@@ -4,6 +4,7 @@ import MockAdapter from "axios-mock-adapter";
 import { getTestData } from "../../../modules/confirmationPopupTestData";
 import { getDocumentsData } from "../../../modules/documentTestData";
 import { getCourtData } from "../../../modules/courtTestData";
+import { generateJWTToken } from "../../../modules/authenticationHelper";
 
 import PackageConfirmation from "./PackageConfirmation";
 
@@ -20,6 +21,10 @@ const csoAccountStatus = { isNew: false };
 const documents = getDocumentsData();
 const courtData = getCourtData();
 const submissionFeeAmount = 25.5;
+
+sessionStorage.setItem("csoAccountId", "123");
+const token = generateJWTToken({ preferred_username: "username@bceid" });
+localStorage.setItem("jwt", token);
 
 const LoadData = (props) => {
   const mock = new MockAdapter(axios);

--- a/src/frontend/efiling-frontend/src/components/page/package-confirmation/PackageConfirmation.test.js
+++ b/src/frontend/efiling-frontend/src/components/page/package-confirmation/PackageConfirmation.test.js
@@ -5,6 +5,7 @@ import { render, waitFor, fireEvent, getByText } from "@testing-library/react";
 import { getTestData } from "../../../modules/confirmationPopupTestData";
 import { getDocumentsData } from "../../../modules/documentTestData";
 import { getCourtData } from "../../../modules/courtTestData";
+import { generateJWTToken } from "../../../modules/authenticationHelper";
 
 import PackageConfirmation from "./PackageConfirmation";
 
@@ -25,6 +26,8 @@ describe("PackageConfirmation Component", () => {
   const submissionFeeAmount = 25.5;
 
   sessionStorage.setItem("csoAccountId", "123");
+  const token = generateJWTToken({ preferred_username: "username@bceid" });
+  localStorage.setItem("jwt", token);
 
   let mock;
   beforeEach(() => {

--- a/src/frontend/efiling-frontend/src/components/page/package-confirmation/__snapshots__/PackageConfirmation.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/components/page/package-confirmation/__snapshots__/PackageConfirmation.stories.storyshot
@@ -388,7 +388,7 @@ exports[`Storyshots PackageConfirmation Existing Account 1`] = `
                     </b>
                      is linked to your Basic BCeID account 
                     <b>
-                      blah2
+                      username
                     </b>
                      and will be used to file documents. 
                     <a
@@ -877,7 +877,7 @@ exports[`Storyshots PackageConfirmation Mobile 1`] = `
                     </b>
                      is linked to your Basic BCeID account 
                     <b>
-                      blah2
+                      username
                     </b>
                      and will be used to file documents. 
                     <a
@@ -1398,7 +1398,7 @@ exports[`Storyshots PackageConfirmation New Account 1`] = `
                     </b>
                      is linked to your Basic BCeID account 
                     <b>
-                      blah2
+                      username
                     </b>
                      and will be used to file documents. 
                     <a

--- a/src/frontend/efiling-frontend/src/components/page/package-confirmation/__snapshots__/PackageConfirmation.test.js.snap
+++ b/src/frontend/efiling-frontend/src/components/page/package-confirmation/__snapshots__/PackageConfirmation.test.js.snap
@@ -388,7 +388,7 @@ exports[`PackageConfirmation Component Matches the existing account snapshot 1`]
                     </b>
                      is linked to your Basic BCeID account 
                     <b>
-                      blah2
+                      username
                     </b>
                      and will be used to file documents. 
                     <a
@@ -909,7 +909,7 @@ exports[`PackageConfirmation Component Matches the new account snapshot 1`] = `
                     </b>
                      is linked to your Basic BCeID account 
                     <b>
-                      blah2
+                      username
                     </b>
                      and will be used to file documents. 
                     <a
@@ -1655,7 +1655,7 @@ registered to my account. Statutory fees will be processed when documents are fi
                     </b>
                      is linked to your Basic BCeID account 
                     <b>
-                      blah2
+                      username
                     </b>
                      and will be used to file documents. 
                     <a

--- a/src/frontend/efiling-frontend/src/components/page/payment/Payment.test.js
+++ b/src/frontend/efiling-frontend/src/components/page/payment/Payment.test.js
@@ -11,6 +11,7 @@ import {
 import { getTestData } from "../../../modules/confirmationPopupTestData";
 import { getDocumentsData } from "../../../modules/documentTestData";
 import { getCourtData } from "../../../modules/courtTestData";
+import { generateJWTToken } from "../../../modules/authenticationHelper";
 
 import Payment from "./Payment";
 
@@ -28,6 +29,9 @@ describe("Payment Component", () => {
     files,
     submissionFee,
   };
+
+  const token = generateJWTToken({ preferred_username: "username@bceid" });
+  localStorage.setItem("jwt", token);
 
   let mock;
   beforeEach(() => {

--- a/src/frontend/efiling-frontend/src/components/page/payment/__snapshots__/Payment.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/components/page/payment/__snapshots__/Payment.stories.storyshot
@@ -424,7 +424,7 @@ registered to my account. Statutory fees will be processed when documents are fi
                     </b>
                      is linked to your Basic BCeID account 
                     <b>
-                      blah2
+                      username
                     </b>
                      and will be used to file documents. 
                     <a
@@ -949,7 +949,7 @@ registered to my account. Statutory fees will be processed when documents are fi
                     </b>
                      is linked to your Basic BCeID account 
                     <b>
-                      blah2
+                      username
                     </b>
                      and will be used to file documents. 
                     <a

--- a/src/frontend/efiling-frontend/src/components/page/payment/__snapshots__/Payment.test.js.snap
+++ b/src/frontend/efiling-frontend/src/components/page/payment/__snapshots__/Payment.test.js.snap
@@ -422,7 +422,7 @@ registered to my account. Statutory fees will be processed when documents are fi
                     <b />
                      is linked to your Basic BCeID account 
                     <b>
-                      blah2
+                      username
                     </b>
                      and will be used to file documents. 
                     <a
@@ -909,7 +909,7 @@ exports[`Payment Component On back click, it redirects back to the package confi
                     <b />
                      is linked to your Basic BCeID account 
                     <b>
-                      blah2
+                      username
                     </b>
                      and will be used to file documents. 
                     <a

--- a/src/frontend/efiling-frontend/src/components/page/upload/Upload.test.js
+++ b/src/frontend/efiling-frontend/src/components/page/upload/Upload.test.js
@@ -5,6 +5,7 @@ import { render, fireEvent, getByText, waitFor } from "@testing-library/react";
 import { getTestData } from "../../../modules/confirmationPopupTestData";
 import { getDocumentsData } from "../../../modules/documentTestData";
 import { getCourtData } from "../../../modules/courtTestData";
+import { generateJWTToken } from "../../../modules/authenticationHelper";
 
 import Upload from "./Upload";
 
@@ -48,6 +49,9 @@ describe("Upload Component", () => {
     confirmationPopup,
     submissionId,
   };
+
+  const token = generateJWTToken({ preferred_username: "username@bceid" });
+  localStorage.setItem("jwt", token);
 
   const apiRequest = `/submission/${submissionId}/filing-package`;
   let mock;

--- a/src/frontend/efiling-frontend/src/components/page/upload/__snapshots__/Upload.test.js.snap
+++ b/src/frontend/efiling-frontend/src/components/page/upload/__snapshots__/Upload.test.js.snap
@@ -607,7 +607,7 @@ exports[`Upload Component On cancel upload button click, it redirects to the pac
                     <b />
                      is linked to your Basic BCeID account 
                     <b>
-                      blah2
+                      username
                     </b>
                      and will be used to file documents. 
                     <a

--- a/src/frontend/efiling-frontend/src/modules/authenticationHelper.js
+++ b/src/frontend/efiling-frontend/src/modules/authenticationHelper.js
@@ -2,18 +2,13 @@ const jwt = require("jsonwebtoken");
 
 export function getJWTData() {
   const token = localStorage.getItem("jwt");
-
-  console.log("token is ", token);
-
   if (!token) return false;
 
   // get the decoded payload and header
   const decoded = jwt.decode(token, { complete: true });
-
   return decoded.payload;
 }
 
 export function generateJWTToken(payload) {
-  console.log("inside generate jwt", payload);
   return jwt.sign(payload, "something");
 }

--- a/src/frontend/efiling-frontend/src/modules/authenticationHelper.js
+++ b/src/frontend/efiling-frontend/src/modules/authenticationHelper.js
@@ -1,0 +1,19 @@
+const jwt = require("jsonwebtoken");
+
+export function getJWTData() {
+  const token = localStorage.getItem("jwt");
+
+  console.log("token is ", token);
+
+  if (!token) return false;
+
+  // get the decoded payload and header
+  const decoded = jwt.decode(token, { complete: true });
+
+  return decoded.payload;
+}
+
+export function generateJWTToken(payload) {
+  console.log("inside generate jwt", payload);
+  return jwt.sign(payload, "something");
+}

--- a/src/frontend/efiling-frontend/src/modules/authenticationHelper.js
+++ b/src/frontend/efiling-frontend/src/modules/authenticationHelper.js
@@ -10,5 +10,5 @@ export function getJWTData() {
 }
 
 export function generateJWTToken(payload) {
-  return jwt.sign(payload, "something");
+  return jwt.sign(payload, "secret");
 }

--- a/src/frontend/efiling-frontend/src/modules/sidecardData.js
+++ b/src/frontend/efiling-frontend/src/modules/sidecardData.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-one-expression-per-line */
 import React from "react";
 import { MdInfoOutline, MdPerson, MdTimer } from "react-icons/md";
+import { getJWTData } from "./authenticationHelper";
 
 const aboutCso = () => {
   return {
@@ -27,13 +28,16 @@ const aboutCso = () => {
 };
 
 const csoAccountDetails = () => {
+  let username = getJWTData().preferred_username;
+  username = username.substring(0, username.indexOf("@"));
+
   return {
     heading: "Your CSO Account",
     content: [
       <p key="csoAccountDetails">
         CSO account <b>{sessionStorage.getItem("csoAccountId")}</b> is linked to
         your Basic BCeID account&nbsp;
-        <b>blah2</b>
+        <b>{username}</b>
         &nbsp;and will be used to file documents.&nbsp;
         {/* TODO: fix url and blahs */}
         <a

--- a/src/frontend/efiling-frontend/src/modules/translateApplicantInfo.js
+++ b/src/frontend/efiling-frontend/src/modules/translateApplicantInfo.js
@@ -5,7 +5,7 @@ export function translateApplicantInfo({
   lastName,
   email,
 }) {
-  let fullName = middleName
+  const fullName = middleName
     ? [firstName, middleName, lastName]
     : [firstName, lastName];
   return [

--- a/src/frontend/efiling-frontend/src/modules/translateApplicantInfo.js
+++ b/src/frontend/efiling-frontend/src/modules/translateApplicantInfo.js
@@ -5,7 +5,9 @@ export function translateApplicantInfo({
   lastName,
   email,
 }) {
-  const fullName = [firstName, middleName, lastName];
+  let fullName = middleName
+    ? [firstName, middleName, lastName]
+    : [firstName, lastName];
   return [
     {
       name: "BCeID:",

--- a/src/frontend/efiling-frontend/src/modules/userDetails.js
+++ b/src/frontend/efiling-frontend/src/modules/userDetails.js
@@ -1,9 +1,5 @@
 const userDetails = {
   universalId: "123",
-  firstName: "Bob",
-  middleName: "Norman",
-  lastName: "Ross",
-  email: "bob.ross@example.com",
   accounts: [
     {
       type: "CSO",

--- a/src/frontend/efiling-frontend/src/modules/userDetails.js
+++ b/src/frontend/efiling-frontend/src/modules/userDetails.js
@@ -1,6 +1,5 @@
 const userDetails = {
   universalId: "123",
-  bceid: "bobross42",
   firstName: "Bob",
   middleName: "Norman",
   lastName: "Ross",

--- a/src/frontend/efiling-frontend/yarn.lock
+++ b/src/frontend/efiling-frontend/yarn.lock
@@ -3942,6 +3942,11 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
+
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
@@ -5482,6 +5487,13 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -8774,6 +8786,22 @@ jsonify@~0.0.0:
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
+jsonwebtoken@^8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^5.6.0"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -8791,6 +8819,23 @@ jsx-ast-utils@^2.2.1, jsx-ast-utils@^2.2.3, jsx-ast-utils@^2.4.1:
   dependencies:
     array-includes "^3.1.1"
     object.assign "^4.1.0"
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
 
 keycloak-js@^7.0.1:
   version "7.0.1"
@@ -9034,15 +9079,50 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
+
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
 
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- populate BCeID username in sidecard
- populate also on CSO Account creation page table

![Screen Shot 2020-07-29 at 3 35 38 PM](https://user-images.githubusercontent.com/55710226/88860725-3a8da780-d1b1-11ea-80b4-ae64fb27ef00.png)
![Screen Shot 2020-07-29 at 3 35 47 PM](https://user-images.githubusercontent.com/55710226/88860727-3bbed480-d1b1-11ea-9b0f-59ed4ff7ccd6.png)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- local
- ui/storybook
- jest