### PR TITLE
Add loader state to button on upload page

### DIFF
--- a/src/frontend/efiling-frontend/src/components/page/upload/Upload.js
+++ b/src/frontend/efiling-frontend/src/components/page/upload/Upload.js
@@ -245,7 +245,9 @@ const generateFormData = (acceptedFiles) => {
 export const uploadDocuments = (
   submissionId,
   acceptedFiles,
-  setShowPackageConfirmation
+  setShowPackageConfirmation,
+  setShowLoader,
+  setContinueBtnEnabled
 ) => {
   axios
     .post(
@@ -263,7 +265,11 @@ export const uploadDocuments = (
           errorRedirect(sessionStorage.getItem("errorUrl"), error)
         );
     })
-    .catch((err) => errorRedirect(sessionStorage.getItem("errorUrl"), err));
+    .catch((err) => {
+      setShowLoader(false);
+      setContinueBtnEnabled(true);
+      errorRedirect(sessionStorage.getItem("errorUrl"), err);
+    });
 };
 
 const checkForDuplicateFiles = (droppedFiles, acceptedFiles) => {
@@ -288,6 +294,7 @@ export default function Upload({
   const [items, setItems] = useState([]);
   const [continueBtnEnabled, setContinueBtnEnabled] = useState(false);
   const [errorMessage, setErrorMessage] = useState(null);
+  const [showLoader, setShowLoader] = useState(false);
 
   useEffect(() => {
     sessionStorage.setItem("currentPage", "upload");
@@ -383,15 +390,20 @@ export default function Upload({
           />
           <Button
             label="Continue"
-            onClick={() =>
+            onClick={() => {
+              setShowLoader(true);
+              setContinueBtnEnabled(false);
               uploadDocuments(
                 submissionId,
                 acceptedFiles,
-                setShowPackageConfirmation
-              )
-            }
+                setShowPackageConfirmation,
+                setShowLoader,
+                setContinueBtnEnabled
+              );
+            }}
             styling="normal-blue btn"
             disabled={!continueBtnEnabled}
+            hasLoader={showLoader}
           />
         </section>
       </div>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Add loader state to button on upload page
(for longer requests, uploading many big files)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- local
- jest

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
