### PR TITLE
Styling change for credit card alert

### DIFF
--- a/src/frontend/efiling-frontend/src/components/page/payment/__snapshots__/Payment.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/components/page/payment/__snapshots__/Payment.stories.storyshot
@@ -12,13 +12,13 @@ exports[`Storyshots Payment Default 1`] = `
         Payment
       </h1>
       <div
-        class="display-box warning-background no-padding-bottom"
+        class="display-box success-background no-padding-bottom"
       >
         <div
           class="display-icon"
         >
           <div
-            style="color: rgb(252, 186, 25);"
+            style="color: rgb(46, 133, 64);"
           >
             <svg
               fill="currentColor"
@@ -509,13 +509,13 @@ exports[`Storyshots Payment Mobile 1`] = `
         Payment
       </h1>
       <div
-        class="display-box warning-background no-padding-bottom"
+        class="display-box success-background no-padding-bottom"
       >
         <div
           class="display-icon"
         >
           <div
-            style="color: rgb(252, 186, 25);"
+            style="color: rgb(46, 133, 64);"
           >
             <svg
               fill="currentColor"

--- a/src/frontend/efiling-frontend/src/modules/creditCardAlerts.js
+++ b/src/frontend/efiling-frontend/src/modules/creditCardAlerts.js
@@ -6,8 +6,8 @@ const existingCreditCard = () => {
   return (
     <Alert
       icon={<MdCreditCard size={32} />}
-      type="warning"
-      styling="warning-background no-padding-bottom"
+      type="success"
+      styling="success-background no-padding-bottom"
       element={
         <p>
           <span>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- use success green instead of warning yellow when user has card already registered!

![Screen Shot 2020-08-12 at 10 14 30 AM](https://user-images.githubusercontent.com/55710226/90045967-a2012800-dc84-11ea-92ce-3b5963175932.png)

## Type of change

- [x] Refactoring / Documentation

## How Has This Been Tested?

- local
- jest