### PR TITLE
Fix valid exit cases when using beforeunload listener

### DIFF
--- a/src/frontend/efiling-frontend/src/App.js
+++ b/src/frontend/efiling-frontend/src/App.js
@@ -41,6 +41,7 @@ export default function App() {
   );
 
   const handleConfirm = () => {
+    sessionStorage.setItem("validExit", true);
     const cancelUrl = sessionStorage.getItem("cancelUrl");
 
     if (cancelUrl) {

--- a/src/frontend/efiling-frontend/src/components/page/payment/Payment.js
+++ b/src/frontend/efiling-frontend/src/components/page/payment/Payment.js
@@ -50,7 +50,10 @@ const generateCourtDataTable = ({
 const submitPackage = (submissionId) => {
   axios
     .post(`/submission/${submissionId}/submit`, {})
-    .then(() => window.open(sessionStorage.getItem("successUrl"), "_self"))
+    .then(() => {
+      sessionStorage.setItem("validExit", true);
+      window.open(sessionStorage.getItem("successUrl"), "_self");
+    })
     .catch((err) => errorRedirect(sessionStorage.getItem("errorUrl"), err));
 };
 

--- a/src/frontend/efiling-frontend/src/components/page/upload/Upload.js
+++ b/src/frontend/efiling-frontend/src/components/page/upload/Upload.js
@@ -13,6 +13,7 @@ import {
   Radio,
 } from "shared-components";
 import { getSidecardData } from "../../../modules/sidecardData";
+import { errorRedirect } from "../../../modules/errorRedirect";
 import { propTypes } from "../../../types/propTypes";
 
 import "./Upload.css";
@@ -41,7 +42,7 @@ const setDropdownItems = ({ level, courtClass }, setItems, items) => {
   axios
     .get(`/lookup/documentTypes/${level}/${courtClass}`)
     .then(({ data: { documentTypes } }) => setItems(documentTypes))
-    .catch(() => window.open(sessionStorage.getItem("errorUrl"), "_self"));
+    .catch((error) => errorRedirect(sessionStorage.getItem("errorUrl"), error));
 };
 
 const translateItems = (items) => {
@@ -255,9 +256,11 @@ export const uploadDocuments = (
       axios
         .post(`/submission/${submissionId}/update-documents`, filesToUpload)
         .then(() => setShowPackageConfirmation(true))
-        .catch(() => window.open(sessionStorage.getItem("errorUrl"), "_self"));
+        .catch((error) =>
+          errorRedirect(sessionStorage.getItem("errorUrl"), error)
+        );
     })
-    .catch(() => window.open(sessionStorage.getItem("errorUrl"), "_self"));
+    .catch((err) => errorRedirect(sessionStorage.getItem("errorUrl"), err));
 };
 
 const checkForDuplicateFiles = (droppedFiles, acceptedFiles) => {

--- a/src/frontend/efiling-frontend/src/components/page/upload/Upload.test.js
+++ b/src/frontend/efiling-frontend/src/components/page/upload/Upload.test.js
@@ -131,35 +131,48 @@ describe("Upload Component", () => {
   test("redirects to error page if fail to generate dropdown elements", async () => {
     mock
       .onGet(`/lookup/documentTypes/${court.level}/${court.courtClass}`)
-      .reply(400);
+      .reply(400, { message: "There was an error." });
 
     render(<Upload upload={upload} />);
 
     await waitFor(() => {});
 
-    expect(window.open).toHaveBeenCalledWith("errorexample.com", "_self");
+    expect(window.open).toHaveBeenCalledWith(
+      "errorexample.com?status=400&message=There was an error.",
+      "_self"
+    );
   });
 
   test("failed uploadDocuments call to /submission/submissionId/documents opens error page", async () => {
-    mock.onPost(`/submission/${submissionId}/documents`).reply(400);
+    mock
+      .onPost(`/submission/${submissionId}/documents`)
+      .reply(400, { message: "There was an error." });
 
     uploadDocuments(submissionId, [], jest.fn());
 
     await waitFor(() => {});
 
-    expect(window.open).toHaveBeenCalledWith("errorexample.com", "_self");
+    expect(window.open).toHaveBeenCalledWith(
+      "errorexample.com?status=400&message=There was an error.",
+      "_self"
+    );
   });
 
   test("failed uploadDocuments call to /submission/submissionId/update-documents opens error page", async () => {
     mock.onPost(`/submission/${submissionId}/documents`).reply(200);
 
-    mock.onPost(`/submission/${submissionId}/update-documents`).reply(400);
+    mock
+      .onPost(`/submission/${submissionId}/update-documents`)
+      .reply(400, { message: "There was an error." });
 
     uploadDocuments(submissionId, [], jest.fn());
 
     await waitFor(() => {});
 
-    expect(window.open).toHaveBeenCalledWith("errorexample.com", "_self");
+    expect(window.open).toHaveBeenCalledWith(
+      "errorexample.com?status=400&message=There was an error.",
+      "_self"
+    );
   });
 
   test("successful document upload works as expected", async () => {

--- a/src/frontend/efiling-frontend/src/index.js
+++ b/src/frontend/efiling-frontend/src/index.js
@@ -15,6 +15,8 @@ axios.defaults.baseURL = window.REACT_APP_API_BASE_URL
 
 // prevent user from leaving site and losing saved data
 window.addEventListener("beforeunload", (e) => {
+  if (sessionStorage.getItem("validExit")) return false;
+
   const confirmationMessage = "";
   (e || window.event).returnValue = confirmationMessage;
   return confirmationMessage;
@@ -22,6 +24,7 @@ window.addEventListener("beforeunload", (e) => {
 
 window.addEventListener("unload", () => {
   sessionStorage.removeItem("listenerExists");
+  sessionStorage.removeItem("validExit");
 });
 
 ReactDOM.render(

--- a/src/frontend/efiling-frontend/src/modules/errorRedirect.js
+++ b/src/frontend/efiling-frontend/src/modules/errorRedirect.js
@@ -6,6 +6,7 @@ export function errorRedirect(errorUrl, error) {
     error.response.data &&
     error.response.data.message
   ) {
+    sessionStorage.setItem("validExit", true);
     return window.open(
       `${errorUrl}?status=${error.response.status}&message=${error.response.data.message}`,
       "_self"


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Fix valid exit cases when using beforeunload listener, this is so we dont get additional popups for cancel popup or dont get popups where we dont need them (valid exits)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- locally
