### PR TITLE
Add temp sidecards to rush submission page

### DIFF
--- a/src/frontend/efiling-frontend/src/components/page/home/__snapshots__/Home.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/components/page/home/__snapshots__/Home.stories.storyshot
@@ -424,13 +424,13 @@ exports[`Storyshots Home Account Exists 1`] = `
                 >
                   <p>
                     CSO account 
-                    <b>
+                    <strong>
                       123
-                    </b>
+                    </strong>
                      is linked to your Basic BCeID account 
-                    <b>
+                    <strong>
                       username
-                    </b>
+                    </strong>
                      and will be used to file documents. 
                     <a
                       href="https://justice.gov.bc.ca/cso/about/index.do"
@@ -1033,13 +1033,13 @@ exports[`Storyshots Home Account Exists Mobile 1`] = `
                 >
                   <p>
                     CSO account 
-                    <b>
+                    <strong>
                       123
-                    </b>
+                    </strong>
                      is linked to your Basic BCeID account 
-                    <b>
+                    <strong>
                       username
-                    </b>
+                    </strong>
                      and will be used to file documents. 
                     <a
                       href="https://justice.gov.bc.ca/cso/about/index.do"

--- a/src/frontend/efiling-frontend/src/components/page/home/__snapshots__/Home.test.js.snap
+++ b/src/frontend/efiling-frontend/src/components/page/home/__snapshots__/Home.test.js.snap
@@ -1816,13 +1816,13 @@ exports[`Home Component matches the snapshot when user cso account exists 1`] = 
                 >
                   <p>
                     CSO account 
-                    <b>
+                    <strong>
                       123
-                    </b>
+                    </strong>
                      is linked to your Basic BCeID account 
-                    <b>
+                    <strong>
                       username
-                    </b>
+                    </strong>
                      and will be used to file documents. 
                     <a
                       href="https://justice.gov.bc.ca/cso/about/index.do"

--- a/src/frontend/efiling-frontend/src/components/page/package-confirmation/__snapshots__/PackageConfirmation.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/components/page/package-confirmation/__snapshots__/PackageConfirmation.stories.storyshot
@@ -387,13 +387,13 @@ exports[`Storyshots PackageConfirmation Existing Account 1`] = `
               >
                 <p>
                   CSO account 
-                  <b>
+                  <strong>
                     123
-                  </b>
+                  </strong>
                    is linked to your Basic BCeID account 
-                  <b>
+                  <strong>
                     username
-                  </b>
+                  </strong>
                    and will be used to file documents. 
                   <a
                     href="https://justice.gov.bc.ca/cso/about/index.do"
@@ -871,13 +871,13 @@ exports[`Storyshots PackageConfirmation Mobile 1`] = `
               >
                 <p>
                   CSO account 
-                  <b>
+                  <strong>
                     123
-                  </b>
+                  </strong>
                    is linked to your Basic BCeID account 
-                  <b>
+                  <strong>
                     username
-                  </b>
+                  </strong>
                    and will be used to file documents. 
                   <a
                     href="https://justice.gov.bc.ca/cso/about/index.do"
@@ -1387,13 +1387,13 @@ exports[`Storyshots PackageConfirmation New Account 1`] = `
               >
                 <p>
                   CSO account 
-                  <b>
+                  <strong>
                     123
-                  </b>
+                  </strong>
                    is linked to your Basic BCeID account 
-                  <b>
+                  <strong>
                     username
-                  </b>
+                  </strong>
                    and will be used to file documents. 
                   <a
                     href="https://justice.gov.bc.ca/cso/about/index.do"

--- a/src/frontend/efiling-frontend/src/components/page/package-confirmation/__snapshots__/PackageConfirmation.test.js.snap
+++ b/src/frontend/efiling-frontend/src/components/page/package-confirmation/__snapshots__/PackageConfirmation.test.js.snap
@@ -387,13 +387,13 @@ exports[`PackageConfirmation Component Matches the existing account snapshot 1`]
               >
                 <p>
                   CSO account 
-                  <b>
+                  <strong>
                     123
-                  </b>
+                  </strong>
                    is linked to your Basic BCeID account 
-                  <b>
+                  <strong>
                     username
-                  </b>
+                  </strong>
                    and will be used to file documents. 
                   <a
                     href="https://justice.gov.bc.ca/cso/about/index.do"
@@ -903,13 +903,13 @@ exports[`PackageConfirmation Component Matches the new account snapshot 1`] = `
               >
                 <p>
                   CSO account 
-                  <b>
+                  <strong>
                     123
-                  </b>
+                  </strong>
                    is linked to your Basic BCeID account 
-                  <b>
+                  <strong>
                     username
-                  </b>
+                  </strong>
                    and will be used to file documents. 
                   <a
                     href="https://justice.gov.bc.ca/cso/about/index.do"
@@ -1603,13 +1603,13 @@ registered to my account. Statutory fees will be processed when documents are fi
               >
                 <p>
                   CSO account 
-                  <b>
+                  <strong>
                     123
-                  </b>
+                  </strong>
                    is linked to your Basic BCeID account 
-                  <b>
+                  <strong>
                     username
-                  </b>
+                  </strong>
                    and will be used to file documents. 
                   <a
                     href="https://justice.gov.bc.ca/cso/about/index.do"

--- a/src/frontend/efiling-frontend/src/components/page/payment/__snapshots__/Payment.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/components/page/payment/__snapshots__/Payment.stories.storyshot
@@ -400,13 +400,13 @@ registered to my account. Statutory fees will be processed when documents are fi
               >
                 <p>
                   CSO account 
-                  <b>
+                  <strong>
                     123
-                  </b>
+                  </strong>
                    is linked to your Basic BCeID account 
-                  <b>
+                  <strong>
                     username
-                  </b>
+                  </strong>
                    and will be used to file documents. 
                   <a
                     href="https://justice.gov.bc.ca/cso/about/index.do"
@@ -897,13 +897,13 @@ registered to my account. Statutory fees will be processed when documents are fi
               >
                 <p>
                   CSO account 
-                  <b>
+                  <strong>
                     123
-                  </b>
+                  </strong>
                    is linked to your Basic BCeID account 
-                  <b>
+                  <strong>
                     username
-                  </b>
+                  </strong>
                    and will be used to file documents. 
                   <a
                     href="https://justice.gov.bc.ca/cso/about/index.do"

--- a/src/frontend/efiling-frontend/src/components/page/payment/__snapshots__/Payment.test.js.snap
+++ b/src/frontend/efiling-frontend/src/components/page/payment/__snapshots__/Payment.test.js.snap
@@ -378,6 +378,156 @@ you feel are necessary.
         </button>
       </section>
     </div>
+    <div
+      class="sidecard"
+    >
+      <div
+        class="wide-dashboard-spacing"
+        style="position: relative;"
+      >
+        <div
+          class="col-12 pt-2"
+          style="position: relative;"
+        >
+          <p />
+          <section
+            class="bluegrey-container"
+            id="bluegrey-section"
+          >
+            <div
+              class="container-background bluegrey-heading"
+            >
+              <h2
+                class="heading-style"
+              >
+                <div
+                  class="side-card-row"
+                >
+                  <div
+                    class="round-icon-wrapper"
+                  >
+                    <svg
+                      class="side-card-icon"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="side-card-title"
+                  >
+                    Your CSO Account
+                  </div>
+                </div>
+              </h2>
+            </div>
+            <div
+              class="bluegrey-content"
+            >
+              <span
+                class="content-style"
+              >
+                <p>
+                  CSO account 
+                  <b />
+                   is linked to your Basic BCeID account 
+                  <b>
+                    username
+                  </b>
+                   and will be used to file documents. 
+                  <a
+                    href="https://justice.gov.bc.ca/cso/about/index.do"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    View your CSO account details
+                  </a>
+                  .
+                </p>
+              </span>
+            </div>
+          </section>
+        </div>
+      </div>
+      <div
+        class="wide-dashboard-spacing"
+        style="position: relative;"
+      >
+        <div
+          class="col-12 pt-2"
+          style="position: relative;"
+        >
+          <p />
+          <section
+            class="bluegrey-container"
+            id="bluegrey-section"
+          >
+            <div
+              class="container-background bluegrey-heading"
+            >
+              <h2
+                class="heading-style"
+              >
+                <div
+                  class="side-card-row"
+                >
+                  <div
+                    class="round-icon-wrapper"
+                  >
+                    <svg
+                      class="side-card-icon"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="side-card-title"
+                  >
+                    About E-File Submission
+                  </div>
+                </div>
+              </h2>
+            </div>
+            <div
+              class="bluegrey-content"
+            >
+              <span
+                class="content-style"
+              >
+                <p>
+                  E-File submission is a service to help you securely and electronically file documents with the Government of British Columbia Court Services Online (CSO). 
+                  <a
+                    href="https://justice.gov.bc.ca/cso/about/index.do"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    Learn more about CSO
+                  </a>
+                  .
+                </p>
+              </span>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/src/frontend/efiling-frontend/src/components/page/payment/__snapshots__/Payment.test.js.snap
+++ b/src/frontend/efiling-frontend/src/components/page/payment/__snapshots__/Payment.test.js.snap
@@ -108,7 +108,7 @@ you feel are necessary.
             <input
               class=""
               type="text"
-              value="08/13/2020"
+              value="08/14/2020"
             />
           </div>
         </div>
@@ -437,11 +437,11 @@ you feel are necessary.
               >
                 <p>
                   CSO account 
-                  <b />
+                  <strong />
                    is linked to your Basic BCeID account 
-                  <b>
+                  <strong>
                     username
-                  </b>
+                  </strong>
                    and will be used to file documents. 
                   <a
                     href="https://justice.gov.bc.ca/cso/about/index.do"
@@ -932,11 +932,11 @@ registered to my account. Statutory fees will be processed when documents are fi
               >
                 <p>
                   CSO account 
-                  <b />
+                  <strong />
                    is linked to your Basic BCeID account 
-                  <b>
+                  <strong>
                     username
-                  </b>
+                  </strong>
                    and will be used to file documents. 
                   <a
                     href="https://justice.gov.bc.ca/cso/about/index.do"
@@ -1414,11 +1414,11 @@ exports[`Payment Component On back click, it redirects back to the package confi
               >
                 <p>
                   CSO account 
-                  <b />
+                  <strong />
                    is linked to your Basic BCeID account 
-                  <b>
+                  <strong>
                     username
-                  </b>
+                  </strong>
                    and will be used to file documents. 
                   <a
                     href="https://justice.gov.bc.ca/cso/about/index.do"

--- a/src/frontend/efiling-frontend/src/components/page/rush/Rush.js
+++ b/src/frontend/efiling-frontend/src/components/page/rush/Rush.js
@@ -9,7 +9,9 @@ import {
   Input,
   Textarea,
   DatePick,
+  Sidecard,
 } from "shared-components";
+import { getSidecardData } from "../../../modules/helpers/sidecardData";
 import Payment from "../payment/Payment";
 
 import "./Rush.css";
@@ -32,6 +34,8 @@ export default function Rush({ payment }) {
     styling: "editable-white",
     isRequired: true,
   };
+  const aboutCsoSidecard = getSidecardData().aboutCso;
+  const csoAccountDetailsSidecard = getSidecardData().csoAccountDetails;
 
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [showPayment, setShowPayment] = useState(false);
@@ -175,6 +179,10 @@ export default function Rush({ payment }) {
             styling="normal-blue btn"
           />
         </section>
+      </div>
+      <div className="sidecard">
+        <Sidecard sideCard={csoAccountDetailsSidecard} />
+        <Sidecard sideCard={aboutCsoSidecard} />
       </div>
     </div>
   );

--- a/src/frontend/efiling-frontend/src/components/page/rush/__snapshots__/Rush.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/components/page/rush/__snapshots__/Rush.stories.storyshot
@@ -378,6 +378,158 @@ you feel are necessary.
         </button>
       </section>
     </div>
+    <div
+      class="sidecard"
+    >
+      <div
+        class="wide-dashboard-spacing"
+        style="position: relative;"
+      >
+        <div
+          class="col-12 pt-2"
+          style="position: relative;"
+        >
+          <p />
+          <section
+            class="bluegrey-container"
+            id="bluegrey-section"
+          >
+            <div
+              class="container-background bluegrey-heading"
+            >
+              <h2
+                class="heading-style"
+              >
+                <div
+                  class="side-card-row"
+                >
+                  <div
+                    class="round-icon-wrapper"
+                  >
+                    <svg
+                      class="side-card-icon"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="side-card-title"
+                  >
+                    Your CSO Account
+                  </div>
+                </div>
+              </h2>
+            </div>
+            <div
+              class="bluegrey-content"
+            >
+              <span
+                class="content-style"
+              >
+                <p>
+                  CSO account 
+                  <b>
+                    123
+                  </b>
+                   is linked to your Basic BCeID account 
+                  <b>
+                    username
+                  </b>
+                   and will be used to file documents. 
+                  <a
+                    href="https://justice.gov.bc.ca/cso/about/index.do"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    View your CSO account details
+                  </a>
+                  .
+                </p>
+              </span>
+            </div>
+          </section>
+        </div>
+      </div>
+      <div
+        class="wide-dashboard-spacing"
+        style="position: relative;"
+      >
+        <div
+          class="col-12 pt-2"
+          style="position: relative;"
+        >
+          <p />
+          <section
+            class="bluegrey-container"
+            id="bluegrey-section"
+          >
+            <div
+              class="container-background bluegrey-heading"
+            >
+              <h2
+                class="heading-style"
+              >
+                <div
+                  class="side-card-row"
+                >
+                  <div
+                    class="round-icon-wrapper"
+                  >
+                    <svg
+                      class="side-card-icon"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="side-card-title"
+                  >
+                    About E-File Submission
+                  </div>
+                </div>
+              </h2>
+            </div>
+            <div
+              class="bluegrey-content"
+            >
+              <span
+                class="content-style"
+              >
+                <p>
+                  E-File submission is a service to help you securely and electronically file documents with the Government of British Columbia Court Services Online (CSO). 
+                  <a
+                    href="https://justice.gov.bc.ca/cso/about/index.do"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    Learn more about CSO
+                  </a>
+                  .
+                </p>
+              </span>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -759,6 +911,158 @@ you feel are necessary.
           Submit Request
         </button>
       </section>
+    </div>
+    <div
+      class="sidecard"
+    >
+      <div
+        class="wide-dashboard-spacing"
+        style="position: relative;"
+      >
+        <div
+          class="col-12 pt-2"
+          style="position: relative;"
+        >
+          <p />
+          <section
+            class="bluegrey-container"
+            id="bluegrey-section"
+          >
+            <div
+              class="container-background bluegrey-heading"
+            >
+              <h2
+                class="heading-style"
+              >
+                <div
+                  class="side-card-row"
+                >
+                  <div
+                    class="round-icon-wrapper"
+                  >
+                    <svg
+                      class="side-card-icon"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="side-card-title"
+                  >
+                    Your CSO Account
+                  </div>
+                </div>
+              </h2>
+            </div>
+            <div
+              class="bluegrey-content"
+            >
+              <span
+                class="content-style"
+              >
+                <p>
+                  CSO account 
+                  <b>
+                    123
+                  </b>
+                   is linked to your Basic BCeID account 
+                  <b>
+                    username
+                  </b>
+                   and will be used to file documents. 
+                  <a
+                    href="https://justice.gov.bc.ca/cso/about/index.do"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    View your CSO account details
+                  </a>
+                  .
+                </p>
+              </span>
+            </div>
+          </section>
+        </div>
+      </div>
+      <div
+        class="wide-dashboard-spacing"
+        style="position: relative;"
+      >
+        <div
+          class="col-12 pt-2"
+          style="position: relative;"
+        >
+          <p />
+          <section
+            class="bluegrey-container"
+            id="bluegrey-section"
+          >
+            <div
+              class="container-background bluegrey-heading"
+            >
+              <h2
+                class="heading-style"
+              >
+                <div
+                  class="side-card-row"
+                >
+                  <div
+                    class="round-icon-wrapper"
+                  >
+                    <svg
+                      class="side-card-icon"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="side-card-title"
+                  >
+                    About E-File Submission
+                  </div>
+                </div>
+              </h2>
+            </div>
+            <div
+              class="bluegrey-content"
+            >
+              <span
+                class="content-style"
+              >
+                <p>
+                  E-File submission is a service to help you securely and electronically file documents with the Government of British Columbia Court Services Online (CSO). 
+                  <a
+                    href="https://justice.gov.bc.ca/cso/about/index.do"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    Learn more about CSO
+                  </a>
+                  .
+                </p>
+              </span>
+            </div>
+          </section>
+        </div>
+      </div>
     </div>
   </div>
 </DocumentFragment>

--- a/src/frontend/efiling-frontend/src/components/page/rush/__snapshots__/Rush.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/components/page/rush/__snapshots__/Rush.stories.storyshot
@@ -108,7 +108,7 @@ you feel are necessary.
             <input
               class=""
               type="text"
-              value="08/13/2020"
+              value="08/14/2020"
             />
           </div>
         </div>
@@ -437,13 +437,13 @@ you feel are necessary.
               >
                 <p>
                   CSO account 
-                  <b>
+                  <strong>
                     123
-                  </b>
+                  </strong>
                    is linked to your Basic BCeID account 
-                  <b>
+                  <strong>
                     username
-                  </b>
+                  </strong>
                    and will be used to file documents. 
                   <a
                     href="https://justice.gov.bc.ca/cso/about/index.do"
@@ -642,7 +642,7 @@ you feel are necessary.
             <input
               class=""
               type="text"
-              value="08/13/2020"
+              value="08/14/2020"
             />
           </div>
         </div>
@@ -971,13 +971,13 @@ you feel are necessary.
               >
                 <p>
                   CSO account 
-                  <b>
+                  <strong>
                     123
-                  </b>
+                  </strong>
                    is linked to your Basic BCeID account 
-                  <b>
+                  <strong>
                     username
-                  </b>
+                  </strong>
                    and will be used to file documents. 
                   <a
                     href="https://justice.gov.bc.ca/cso/about/index.do"

--- a/src/frontend/efiling-frontend/src/components/page/rush/__snapshots__/Rush.test.js.snap
+++ b/src/frontend/efiling-frontend/src/components/page/rush/__snapshots__/Rush.test.js.snap
@@ -401,11 +401,11 @@ registered to my account. Statutory fees will be processed when documents are fi
               >
                 <p>
                   CSO account 
-                  <b />
+                  <strong />
                    is linked to your Basic BCeID account 
-                  <b>
+                  <strong>
                     username
-                  </b>
+                  </strong>
                    and will be used to file documents. 
                   <a
                     href="https://justice.gov.bc.ca/cso/about/index.do"
@@ -604,7 +604,7 @@ you feel are necessary.
             <input
               class=""
               type="text"
-              value="08/13/2020"
+              value="08/14/2020"
             />
           </div>
         </div>
@@ -933,11 +933,11 @@ you feel are necessary.
               >
                 <p>
                   CSO account 
-                  <b />
+                  <strong />
                    is linked to your Basic BCeID account 
-                  <b>
+                  <strong>
                     username
-                  </b>
+                  </strong>
                    and will be used to file documents. 
                   <a
                     href="https://justice.gov.bc.ca/cso/about/index.do"

--- a/src/frontend/efiling-frontend/src/components/page/rush/__snapshots__/Rush.test.js.snap
+++ b/src/frontend/efiling-frontend/src/components/page/rush/__snapshots__/Rush.test.js.snap
@@ -874,6 +874,156 @@ you feel are necessary.
         </button>
       </section>
     </div>
+    <div
+      class="sidecard"
+    >
+      <div
+        class="wide-dashboard-spacing"
+        style="position: relative;"
+      >
+        <div
+          class="col-12 pt-2"
+          style="position: relative;"
+        >
+          <p />
+          <section
+            class="bluegrey-container"
+            id="bluegrey-section"
+          >
+            <div
+              class="container-background bluegrey-heading"
+            >
+              <h2
+                class="heading-style"
+              >
+                <div
+                  class="side-card-row"
+                >
+                  <div
+                    class="round-icon-wrapper"
+                  >
+                    <svg
+                      class="side-card-icon"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="side-card-title"
+                  >
+                    Your CSO Account
+                  </div>
+                </div>
+              </h2>
+            </div>
+            <div
+              class="bluegrey-content"
+            >
+              <span
+                class="content-style"
+              >
+                <p>
+                  CSO account 
+                  <b />
+                   is linked to your Basic BCeID account 
+                  <b>
+                    username
+                  </b>
+                   and will be used to file documents. 
+                  <a
+                    href="https://justice.gov.bc.ca/cso/about/index.do"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    View your CSO account details
+                  </a>
+                  .
+                </p>
+              </span>
+            </div>
+          </section>
+        </div>
+      </div>
+      <div
+        class="wide-dashboard-spacing"
+        style="position: relative;"
+      >
+        <div
+          class="col-12 pt-2"
+          style="position: relative;"
+        >
+          <p />
+          <section
+            class="bluegrey-container"
+            id="bluegrey-section"
+          >
+            <div
+              class="container-background bluegrey-heading"
+            >
+              <h2
+                class="heading-style"
+              >
+                <div
+                  class="side-card-row"
+                >
+                  <div
+                    class="round-icon-wrapper"
+                  >
+                    <svg
+                      class="side-card-icon"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="side-card-title"
+                  >
+                    About E-File Submission
+                  </div>
+                </div>
+              </h2>
+            </div>
+            <div
+              class="bluegrey-content"
+            >
+              <span
+                class="content-style"
+              >
+                <p>
+                  E-File submission is a service to help you securely and electronically file documents with the Government of British Columbia Court Services Online (CSO). 
+                  <a
+                    href="https://justice.gov.bc.ca/cso/about/index.do"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    Learn more about CSO
+                  </a>
+                  .
+                </p>
+              </span>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/src/frontend/efiling-frontend/src/components/page/upload/__snapshots__/Upload.test.js.snap
+++ b/src/frontend/efiling-frontend/src/components/page/upload/__snapshots__/Upload.test.js.snap
@@ -589,11 +589,11 @@ exports[`Upload Component On cancel upload button click, it redirects to the pac
               >
                 <p>
                   CSO account 
-                  <b />
+                  <strong />
                    is linked to your Basic BCeID account 
-                  <b>
+                  <strong>
                     username
-                  </b>
+                  </strong>
                    and will be used to file documents. 
                   <a
                     href="https://justice.gov.bc.ca/cso/about/index.do"
@@ -1726,11 +1726,11 @@ exports[`Upload Component successful document upload works as expected 1`] = `
               >
                 <p>
                   CSO account 
-                  <b />
+                  <strong />
                    is linked to your Basic BCeID account 
-                  <b>
+                  <strong>
                     username
-                  </b>
+                  </strong>
                    and will be used to file documents. 
                   <a
                     href="https://justice.gov.bc.ca/cso/about/index.do"

--- a/src/frontend/efiling-frontend/src/modules/helpers/sidecardData.js
+++ b/src/frontend/efiling-frontend/src/modules/helpers/sidecardData.js
@@ -39,7 +39,7 @@ const csoAccountDetails = () => {
         your Basic BCeID account&nbsp;
         <b>{username}</b>
         &nbsp;and will be used to file documents.&nbsp;
-        {/* TODO: fix url and blahs */}
+        {/* TODO: fix url */}
         <a
           href="https://justice.gov.bc.ca/cso/about/index.do"
           target="_blank"

--- a/src/frontend/efiling-frontend/src/modules/helpers/sidecardData.js
+++ b/src/frontend/efiling-frontend/src/modules/helpers/sidecardData.js
@@ -35,9 +35,9 @@ const csoAccountDetails = () => {
     heading: "Your CSO Account",
     content: [
       <p key="csoAccountDetails">
-        CSO account <b>{sessionStorage.getItem("csoAccountId")}</b> is linked to
-        your Basic BCeID account&nbsp;
-        <b>{username}</b>
+        CSO account <strong>{sessionStorage.getItem("csoAccountId")}</strong> is
+        linked to your Basic BCeID account&nbsp;
+        <strong>{username}</strong>
         &nbsp;and will be used to file documents.&nbsp;
         {/* TODO: fix url */}
         <a


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Mockups have 2 empty sidecards shown on rush submission page so I added two temporary sidecards, will be changed later when mockups are finalized

![Screen Shot 2020-08-13 at 4 42 42 PM](https://user-images.githubusercontent.com/55710226/90197629-08b93b00-dd84-11ea-8055-1628076b9b3e.png)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- local
- jest
- storybook
