### PR TITLE
Removed preferred auth provider in demo app

### DIFF
--- a/src/frontend/efiling-demo/.env.dev
+++ b/src/frontend/efiling-demo/.env.dev
@@ -1,0 +1,6 @@
+REACT_APP_API_BASE_URL = https://fla-nginx-proxy-qzaydf-dev.pathfinder.gov.bc.ca/api
+REACT_APP_KEYCLOAK_URL = https://dev.oidc.gov.bc.ca/auth
+REACT_APP_KEYCLOAK_REALM = tz0e228w
+REACT_APP_KEYCLOAK_CLIENT_ID = demo-app
+REACT_APP_API_KEYCLOAK_URL = https://dev.oidc.gov.bc.ca/auth
+PORT = 3001

--- a/src/frontend/efiling-demo/README.md
+++ b/src/frontend/efiling-demo/README.md
@@ -4,15 +4,27 @@ Welcome to the eFiling demo!
 
 ## Running the Frontend
 
+### Running against local dockerized backend
+
 In the project directory `efiling-demo`:
 
-Set the required environment variables locally. Create a `.env.development` file and populate the environment variables as shown in the `.env.example` file.
+Create a `.env.development` file and populate the environment variables as shown in the `.env.example` file.
 
-In the root directory `jag-file-submission`, run:
+To bring up all the backend docker containers locally, n the root directory `jag-file-submission`, run:
 
 ```bash
 docker-compose up efiling-api efiling-frontend keycloak keycloak-config redis
 ```
+
+Continue below with `yarn install`
+
+### Running the Frontend against the dockerized containers on DEV (dev.justice.gov.bc.ca)
+
+It's possible to run the demo application locally, but use keycloak, the api, and the other backend containers running on DEV.
+
+In the project directory `efiling-demo`:
+
+Create a `.env.development` file and populate the environment variables as shown in the `.env.dev` file.
 
 In the project directory `efiling-demo` open a new terminal and run:
 

--- a/src/frontend/efiling-demo/README.md
+++ b/src/frontend/efiling-demo/README.md
@@ -8,9 +8,11 @@ Welcome to the eFiling demo!
 
 In the project directory `efiling-demo`:
 
-Create a `.env.development` file and populate the environment variables as shown in the `.env.example` file.
+Create a `.env.development` file and populate the environment variables as
+shown in the `.env.example` file.
 
-To bring up all the backend docker containers locally, n the root directory `jag-file-submission`, run:
+To bring up all the backend docker containers locally, n the root directory
+`jag-file-submission`, run:
 
 ```bash
 docker-compose up efiling-api efiling-frontend keycloak keycloak-config redis
@@ -18,13 +20,15 @@ docker-compose up efiling-api efiling-frontend keycloak keycloak-config redis
 
 Continue below with `yarn install`
 
-### Running the Frontend against the dockerized containers on DEV (dev.justice.gov.bc.ca)
+### Running the Frontend against the dockerized containers on DEV
 
-It's possible to run the demo application locally, but use keycloak, the api, and the other backend containers running on DEV.
+It's possible to run the demo application locally, but use keycloak, the api,
+and the other backend containers running on DEV (dev.justice.gov.bc.ca).
 
 In the project directory `efiling-demo`:
 
-Create a `.env.development` file and populate the environment variables as shown in the `.env.dev` file.
+Create a `.env.development` file and populate the environment variables as
+shown in the `.env.dev` file.
 
 In the project directory `efiling-demo` open a new terminal and run:
 

--- a/src/frontend/efiling-demo/src/components/hoc/AuthenticationGuard.js
+++ b/src/frontend/efiling-demo/src/components/hoc/AuthenticationGuard.js
@@ -14,10 +14,6 @@ const clientId = window.REACT_APP_KEYCLOAK_CLIENT_ID
   ? window.REACT_APP_KEYCLOAK_CLIENT_ID
   : process.env.REACT_APP_KEYCLOAK_CLIENT_ID;
 
-const defaultIdentityProvider = window.REACT_APP_DEFAULT_IDENTITY_PROVIDER
-  ? window.REACT_APP_DEFAULT_IDENTITY_PROVIDER
-  : process.env.REACT_APP_DEFAULT_IDENTITY_PROVIDER;
-
 const KEYCLOAK = {
   realm,
   url,
@@ -46,9 +42,7 @@ export default function AuthenticationGuard({ page: { header } }) {
           localStorage.setItem("jwt", keycloak.token);
           setAuthedKeycloak(keycloak);
         } else {
-          keycloak.login({
-            idpHint: `${defaultIdentityProvider}`,
-          });
+          keycloak.login();
         }
       });
   }

--- a/src/frontend/efiling-frontend/.env.dev
+++ b/src/frontend/efiling-frontend/.env.dev
@@ -1,0 +1,6 @@
+REACT_APP_KEYCLOAK_REALM = tz0e228w
+REACT_APP_KEYCLOAK_CLIENT_ID = efiling-frontend
+REACT_APP_KEYCLOAK_URL = https://dev.oidc.gov.bc.ca/auth
+REACT_APP_API_BASE_URL = https://fla-nginx-proxy-qzaydf-dev.pathfinder.gov.bc.ca/api
+REACT_APP_BAMBORA_REDIRECT_URL = http://localhost:3000/efilinghub
+PORT=3000

--- a/src/frontend/efiling-frontend/README.md
+++ b/src/frontend/efiling-frontend/README.md
@@ -22,8 +22,10 @@ Continue below with `yarn install`
 
 ### Running the Frontend against the dockerized containers on DEV (dev.justice.gov.bc.ca)
 
-It's possible to run the frontend application locally, but use keycloak, the api, and the other backend containers running on DEV.
-Note: Once in a while the backend may redirect back to the frontend running on DEV (ie. `https://dev.justice.gov.bc.ca/efilinghub?submissionId=b8219b1`...).
+It's possible to run the frontend application locally, but use keycloak,
+the api, and the other backend containers running on DEV.
+Note: Once in a while the backend may redirect back to the frontend running
+on DEV (ie. `https://dev.justice.gov.bc.ca/efilinghub?submissionId=b8219b1`...).
 To continue, replace the domain in the browser URL with `http://localhost:3000/efilinghub`...
 
 In the project directory `efiling-frontend`:

--- a/src/frontend/efiling-frontend/README.md
+++ b/src/frontend/efiling-frontend/README.md
@@ -4,17 +4,31 @@ Welcome to the eFiling frontend!
 
 ## Running the Frontend
 
+### Running against local dockerized backend
+
 In the project directory `efiling-frontend`:
 
-Set the required environment variables locally. Create a `.env.development` file and populate the environment variables as shown in the `.env.example` file.
+Create a `.env.development` file and populate the environment variables as shown in the `.env.example` file.
 
-In the root directory `jag-file-submission`, run:
+To bring up all the backend docker containers locally, n the root directory `jag-file-submission`, run:
 
 ```bash
-docker-compose up -d efiling-api efiling-demo keycloak keycloak-config redis redis-commander clamav
+docker-compose up efiling-api efiling-frontend keycloak keycloak-config redis
 ```
 
-In the project directory (`efiling-frontend`), you can run:
+Continue below with `yarn install`
+
+### Running the Frontend against the dockerized containers on DEV (dev.justice.gov.bc.ca)
+
+It's possible to run the frontend application locally, but use keycloak, the api, and the other backend containers running on DEV.
+Note: Once in a while the backend may redirect back to the frontend running on DEV (ie. `https://dev.justice.gov.bc.ca/efilinghub?submissionId=b8219b1`...).
+To continue, replace the domain in the browser URL with `http://localhost:3000/efilinghub`...
+
+In the project directory `efiling-frontend`:
+
+Create a `.env.development` file and populate the environment variables as shown in the `.env.env` file.
+
+Run:
 
 ```bash
 yarn install

--- a/src/frontend/efiling-frontend/README.md
+++ b/src/frontend/efiling-frontend/README.md
@@ -8,9 +8,11 @@ Welcome to the eFiling frontend!
 
 In the project directory `efiling-frontend`:
 
-Create a `.env.development` file and populate the environment variables as shown in the `.env.example` file.
+Create a `.env.development` file and populate the environment variables as
+shown in the `.env.example` file.
 
-To bring up all the backend docker containers locally, n the root directory `jag-file-submission`, run:
+To bring up all the backend docker containers locally, n the root directory
+`jag-file-submission`, run:
 
 ```bash
 docker-compose up efiling-api efiling-frontend keycloak keycloak-config redis
@@ -26,7 +28,8 @@ To continue, replace the domain in the browser URL with `http://localhost:3000/e
 
 In the project directory `efiling-frontend`:
 
-Create a `.env.development` file and populate the environment variables as shown in the `.env.env` file.
+Create a `.env.development` file and populate the environment variables as
+shown in the `.env.env` file.
 
 Run:
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

https://justice.gov.bc.ca/jira/browse/FLA-702

- Added an .env.dev file to permit the demo app to run locally against the backend on DEV
- Update README.md
- Removed the default provider of bceid so we can choose which provider to use when running demo

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

yarn lint
yarn test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
