### PR TITLE
Pull client app display name from backend and display in modal

### DIFF
--- a/src/backend/efiling-api/jag-efiling-api.yaml
+++ b/src/backend/efiling-api/jag-efiling-api.yaml
@@ -419,6 +419,8 @@ components:
           $ref: "#/components/schemas/UserDetails"
         navigation:
           $ref: "#/components/schemas/Navigation"
+        clientApplication:
+          $ref: "#/components/schemas/ClientApplication"
     Navigation:
       required:
         - success

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImpl.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImpl.java
@@ -260,6 +260,8 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
 
         response.setUserDetails(userDetails);
 
+        response.setClientApplication(fromCacheSubmission.get().getClientApplication());
+
         response.setNavigation(fromCacheSubmission.get().getNavigation());
 
         logger.info("Successfully retrieved submission for transactionId [{}]", xTransactionId);

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/submissionApiDelegateImpl/GetSubmissionTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/submissionApiDelegateImpl/GetSubmissionTest.java
@@ -98,6 +98,7 @@ public class GetSubmissionTest {
         Submission submissionWithCsoAccount = Submission
                 .builder()
                 .navigation(TestHelpers.createNavigation(TestHelpers.SUCCESS_URL, TestHelpers.CANCEL_URL, TestHelpers.ERROR_URL))
+                .clientApplication(TestHelpers.createClientApplication(TestHelpers.DESCRIPTION, TestHelpers.TYPE))
                 .create();
 
         Mockito.when(submissionStoreMock.get(Mockito.eq(TestHelpers.CASE_2), Mockito.any())).thenReturn(Optional.of(submissionWithCsoAccount));
@@ -168,6 +169,8 @@ public class GetSubmissionTest {
         assertEquals(TestHelpers.SUCCESS_URL, actual.getBody().getNavigation().getSuccess().getUrl());
         assertEquals(TestHelpers.CANCEL_URL, actual.getBody().getNavigation().getCancel().getUrl());
         assertEquals(TestHelpers.ERROR_URL, actual.getBody().getNavigation().getError().getUrl());
+        assertEquals(TestHelpers.TYPE, actual.getBody().getClientApplication().getType());
+        assertEquals(TestHelpers.DESCRIPTION, actual.getBody().getClientApplication().getDisplayName());
 
     }
 

--- a/src/frontend/efiling-frontend/src/App.js
+++ b/src/frontend/efiling-frontend/src/App.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-one-expression-per-line */
 import React, { useState } from "react";
 import axios from "axios";
 import queryString from "query-string";

--- a/src/frontend/efiling-frontend/src/App.js
+++ b/src/frontend/efiling-frontend/src/App.js
@@ -40,17 +40,6 @@ export default function App() {
   const handleClose = () => setShow(false);
   const handleShow = () => setShow(true);
 
-  const body = () => (
-    <>
-      <p>Your files will not be submitted.</p>
-      <p>
-        You will be returned to:
-        <br />
-        <b>Family Law Protection Order</b> website
-      </p>
-    </>
-  );
-
   const handleConfirm = () => {
     sessionStorage.setItem("validExit", true);
     const cancelUrl = sessionStorage.getItem("cancelUrl");
@@ -66,7 +55,6 @@ export default function App() {
   const modal = {
     show,
     title: "Cancel E-File Submission?",
-    body,
   };
 
   const confirmationPopup = {

--- a/src/frontend/efiling-frontend/src/components/page/home/Home.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.js
@@ -60,11 +60,13 @@ const checkCSOAccountStatus = (
   setCsoAccountStatus,
   setShowLoader,
   setApplicantInfo,
+  setClientApplicationName,
   setError
 ) => {
   axios
     .get(`/submission/${submissionId}`)
-    .then(({ data: { userDetails, navigation } }) => {
+    .then(({ data: { userDetails, navigation, clientApplication } }) => {
+      setClientApplicationName(clientApplication.displayName);
       saveDataToSessionStorage(userDetails.cardRegistered, navigation);
 
       if (userDetails.accounts) {
@@ -109,6 +111,7 @@ export default function Home({
   });
   const [applicantInfo, setApplicantInfo] = useState({});
   const [error, setError] = useState(false);
+  const [clientApplicationName, setClientApplicationName] = useState("");
 
   setRequestHeaders(transactionId);
 
@@ -118,12 +121,25 @@ export default function Home({
       setCsoAccountStatus,
       setShowLoader,
       setApplicantInfo,
+      setClientApplicationName,
       setError
     );
   }, [submissionId]);
 
+  const body = () => (
+    <>
+      <p>Your files will not be submitted.</p>
+      <p>
+        You will be returned to:
+        <br />
+        <b>{clientApplicationName}</b> website
+      </p>
+    </>
+  );
+  const updatedModal = { ...confirmationPopup.modal, body };
+
   const packageConfirmation = {
-    confirmationPopup,
+    confirmationPopup: { ...confirmationPopup, modal: updatedModal },
     submissionId,
   };
 
@@ -148,7 +164,7 @@ export default function Home({
         !csoAccountStatus.exists &&
         JSON.stringify(applicantInfo) !== "{}" && (
           <CSOAccount
-            confirmationPopup={confirmationPopup}
+            confirmationPopup={{ ...confirmationPopup, modal: updatedModal }}
             applicantInfo={applicantInfo}
             setCsoAccountStatus={setCsoAccountStatus}
           />

--- a/src/frontend/efiling-frontend/src/components/page/home/Home.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.js
@@ -1,4 +1,4 @@
-/* eslint-disable camelcase */
+/* eslint-disable camelcase, react/jsx-one-expression-per-line */
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import axios from "axios";
@@ -132,7 +132,7 @@ export default function Home({
       <p>
         You will be returned to:
         <br />
-        <b>{clientApplicationName}</b>&nbsp; website
+        <b>{clientApplicationName}</b> website
       </p>
     </>
   );

--- a/src/frontend/efiling-frontend/src/components/page/home/Home.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.js
@@ -132,7 +132,7 @@ export default function Home({
       <p>
         You will be returned to:
         <br />
-        <b>{clientApplicationName}</b> website
+        <b>{clientApplicationName}</b>&nbsp; website
       </p>
     </>
   );

--- a/src/frontend/efiling-frontend/src/components/page/home/Home.stories.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.stories.js
@@ -32,6 +32,7 @@ const documents = getDocumentsData();
 const court = getCourtData();
 const submissionFeeAmount = 25.5;
 const userDetails = getUserDetails();
+const clientApplication = { displayName: "client app" };
 
 const setRequiredStorage = () => {
   sessionStorage.setItem("errorUrl", "error.com");
@@ -56,7 +57,9 @@ const LoaderStateData = (props) => {
 const AccountExistsStateData = (props) => {
   setRequiredStorage();
   const mock = new MockAdapter(axios);
-  mock.onGet(apiRequest).reply(200, { userDetails, navigation });
+  mock
+    .onGet(apiRequest)
+    .reply(200, { userDetails, navigation, clientApplication });
   mock
     .onGet(getFilingPackagePath)
     .reply(200, { documents, court, submissionFeeAmount });
@@ -69,6 +72,7 @@ const NoAccountExistsStateData = (props) => {
   mock.onGet(apiRequest).reply(200, {
     userDetails: { ...userDetails, accounts: null },
     navigation,
+    clientApplication,
   });
   mock.onGet("/bceidAccount").reply(200, {
     firstName: "User",

--- a/src/frontend/efiling-frontend/src/components/page/home/Home.test.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.test.js
@@ -29,6 +29,7 @@ describe("Home", () => {
   const court = getCourtData();
   const submissionFeeAmount = 25.5;
   const userDetails = getUserDetails();
+  const clientApplication = { displayName: "client app" };
 
   window.open = jest.fn();
 
@@ -47,7 +48,9 @@ describe("Home", () => {
   const component = <Home page={page} />;
 
   test("Component matches the snapshot when user cso account exists", async () => {
-    mock.onGet(apiRequest).reply(200, { userDetails, navigation });
+    mock
+      .onGet(apiRequest)
+      .reply(200, { userDetails, navigation, clientApplication });
     mock
       .onGet(getFilingPackagePath)
       .reply(200, { documents, court, submissionFeeAmount });
@@ -64,6 +67,7 @@ describe("Home", () => {
     mock.onGet(apiRequest).reply(200, {
       userDetails: { ...userDetails, accounts: null },
       navigation,
+      clientApplication,
     });
 
     mock.onGet("/bceidAccount").reply(200, {
@@ -140,6 +144,7 @@ describe("Home", () => {
     mock.onGet(apiRequest).reply(200, {
       userDetails: { ...userDetails, accounts: null },
       navigation,
+      clientApplication,
     });
 
     mock.onGet("/bceidAccount").reply(400, {
@@ -160,6 +165,7 @@ describe("Home", () => {
     mock.onGet(apiRequest).reply(200, {
       userDetails: { ...userDetails, accounts: null },
       navigation,
+      clientApplication,
     });
 
     mock.onGet("/bceidAccount").reply(200, {

--- a/src/frontend/efiling-frontend/src/components/page/home/Home.test.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.test.js
@@ -42,6 +42,11 @@ describe("Home", () => {
   let mock;
   beforeEach(() => {
     mock = new MockAdapter(axios);
+    mock.onGet(apiRequest).reply(200, {
+      userDetails: { ...userDetails, accounts: null },
+      navigation,
+      clientApplication,
+    });
     sessionStorage.clear();
   });
 
@@ -64,12 +69,6 @@ describe("Home", () => {
   });
 
   test("Component matches the snapshot when user cso account does not exist", async () => {
-    mock.onGet(apiRequest).reply(200, {
-      userDetails: { ...userDetails, accounts: null },
-      navigation,
-      clientApplication,
-    });
-
     mock.onGet("/bceidAccount").reply(200, {
       firstName: "User",
       lastName: "Name",
@@ -141,12 +140,6 @@ describe("Home", () => {
   test("Redirects to error page when lookup to bceid call fails", async () => {
     sessionStorage.setItem("errorUrl", "error.com");
 
-    mock.onGet(apiRequest).reply(200, {
-      userDetails: { ...userDetails, accounts: null },
-      navigation,
-      clientApplication,
-    });
-
     mock.onGet("/bceidAccount").reply(400, {
       message: "There was an error",
     });
@@ -162,12 +155,6 @@ describe("Home", () => {
   });
 
   test("clicking cancel opens confirmation popup and clicking confirm takes user back to client app", async () => {
-    mock.onGet(apiRequest).reply(200, {
-      userDetails: { ...userDetails, accounts: null },
-      navigation,
-      clientApplication,
-    });
-
     mock.onGet("/bceidAccount").reply(200, {
       firstName: "User",
       lastName: "Name",


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Pull client app display name from backend and display in modal

@TayGov need the `GET /submission/${submissionId}` call to return `clientApplication` object with a property called `displayName` along with `userDetails` and `navigation` 😄 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- local
- jest
- needs backend work to fully implement and test
