### PR TITLE
Adding BCeID lookup endpoint, get name data from BCeID

### DIFF
--- a/src/backend/efiling-api/jag-efiling-api.yaml
+++ b/src/backend/efiling-api/jag-efiling-api.yaml
@@ -235,7 +235,7 @@ paths:
     get:
       summary: Get a BCeID account
       operationId: GetBceidAccount
-      description: Retrive bceid user account information
+      description: Retrieve BCeID user account information
       tags:
         - account
       parameters:

--- a/src/backend/efiling-api/jag-efiling-api.yaml
+++ b/src/backend/efiling-api/jag-efiling-api.yaml
@@ -313,7 +313,7 @@ components:
           description: the account identifier
     BceidAccount:
       type: object
-      description: bceid account details
+      description: BCeID account details
       properties:
         firstName:
           type: string

--- a/src/backend/efiling-api/jag-efiling-api.yaml
+++ b/src/backend/efiling-api/jag-efiling-api.yaml
@@ -231,6 +231,24 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/UserFullDetails"
+  "/bceidAccount":
+    get:
+      summary: Get a Bceid account
+      operationId: GetBceidAccount
+      description: Retrive bceid user account information
+      tags:
+        - account
+      parameters:
+        - $ref: "#/components/parameters/xTransactionId"
+      responses:
+        "200":
+          description: Account Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BceidAccount"
+        "404":
+          description: Account not found
   "/lookup/documentTypes/{courtLevel}/{courtClass}":
     get:
       summary: Get document types
@@ -292,7 +310,17 @@ components:
           description: the account type
         identifier:
           type: string
-          description: the account identifier
+          description: the account identifie
+    BceidAccount:
+      type: object
+      description: bceid account details
+      properties:
+        firstName:
+          type: string
+        lastName:
+          type: string
+        middleName:
+          type: string
     DocumentProperties:
       type: object
       description: Submission Metadata used to describe the submission that will be e-filled

--- a/src/backend/efiling-api/jag-efiling-api.yaml
+++ b/src/backend/efiling-api/jag-efiling-api.yaml
@@ -310,7 +310,7 @@ components:
           description: the account type
         identifier:
           type: string
-          description: the account identifie
+          description: the account identifier
     BceidAccount:
       type: object
       description: bceid account details

--- a/src/backend/efiling-api/jag-efiling-api.yaml
+++ b/src/backend/efiling-api/jag-efiling-api.yaml
@@ -233,7 +233,7 @@ paths:
                 $ref: "#/components/schemas/UserFullDetails"
   "/bceidAccount":
     get:
-      summary: Get a Bceid account
+      summary: Get a BCeID account
       operationId: GetBceidAccount
       description: Retrive bceid user account information
       tags:

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/account/BceidAccountApiDelagateImpl.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/account/BceidAccountApiDelagateImpl.java
@@ -3,10 +3,12 @@ package ca.bc.gov.open.jag.efilingapi.account;
 import ca.bc.gov.open.jag.efilingapi.api.BceidAccountApiDelegate;
 import ca.bc.gov.open.jag.efilingapi.api.model.BceidAccount;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
 
 import javax.annotation.security.RolesAllowed;
 import java.util.UUID;
 
+@Service
 public class BceidAccountApiDelagateImpl implements BceidAccountApiDelegate {
 
     @Override

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/account/BceidAccountApiDelagateImpl.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/account/BceidAccountApiDelagateImpl.java
@@ -1,0 +1,23 @@
+package ca.bc.gov.open.jag.efilingapi.account;
+
+import ca.bc.gov.open.jag.efilingapi.api.BceidAccountApiDelegate;
+import ca.bc.gov.open.jag.efilingapi.api.model.BceidAccount;
+import org.springframework.http.ResponseEntity;
+
+import java.util.UUID;
+
+public class BceidAccountApiDelagateImpl implements BceidAccountApiDelegate {
+
+    @Override
+    public ResponseEntity<BceidAccount> getBceidAccount(UUID xTransactionId) {
+
+        BceidAccount result = new BceidAccount();
+
+        result.setFirstName("Bob");
+        result.setMiddleName("Alan");
+        result.setLastName("Ross");
+
+        return ResponseEntity.ok(result);
+
+    }
+}

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/account/BceidAccountApiDelagateImpl.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/account/BceidAccountApiDelagateImpl.java
@@ -4,11 +4,13 @@ import ca.bc.gov.open.jag.efilingapi.api.BceidAccountApiDelegate;
 import ca.bc.gov.open.jag.efilingapi.api.model.BceidAccount;
 import org.springframework.http.ResponseEntity;
 
+import javax.annotation.security.RolesAllowed;
 import java.util.UUID;
 
 public class BceidAccountApiDelagateImpl implements BceidAccountApiDelegate {
 
     @Override
+    @RolesAllowed("efiling-user")
     public ResponseEntity<BceidAccount> getBceidAccount(UUID xTransactionId) {
 
         BceidAccount result = new BceidAccount();

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/account/BceidAccountApiDelegateImplTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/account/BceidAccountApiDelegateImplTest.java
@@ -20,7 +20,7 @@ public class BceidAccountApiDelegateImplTest {
     }
 
     @Test
-    @DisplayName("")
+    @DisplayName("200: should return bceid account")
     public void withAccountShouldReturnAccount() {
 
         ResponseEntity<BceidAccount> actual = sut.getBceidAccount(UUID.randomUUID());

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/account/BceidAccountApiDelegateImplTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/account/BceidAccountApiDelegateImplTest.java
@@ -1,0 +1,36 @@
+package ca.bc.gov.open.jag.efilingapi.account;
+
+import ca.bc.gov.open.jag.efilingapi.api.model.BceidAccount;
+import org.junit.jupiter.api.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.UUID;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class BceidAccountApiDelegateImplTest {
+
+    private BceidAccountApiDelagateImpl sut;
+
+    @BeforeAll
+    public void setup() {
+
+        sut = new BceidAccountApiDelagateImpl();
+
+    }
+
+    @Test
+    @DisplayName("")
+    public void withAccountShouldReturnAccount() {
+
+        ResponseEntity<BceidAccount> actual = sut.getBceidAccount(UUID.randomUUID());
+
+        Assertions.assertEquals(HttpStatus.OK, actual.getStatusCode());
+        Assertions.assertEquals("Bob", actual.getBody().getFirstName());
+        Assertions.assertEquals("Alan", actual.getBody().getMiddleName());
+        Assertions.assertEquals("Ross", actual.getBody().getLastName());
+
+    }
+
+
+}

--- a/src/frontend/efiling-frontend/src/components/page/cso-account/CSOAccount.js
+++ b/src/frontend/efiling-frontend/src/components/page/cso-account/CSOAccount.js
@@ -28,6 +28,8 @@ export default function CSOAccount({
   const [termsAccepted, acceptTerms] = useState(false);
   const [continueBtnEnabled, setContinueBtnEnabled] = useState(false);
 
+  console.log(applicantInfo);
+
   useEffect(() => {
     if (termsAccepted) {
       setContinueBtnEnabled(true);

--- a/src/frontend/efiling-frontend/src/components/page/cso-account/CSOAccount.js
+++ b/src/frontend/efiling-frontend/src/components/page/cso-account/CSOAccount.js
@@ -28,8 +28,6 @@ export default function CSOAccount({
   const [termsAccepted, acceptTerms] = useState(false);
   const [continueBtnEnabled, setContinueBtnEnabled] = useState(false);
 
-  console.log(applicantInfo);
-
   useEffect(() => {
     if (termsAccepted) {
       setContinueBtnEnabled(true);

--- a/src/frontend/efiling-frontend/src/components/page/home/Home.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.js
@@ -35,28 +35,22 @@ export const saveDataToSessionStorage = (
   sessionStorage.setItem("cardRegistered", cardRegistered);
 };
 
-const addUserInfo = () => {
-  const {
-    preferred_username,
-    name,
-    email,
-    given_name,
-    family_name,
-  } = getJWTData();
+const addUserInfo = (firstName, middleName, lastName) => {
+  const { preferred_username, email } = getJWTData();
   let username = preferred_username;
   username = username.substring(0, username.indexOf("@"));
 
-  return {
-    bceid: username,
-    firstName: given_name,
-    lastName: family_name,
-    name,
-    email,
-  };
+  return { bceid: username, email, firstName, middleName, lastName };
 };
 
-const setRequiredState = (setApplicantInfo, setShowLoader) => {
-  const applicantInfo = addUserInfo();
+const setRequiredState = (
+  firstName,
+  middleName,
+  lastName,
+  setApplicantInfo,
+  setShowLoader
+) => {
+  const applicantInfo = addUserInfo(firstName, middleName, lastName);
 
   setApplicantInfo(applicantInfo);
   setShowLoader(false);
@@ -81,9 +75,20 @@ const checkCSOAccountStatus = (
         ).identifier;
         sessionStorage.setItem("csoAccountId", csoAccountIdentifier);
         setCsoAccountStatus({ isNew: false, exists: true });
+      } else {
+        axios
+          .get("/bceidAccount")
+          .then(({ data: { firstName, middleName, lastName } }) => {
+            setRequiredState(
+              firstName,
+              middleName,
+              lastName,
+              setApplicantInfo,
+              setShowLoader
+            );
+          })
+          .catch((err) => console.log(err));
       }
-
-      setRequiredState(setApplicantInfo, setShowLoader);
     })
     .catch((error) => {
       errorRedirect(sessionStorage.getItem("errorUrl"), error);

--- a/src/frontend/efiling-frontend/src/components/page/home/Home.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.js
@@ -144,13 +144,16 @@ export default function Home({ page: { header, confirmationPopup } }) {
           </div>
         </div>
       )}
-      {!showLoader && !error && !csoAccountStatus.exists && (
-        <CSOAccount
-          confirmationPopup={confirmationPopup}
-          applicantInfo={applicantInfo}
-          setCsoAccountStatus={setCsoAccountStatus}
-        />
-      )}
+      {!showLoader &&
+        !error &&
+        !csoAccountStatus.exists &&
+        JSON.stringify(applicantInfo) !== "{}" && (
+          <CSOAccount
+            confirmationPopup={confirmationPopup}
+            applicantInfo={applicantInfo}
+            setCsoAccountStatus={setCsoAccountStatus}
+          />
+        )}
       {!showLoader && !error && csoAccountStatus.exists && (
         <PackageConfirmation
           packageConfirmation={packageConfirmation}

--- a/src/frontend/efiling-frontend/src/components/page/home/Home.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.js
@@ -87,12 +87,13 @@ const checkCSOAccountStatus = (
               setShowLoader
             );
           })
-          .catch((err) => console.log(err));
+          .catch((err) =>
+            errorRedirect(sessionStorage.getItem("errorUrl"), err)
+          );
       }
     })
     .catch((error) => {
       errorRedirect(sessionStorage.getItem("errorUrl"), error);
-
       setError(true);
     })
     .finally(() => {

--- a/src/frontend/efiling-frontend/src/components/page/home/Home.stories.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.stories.js
@@ -37,7 +37,6 @@ const setRequiredStorage = () => {
   sessionStorage.setItem("errorUrl", "error.com");
   const token = generateJWTToken({
     preferred_username: "username@bceid",
-    name: "User Name",
     email: "username@example.com",
     realm_access: {
       roles: ["rush_flag"],
@@ -70,6 +69,11 @@ const NoAccountExistsStateData = (props) => {
   mock.onGet(apiRequest).reply(200, {
     userDetails: { ...userDetails, accounts: null },
     navigation,
+  });
+  mock.onGet("/bceidAccount").reply(200, {
+    firstName: "User",
+    lastName: "Name",
+    middleName: "Middle",
   });
   return props.children({ page });
 };

--- a/src/frontend/efiling-frontend/src/components/page/home/Home.test.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.test.js
@@ -35,7 +35,6 @@ describe("Home", () => {
 
   const token = generateJWTToken({
     preferred_username: "username@bceid",
-    name: "User Name",
     email: "username@example.com",
   });
   localStorage.setItem("jwt", token);
@@ -70,6 +69,12 @@ describe("Home", () => {
     mock.onGet(apiRequest).reply(200, {
       userDetails: { ...userDetails, accounts: null },
       navigation,
+    });
+
+    mock.onGet("/bceidAccount").reply(200, {
+      firstName: "User",
+      lastName: "Name",
+      middleName: null,
     });
 
     const { asFragment } = render(component);
@@ -132,5 +137,27 @@ describe("Home", () => {
     expect(sessionStorage.getItem("successUrl")).toBeFalsy();
     expect(sessionStorage.getItem("errorUrl")).toEqual("error.com");
     expect(sessionStorage.getItem("cardRegistered")).toEqual("true");
+  });
+
+  test("Redirects to error page when lookup to bceid call fails", async () => {
+    sessionStorage.setItem("errorUrl", "error.com");
+
+    mock.onGet(apiRequest).reply(200, {
+      userDetails: { ...userDetails, accounts: null },
+      navigation,
+    });
+
+    mock.onGet("/bceidAccount").reply(400, {
+      message: "There was an error",
+    });
+
+    render(component);
+
+    await waitFor(() => {});
+
+    expect(window.open).toHaveBeenCalledWith(
+      "error.com?status=400&message=There was an error.",
+      "_self"
+    );
   });
 });

--- a/src/frontend/efiling-frontend/src/components/page/home/__snapshots__/Home.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/components/page/home/__snapshots__/Home.stories.storyshot
@@ -1702,7 +1702,7 @@ exports[`Storyshots Home No Account Exists 1`] = `
                     <div
                       class="bcgov-table-value "
                     >
-                      User Name
+                      User Middle Name
                     </div>
                   </div>
                   <div
@@ -2756,7 +2756,7 @@ exports[`Storyshots Home No Account Exists Mobile 1`] = `
                     <div
                       class="bcgov-table-value "
                     >
-                      User Name
+                      User Middle Name
                     </div>
                   </div>
                   <div

--- a/src/frontend/efiling-frontend/src/components/page/payment/Payment.test.js
+++ b/src/frontend/efiling-frontend/src/components/page/payment/Payment.test.js
@@ -16,6 +16,7 @@ import { generateJWTToken } from "../../../modules/helpers/authentication-helper
 import Payment from "./Payment";
 
 describe("Payment Component", () => {
+  let realDate;
   const confirmationPopup = getTestData();
   const submissionId = "abc123";
   const apiRequest = `/submission/${submissionId}/filing-package`;
@@ -119,6 +120,14 @@ describe("Payment Component", () => {
   });
 
   test("Click on request rush submission opens rush submission page", async () => {
+    const currentDate = new Date("2019-05-14T11:01:58.135Z");
+    realDate = Date;
+    global.Date = class extends Date {
+      constructor() {
+        return currentDate;
+      }
+    };
+
     mock.onGet(apiRequest).reply(200, {
       documents: files,
       court: courtData,
@@ -132,5 +141,7 @@ describe("Payment Component", () => {
     await waitFor(() => {});
 
     expect(asFragment()).toMatchSnapshot();
+
+    global.Date = realDate;
   });
 });

--- a/src/frontend/efiling-frontend/src/components/page/payment/__snapshots__/Payment.test.js.snap
+++ b/src/frontend/efiling-frontend/src/components/page/payment/__snapshots__/Payment.test.js.snap
@@ -108,7 +108,7 @@ you feel are necessary.
             <input
               class=""
               type="text"
-              value="08/14/2020"
+              value="05/14/2019"
             />
           </div>
         </div>

--- a/src/frontend/efiling-frontend/src/modules/helpers/translateApplicantInfo.js
+++ b/src/frontend/efiling-frontend/src/modules/helpers/translateApplicantInfo.js
@@ -1,4 +1,14 @@
-export function translateApplicantInfo({ bceid, name, email }) {
+export function translateApplicantInfo({
+  bceid,
+  lastName,
+  firstName,
+  middleName,
+  email,
+}) {
+  const fullName = middleName
+    ? `${firstName} ${middleName} ${lastName}`
+    : `${firstName} ${lastName}`;
+
   return [
     {
       name: "BCeID:",
@@ -6,7 +16,7 @@ export function translateApplicantInfo({ bceid, name, email }) {
     },
     {
       name: "Full Name:",
-      value: name,
+      value: fullName,
     },
     {
       name: "Email Address:",

--- a/src/frontend/efiling-frontend/src/modules/test-data/applicantInfoTestData.js
+++ b/src/frontend/efiling-frontend/src/modules/test-data/applicantInfoTestData.js
@@ -1,6 +1,7 @@
 const applicantInfo = {
   bceid: "bobross42",
-  name: "Bob Ross",
+  firstName: "Bob",
+  lastName: "Ross",
   email: "bob.ross@example.com",
 };
 

--- a/src/frontend/efiling-frontend/src/types/propTypes.js
+++ b/src/frontend/efiling-frontend/src/types/propTypes.js
@@ -30,7 +30,7 @@ export const propTypes = {
   applicantInfo: PropTypes.shape({
     bceid: PropTypes.string.isRequired,
     firstName: PropTypes.string.isRequired,
-    middleName: PropTypes.string.isRequired,
+    middleName: PropTypes.string,
     lastName: PropTypes.string.isRequired,
     email: PropTypes.string.isRequired,
   }).isRequired,

--- a/src/frontend/efiling-frontend/src/types/propTypes.js
+++ b/src/frontend/efiling-frontend/src/types/propTypes.js
@@ -29,7 +29,9 @@ export const propTypes = {
   }).isRequired,
   applicantInfo: PropTypes.shape({
     bceid: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired,
+    firstName: PropTypes.string.isRequired,
+    middleName: PropTypes.string.isRequired,
+    lastName: PropTypes.string.isRequired,
     email: PropTypes.string.isRequired,
   }).isRequired,
   setState: PropTypes.func.isRequired,


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Adding BCeID lookup endpoint, get name data from BCeID
- Get name from a bceid lookup endpoint instead of from original token

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation

## How Has This Been Tested?

- local
- jest
- storybook
