### PR TITLE
FLA-331 Remove XAuth-Id from getSubmission and use the bearer token

### DIFF
--- a/src/backend/efiling-api/jag-efiling-api.yaml
+++ b/src/backend/efiling-api/jag-efiling-api.yaml
@@ -44,7 +44,6 @@ paths:
       tags:
         - submission
       parameters:
-        - $ref: "#/components/parameters/xAuthUserId"
         - $ref: "#/components/parameters/submissionId"
       responses:
         "200":

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/Keys.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/Keys.java
@@ -6,4 +6,6 @@ public class Keys {
 
     public static final String EFILING_SUBMISSION_ID = "efiling.submissionId";
 
+    public static final String UNIVERSAL_ID_CLAIM_KEY = "universal-id";
+
 }

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/error/ErrorResponse.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/error/ErrorResponse.java
@@ -1,13 +1,15 @@
 package ca.bc.gov.open.jag.efilingapi.error;
 
 public enum ErrorResponse {
+
     INVALIDROLE("User does not have a valid role for this request."),
     ACCOUNTEXCEPTION("Client has multiple CSO profiles."),
     DOCUMENT_TYPE_ERROR("Error while retrieving documents"),
     DOCUMENT_REQUIRED("At least one document is required."),
     DOCUMENT_STORAGE_FAILURE("An unknown error happened while storing documents."),
     CREATE_ACCOUNT_EXCEPTION("Error Creating CSO account."),
-    CACHE_ERROR("Cache related error.");
+    CACHE_ERROR("Cache related error."),
+    MISSING_UNIVERSAL_ID("universal-id claim missing in jwt token.");
 
     private final String errorMessage;
 

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImpl.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImpl.java
@@ -269,7 +269,7 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
         try {
             return Optional.of(UUID.fromString(
                     ((KeycloakPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal())
-                            .getKeycloakSecurityContext().getToken().getOtherClaims().get(Keys.EFILING_SUBMISSION_ID).toString()));
+                            .getKeycloakSecurityContext().getToken().getOtherClaims().get(Keys.UNIVERSAL_ID_CLAIM_KEY).toString()));
         } catch (Exception e) {
             logger.error("Unable to extract universal Id from token", e);
             return Optional.empty();

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImpl.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImpl.java
@@ -14,6 +14,7 @@ import ca.bc.gov.open.jag.efilingapi.submission.service.SubmissionService;
 import ca.bc.gov.open.jag.efilingapi.submission.service.SubmissionStore;
 import ca.bc.gov.open.jag.efilingcommons.exceptions.*;
 
+import org.keycloak.KeycloakPrincipal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -23,12 +24,15 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.annotation.security.RolesAllowed;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.security.Principal;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -164,11 +168,17 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
     }
 
     @Override
-    public ResponseEntity<GetSubmissionResponse> getSubmission(UUID xAuthUserId, UUID id) {
+    @RolesAllowed("efiling-user")
+    public ResponseEntity<GetSubmissionResponse> getSubmission(UUID id) {
+
+        Optional<UUID> universalId = getUniversalIdFromContext();
+
+        if(!universalId.isPresent()) return new ResponseEntity(
+                EfilingErrorBuilder.builder().errorResponse(ErrorResponse.MISSING_UNIVERSAL_ID).create(), HttpStatus.FORBIDDEN);
 
         MDC.put(Keys.EFILING_SUBMISSION_ID, id.toString());
 
-        Optional<Submission> fromCacheSubmission = this.submissionStore.get(id, xAuthUserId);
+        Optional<Submission> fromCacheSubmission = this.submissionStore.get(id, universalId.get());
 
         if(!fromCacheSubmission.isPresent())
             return ResponseEntity.notFound().build();
@@ -252,6 +262,18 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
         response.setMessage(errorResponse.getErrorMessage());
         return response;
 
+    }
+
+    private Optional<UUID> getUniversalIdFromContext() {
+
+        try {
+            return Optional.of(UUID.fromString(
+                    ((KeycloakPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal())
+                            .getKeycloakSecurityContext().getToken().getOtherClaims().get(Keys.EFILING_SUBMISSION_ID).toString()));
+        } catch (Exception e) {
+            logger.error("Unable to extract universal Id from token", e);
+            return Optional.empty();
+        }
     }
 
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- FLA-331 Remove XAuth-Id from getSubmission and use the bearer token

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Running the app locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
