### PR TITLE
📆  Mock date in tests to ensure tests dont keep failing

### DIFF
--- a/src/frontend/efiling-frontend/src/components/page/rush/Rush.stories.js
+++ b/src/frontend/efiling-frontend/src/components/page/rush/Rush.stories.js
@@ -14,6 +14,19 @@ const submissionId = "abc123";
 const courtData = getCourtData();
 const files = getDocumentsData();
 const submissionFee = 25.5;
+let realDate;
+const currentDate = new Date("2019-05-14T11:01:58.135Z");
+
+realDate = Date;
+global.Date = class extends Date {
+  constructor(date) {
+    if (date) {
+      return super(date);
+    }
+
+    return currentDate;
+  }
+};
 
 const payment = {
   confirmationPopup,

--- a/src/frontend/efiling-frontend/src/components/page/rush/Rush.stories.js
+++ b/src/frontend/efiling-frontend/src/components/page/rush/Rush.stories.js
@@ -14,16 +14,10 @@ const submissionId = "abc123";
 const courtData = getCourtData();
 const files = getDocumentsData();
 const submissionFee = 25.5;
-let realDate;
 const currentDate = new Date("2019-05-14T11:01:58.135Z");
 
-realDate = Date;
 global.Date = class extends Date {
-  constructor(date) {
-    if (date) {
-      return super(date);
-    }
-
+  constructor() {
     return currentDate;
   }
 };

--- a/src/frontend/efiling-frontend/src/components/page/rush/Rush.test.js
+++ b/src/frontend/efiling-frontend/src/components/page/rush/Rush.test.js
@@ -9,6 +9,7 @@ import { generateJWTToken } from "../../../modules/helpers/authentication-helper
 import Rush from "./Rush";
 
 describe("Rush Component", () => {
+  let realDate;
   const confirmationPopup = getTestData();
   const submissionId = "abc123";
   const courtData = getCourtData();
@@ -32,9 +33,23 @@ describe("Rush Component", () => {
   localStorage.setItem("jwt", token);
 
   test("Matches the snapshot", () => {
+    const currentDate = new Date("2019-05-14T11:01:58.135Z");
+    realDate = Date;
+    global.Date = class extends Date {
+      constructor(date) {
+        if (date) {
+          return super(date);
+        }
+
+        return currentDate;
+      }
+    };
+
     const { asFragment } = render(<Rush payment={payment} />);
 
     expect(asFragment()).toMatchSnapshot();
+
+    global.Date = realDate;
   });
 
   test("Clicking on cancel request takes user back to payment page", () => {

--- a/src/frontend/efiling-frontend/src/components/page/rush/Rush.test.js
+++ b/src/frontend/efiling-frontend/src/components/page/rush/Rush.test.js
@@ -36,11 +36,7 @@ describe("Rush Component", () => {
     const currentDate = new Date("2019-05-14T11:01:58.135Z");
     realDate = Date;
     global.Date = class extends Date {
-      constructor(date) {
-        if (date) {
-          return super(date);
-        }
-
+      constructor() {
         return currentDate;
       }
     };

--- a/src/frontend/efiling-frontend/src/components/page/rush/__snapshots__/Rush.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/components/page/rush/__snapshots__/Rush.stories.storyshot
@@ -108,7 +108,7 @@ you feel are necessary.
             <input
               class=""
               type="text"
-              value="08/14/2020"
+              value="05/14/2019"
             />
           </div>
         </div>
@@ -642,7 +642,7 @@ you feel are necessary.
             <input
               class=""
               type="text"
-              value="08/14/2020"
+              value="05/14/2019"
             />
           </div>
         </div>

--- a/src/frontend/efiling-frontend/src/components/page/rush/__snapshots__/Rush.test.js.snap
+++ b/src/frontend/efiling-frontend/src/components/page/rush/__snapshots__/Rush.test.js.snap
@@ -604,7 +604,7 @@ you feel are necessary.
             <input
               class=""
               type="text"
-              value="08/14/2020"
+              value="05/14/2019"
             />
           </div>
         </div>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

📆  Mock date in tests to ensure tests dont keep failing
- if you notice, in the last PR that got merged the date in the snapshot was updated cause it uses the current day's date. so that means everyday the snapshots will fail and block PRs... so this fixes that issue :) 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- jest
- storyshots
