### PR TITLE
Make generateurl return false if no efile role present

### DIFF
--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImpl.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImpl.java
@@ -229,6 +229,11 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
                     EfilingErrorBuilder.builder().errorResponse(ErrorResponse.INVALIDUNIVERSAL).create(),
                     HttpStatus.FORBIDDEN);
 
+        if (!accountService.getCsoAccountDetails(universalId.get()).isFileRolePresent())
+            return new ResponseEntity(
+                    EfilingErrorBuilder.builder().errorResponse(ErrorResponse.INVALIDROLE).create(),
+                    HttpStatus.FORBIDDEN);
+
         SubmissionKey submissionKey = new SubmissionKey(universalId.get(), xTransactionId, submissionId);
 
         ResponseEntity response;

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/TestHelpers.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/TestHelpers.java
@@ -2,12 +2,13 @@ package ca.bc.gov.open.jag.efilingapi;
 
 
 import ca.bc.gov.open.jag.efilingapi.api.model.*;
+import ca.bc.gov.open.jag.efilingcommons.model.AccountDetails;
+import ca.bc.gov.open.jag.efilingapi.submission.models.*;
 import ca.bc.gov.open.jag.efilingcommons.model.Court;
 import ca.bc.gov.open.jag.efilingcommons.model.Document;
 import ca.bc.gov.open.jag.efilingcommons.model.DocumentType;
 import ca.bc.gov.open.jag.efilingcommons.model.FilingPackage;
 import ca.bc.gov.open.jag.efilingcommons.model.Party;
-import ca.bc.gov.open.jag.efilingapi.submission.models.*;
 import com.google.gson.JsonObject;
 
 import java.math.BigDecimal;
@@ -157,6 +158,10 @@ public class TestHelpers {
                 .partyTypeCd(PARTY_TYPE_CD)
                 .roleTypeCd(ROLE_TYPE_CD)
                 .create();
+    }
+
+    public static AccountDetails createCSOAccountDetails(boolean isFileRolePresent) {
+        return AccountDetails.builder().fileRolePresent(isFileRolePresent).create();
     }
 
     public static NavigationUrls createDefaultNavigation() {


### PR DESCRIPTION
# Description

Make generateurl return false if no efile role present

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- local
- unit tests

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No