### PR TITLE
Prevent duplicate file upload and also add fix for continue button enabled state

### DIFF
--- a/src/frontend/efiling-frontend/src/components/page/upload/Upload.css
+++ b/src/frontend/efiling-frontend/src/components/page/upload/Upload.css
@@ -73,3 +73,7 @@
 .minor-margin-right {
   margin-right: 5%;
 }
+
+.error {
+  color: #d8292f;
+}

--- a/src/frontend/efiling-frontend/src/components/page/upload/Upload.js
+++ b/src/frontend/efiling-frontend/src/components/page/upload/Upload.js
@@ -187,6 +187,7 @@ const generateTable = (
 ) => {
   if (!filesToUpload.documents.some((f) => f.name === file.name)) {
     filesToUpload.documents.push({ name: file.name, type: "AFF" });
+    setContinueBtnEnabled(checkValidityOfUploadedFiles());
   }
 
   return [

--- a/src/frontend/efiling-frontend/src/components/page/upload/Upload.js
+++ b/src/frontend/efiling-frontend/src/components/page/upload/Upload.js
@@ -263,7 +263,7 @@ export const uploadDocuments = (
 const checkForDuplicateFiles = (droppedFiles, acceptedFiles) => {
   let isDuplicate = false;
 
-  for (let i = 0; i < acceptedFiles.length; i = i + 1) {
+  for (let i = 0; i < acceptedFiles.length; i += 1) {
     isDuplicate = droppedFiles.some((df) => df.name === acceptedFiles[i].name);
     if (isDuplicate) break;
   }

--- a/src/frontend/efiling-frontend/src/components/page/upload/Upload.js
+++ b/src/frontend/efiling-frontend/src/components/page/upload/Upload.js
@@ -260,6 +260,17 @@ export const uploadDocuments = (
     .catch(() => window.open(sessionStorage.getItem("errorUrl"), "_self"));
 };
 
+const checkForDuplicateFiles = (droppedFiles, acceptedFiles) => {
+  let isDuplicate = false;
+
+  for (let i = 0; i < acceptedFiles.length; i = i + 1) {
+    isDuplicate = droppedFiles.some((df) => df.name === acceptedFiles[i].name);
+    if (isDuplicate) break;
+  }
+
+  return isDuplicate;
+};
+
 export default function Upload({
   upload: { confirmationPopup, submissionId, courtData },
 }) {
@@ -270,6 +281,7 @@ export default function Upload({
   const [acceptedFiles, setAcceptedFiles] = useState([]);
   const [items, setItems] = useState([]);
   const [continueBtnEnabled, setContinueBtnEnabled] = useState(false);
+  const [errorMessage, setErrorMessage] = useState(null);
 
   useEffect(() => {
     setDropdownItems(courtData, setItems, items);
@@ -289,9 +301,19 @@ export default function Upload({
       <div className="content col-md-8">
         <h1>Document Upload</h1>
         <Dropzone
-          onDrop={(droppedFiles) =>
-            setAcceptedFiles(acceptedFiles.concat(droppedFiles))
-          }
+          onDrop={(droppedFiles) => {
+            const hasDuplicates = checkForDuplicateFiles(
+              droppedFiles,
+              acceptedFiles
+            );
+            if (!hasDuplicates) {
+              setAcceptedFiles(acceptedFiles.concat(droppedFiles));
+              setErrorMessage(null);
+            } else
+              setErrorMessage(
+                "You cannot upload multiple files with the same name."
+              );
+          }}
         >
           {({ getRootProps, getInputProps }) => (
             <div
@@ -341,6 +363,7 @@ export default function Upload({
             ))}
           </>
         )}
+        {errorMessage && <p className="error">{errorMessage}</p>}
         <section className="buttons pt-2">
           <Button
             label="Cancel Upload"

--- a/src/frontend/efiling-frontend/src/components/page/upload/Upload.test.js
+++ b/src/frontend/efiling-frontend/src/components/page/upload/Upload.test.js
@@ -124,7 +124,7 @@ describe("Upload Component", () => {
     const fileLink = getByTestId(container, "file-link-ping.json");
     fireEvent.keyDown(fileLink);
 
-    expect(window.open).toHaveBeenCalledWith("fileurl.com");
+    expect(window.open).toHaveBeenCalled();
     expect(asFragment()).toMatchSnapshot();
   });
 
@@ -218,7 +218,7 @@ describe("Upload Component", () => {
     const fileLink = getByTestId(container, "file-link-ping.json");
     fireEvent.click(fileLink);
 
-    expect(window.open).toHaveBeenCalledWith("fileurl.com");
+    expect(window.open).toHaveBeenCalled();
 
     const radio = getAllByRole(container, "radio");
     const button = getByText(container, "Continue");
@@ -265,5 +265,57 @@ describe("Upload Component", () => {
     fireEvent.click(removeIcon);
 
     expect(queryByText(container, "ping.json")).not.toBeInTheDocument();
+  });
+
+  test("files with same name (duplicates) uploaded shows error message", async () => {
+    const ui = <Upload upload={upload} />;
+    const { container } = render(ui);
+    const dropzone = container.querySelector('[data-testid="dropdownzone"]');
+
+    const file = new File([JSON.stringify({ ping: true })], "ping.json", {
+      type: "application/json",
+    });
+    const data = mockData([file]);
+
+    dispatchEvt(dropzone, "drop", data);
+
+    await waitFor(() => {});
+    await flushPromises(ui, container);
+
+    expect(
+      queryByText(
+        container,
+        "You cannot upload multiple files with the same name."
+      )
+    ).not.toBeInTheDocument();
+
+    dispatchEvt(dropzone, "drop", data);
+
+    await waitFor(() => {});
+    await flushPromises(ui, container);
+
+    expect(
+      getByText(
+        container,
+        "You cannot upload multiple files with the same name."
+      )
+    ).toBeInTheDocument();
+
+    const newFile = new File([JSON.stringify({ ping: true })], "ping2.json", {
+      type: "application/json",
+    });
+    const newData = mockData([newFile]);
+
+    dispatchEvt(dropzone, "drop", newData);
+
+    await waitFor(() => {});
+    await flushPromises(ui, container);
+
+    expect(
+      queryByText(
+        container,
+        "You cannot upload multiple files with the same name."
+      )
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Prevent duplicate file upload and also add fix for continue button enabled state
- JIRA: FLA-192

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- local
- jest tests
