### PR TITLE
FLA-362 Implement isAmendment and isSupremeCourtScheduling on document model

### DIFF
--- a/src/backend/efiling-api/jag-efiling-api.yaml
+++ b/src/backend/efiling-api/jag-efiling-api.yaml
@@ -306,6 +306,12 @@ components:
         type:
           type: string
           description: the submission type
+        isAmendment:
+          type: boolean
+          description: is the document an amendment to another
+        isSupremeCourtScheduling:
+          type: boolean
+          description: supreme court scheduling required
     Document:
       required:
         - description

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/cache/CacheConfiguration.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/cache/CacheConfiguration.java
@@ -157,7 +157,7 @@ public class CacheConfiguration {
         return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(jedisConnectionFactory)
                 .cacheDefaults(redisCacheConfiguration).build();
     }
-    
+
     @Bean(name = "documentDetailsSerializer")
     public Jackson2JsonRedisSerializer documentDetailsSerializer() {
         return new Jackson2JsonRedisSerializer(DocumentDetails.class);

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/lookup/LookupApiDelegateImpl.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/lookup/LookupApiDelegateImpl.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import javax.annotation.security.RolesAllowed;
 import java.util.stream.Collectors;
 @Service
 public class LookupApiDelegateImpl implements LookupApiDelegate {
@@ -26,6 +27,7 @@ public class LookupApiDelegateImpl implements LookupApiDelegate {
 
 
     @Override
+    @RolesAllowed("efiling-user")
     public ResponseEntity<DocumentTypes> getDocumentTypes(String courtLevel, String courtClass) {
 
         try {

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/service/SubmissionServiceImpl.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/service/SubmissionServiceImpl.java
@@ -155,6 +155,8 @@ public class SubmissionServiceImpl implements SubmissionService {
         document.setType(documentProperties.getType());
         document.setName(documentProperties.getName());
         document.setMimeType(FileUtils.guessContentTypeFromName(documentProperties.getName()));
+        document.setIsAmendment(documentProperties.getIsAmendment());
+        document.setIsSupremeCourtScheduling(documentProperties.getIsSupremeCourtScheduling());
 
         return document;
 

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/TestHelpers.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/TestHelpers.java
@@ -98,6 +98,8 @@ public class TestHelpers {
         documentProperties.setName("random.txt");
         documentProperties.setType(TYPE);
         documentProperties.setMimeType("application/txt");
+        documentProperties.setIsSupremeCourtScheduling(true);
+        documentProperties.setIsAmendment(true);
 
         return Arrays.asList(documentProperties);
     }

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/models/SubmissionTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/models/SubmissionTest.java
@@ -57,6 +57,8 @@ public class SubmissionTest {
         Assertions.assertEquals(TestHelpers.LEVEL_DESCRIPTION, actual.getFilingPackage().getCourt().getLevelDescription());
         Assertions.assertEquals(TestHelpers.TYPE, actual.getFilingPackage().getDocuments().get(0).getType());
         Assertions.assertEquals(TestHelpers.DESCRIPTION, actual.getFilingPackage().getDocuments().get(0).getDescription());
+        Assertions.assertEquals(true, actual.getFilingPackage().getDocuments().get(0).getIsAmendment());
+        Assertions.assertEquals(true, actual.getFilingPackage().getDocuments().get(0).getIsSupremeCourtScheduling());
     }
 
 }

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/submissionApiDelegateImpl/GetPackageInformationTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/submissionApiDelegateImpl/GetPackageInformationTest.java
@@ -2,6 +2,8 @@ package ca.bc.gov.open.jag.efilingapi.submission.submissionApiDelegateImpl;
 
 import ca.bc.gov.open.jag.efilingapi.TestHelpers;
 import ca.bc.gov.open.jag.efilingapi.account.service.AccountService;
+import ca.bc.gov.open.jag.efilingapi.api.model.Document;
+import ca.bc.gov.open.jag.efilingapi.api.model.DocumentProperties;
 import ca.bc.gov.open.jag.efilingapi.api.model.FilingPackage;
 import ca.bc.gov.open.jag.efilingapi.config.NavigationProperties;
 import ca.bc.gov.open.jag.efilingapi.document.DocumentStore;
@@ -17,6 +19,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -52,7 +55,7 @@ public class GetPackageInformationTest {
 
         Submission submissionWithParentApplication = Submission
                 .builder()
-                .filingPackage(TestHelpers.createPackage(TestHelpers.createCourt(), TestHelpers.createDocumentList()))
+                .filingPackage(TestHelpers.createPackage(TestHelpers.createCourt(), createDocumentListWithNulls()))
                 .create();
 
         Mockito.when(submissionStoreMock.get(Mockito.eq(TestHelpers.CASE_1), Mockito.any())).thenReturn(Optional.of(submissionWithParentApplication));
@@ -73,6 +76,8 @@ public class GetPackageInformationTest {
         Assertions.assertEquals(TestHelpers.PROPERTYCLASS, actual.getBody().getCourt().getCourtClass());
         Assertions.assertEquals(TestHelpers.TYPE, actual.getBody().getDocuments().get(0).getType());
         Assertions.assertEquals(TestHelpers.DESCRIPTION, actual.getBody().getDocuments().get(0).getDescription());
+        Assertions.assertNull(actual.getBody().getDocuments().get(0).getIsAmendment());
+        Assertions.assertNull(actual.getBody().getDocuments().get(0).getIsSupremeCourtScheduling());
 
     }
     @Test
@@ -80,5 +85,11 @@ public class GetPackageInformationTest {
     public void withInCorrectIDReturnNotFound() {
         ResponseEntity<FilingPackage> actual = sut.getSubmissionFilingPackage(UUID.randomUUID(), TestHelpers.CASE_2);
         assertEquals(HttpStatus.NOT_FOUND, actual.getStatusCode());
+    }
+    private List<Document> createDocumentListWithNulls() {
+        List<Document> documents =  TestHelpers.createDocumentList();
+        documents.get(0).setIsAmendment(null);
+        documents.get(0).setIsSupremeCourtScheduling(null);
+        return documents;
     }
 }

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/submissionApiDelegateImpl/UpdateDocumentPropertiesTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/submissionApiDelegateImpl/UpdateDocumentPropertiesTest.java
@@ -79,6 +79,8 @@ public class UpdateDocumentPropertiesTest {
         DocumentProperties documentProperties = new DocumentProperties();
         documentProperties.setType(TestHelpers.TYPE);
         documentProperties.setName("test.txt");
+        documentProperties.setIsAmendment(true);
+        documentProperties.setIsSupremeCourtScheduling(true);
         updateDocumentRequest.addDocumentsItem(documentProperties);
 
         Mockito.when(submissionServiceMock.updateDocuments(any(), Mockito.refEq(updateDocumentRequest))).thenReturn(Submission
@@ -93,6 +95,8 @@ public class UpdateDocumentPropertiesTest {
         Assertions.assertEquals(1, actual.getBody().getDocuments().size());
         Assertions.assertEquals(TestHelpers.DESCRIPTION, actual.getBody().getDocuments().get(0).getDescription());
         Assertions.assertEquals(BigDecimal.TEN, actual.getBody().getDocuments().get(0).getStatutoryFeeAmount());
+        Assertions.assertEquals(true, actual.getBody().getDocuments().get(0).getIsSupremeCourtScheduling());
+        Assertions.assertEquals(true, actual.getBody().getDocuments().get(0).getIsAmendment());
     }
 
     @Test


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

FLA-326
Also apply security to getDocuments endpoint

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Unit tests

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
