### PR TITLE
Updating universalId to be treated as a String

### DIFF
--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/account/BceidAccountApiDelagateImpl.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/account/BceidAccountApiDelagateImpl.java
@@ -32,7 +32,7 @@ public class BceidAccountApiDelagateImpl implements BceidAccountApiDelegate {
     @RolesAllowed("efiling-user")
     public ResponseEntity<BceidAccount> getBceidAccount(UUID xTransactionId) {
 
-        Optional<UUID> userId = SecurityUtils.getUniversalIdFromContext();
+        Optional<String> userId = SecurityUtils.getUniversalIdFromContext();
 
         if(!userId.isPresent())
             return new ResponseEntity(HttpStatus.FORBIDDEN);

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/account/CsoAccountApiDelegateImpl.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/account/CsoAccountApiDelegateImpl.java
@@ -46,7 +46,7 @@ public class CsoAccountApiDelegateImpl implements CsoAccountApiDelegate {
     @RolesAllowed("efiling-user")
     public ResponseEntity<CsoAccount> createAccount(UUID xTransactionId, CreateCsoAccountRequest createAccountRequest) {
         
-        Optional<UUID> universalId = SecurityUtils.getUniversalIdFromContext();
+        Optional<String> universalId = SecurityUtils.getUniversalIdFromContext();
 
         if(!universalId.isPresent()) return new ResponseEntity(
                 EfilingErrorBuilder.builder().errorResponse(ErrorResponse.MISSING_UNIVERSAL_ID).create(), HttpStatus.FORBIDDEN);
@@ -78,7 +78,7 @@ public class CsoAccountApiDelegateImpl implements CsoAccountApiDelegate {
     @RolesAllowed("efiling-user")
     public ResponseEntity<CsoAccount> getCsoAccount(UUID xTransactionId) {
 
-        Optional<UUID> universalId = SecurityUtils.getUniversalIdFromContext();
+        Optional<String> universalId = SecurityUtils.getUniversalIdFromContext();
 
         if(!universalId.isPresent()) return new ResponseEntity(HttpStatus.FORBIDDEN);
 
@@ -95,7 +95,7 @@ public class CsoAccountApiDelegateImpl implements CsoAccountApiDelegate {
     @RolesAllowed("efiling-user")
     public ResponseEntity<CsoAccount> updateCsoAccount(UUID xTransactionId, CsoAccountUpdateRequest clientUpdateRequest) {
 
-        Optional<UUID> universalId = SecurityUtils.getUniversalIdFromContext();
+        Optional<String> universalId = SecurityUtils.getUniversalIdFromContext();
 
         MdcUtils.setUserMDC(UUID.randomUUID(), xTransactionId);
 

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/account/mappers/CreateAccountRequestMapper.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/account/mappers/CreateAccountRequestMapper.java
@@ -4,11 +4,9 @@ import ca.bc.gov.open.jag.efilingapi.api.model.CreateCsoAccountRequest;
 import ca.bc.gov.open.jag.efilingcommons.model.CreateAccountRequest;
 import org.mapstruct.Mapper;
 
-import java.util.UUID;
-
 @Mapper
 public interface CreateAccountRequestMapper {
 
-    CreateAccountRequest toCreateAccountRequest(UUID universalId, CreateCsoAccountRequest createCsoAccountRequest);
+    CreateAccountRequest toCreateAccountRequest(String universalId, CreateCsoAccountRequest createCsoAccountRequest);
 
 }

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/account/service/AccountService.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/account/service/AccountService.java
@@ -3,14 +3,12 @@ package ca.bc.gov.open.jag.efilingapi.account.service;
 import ca.bc.gov.open.jag.efilingapi.api.model.CreateCsoAccountRequest;
 import ca.bc.gov.open.jag.efilingcommons.model.AccountDetails;
 
-import java.util.UUID;
-
 public interface AccountService {
 
-    AccountDetails getCsoAccountDetails(UUID universalId);
+    AccountDetails getCsoAccountDetails(String universalId);
 
     void updateClient(AccountDetails accountDetails);
 
-    AccountDetails createAccount(UUID universalId, CreateCsoAccountRequest createAccountRequest);
+    AccountDetails createAccount(String universalId, CreateCsoAccountRequest createAccountRequest);
 
 }

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/account/service/AccountServiceImpl.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/account/service/AccountServiceImpl.java
@@ -6,8 +6,6 @@ import ca.bc.gov.open.jag.efilingcommons.model.AccountDetails;
 import ca.bc.gov.open.jag.efilingcommons.service.EfilingAccountService;
 import org.springframework.cache.annotation.Cacheable;
 
-import java.util.UUID;
-
 public class AccountServiceImpl implements AccountService {
 
     private final EfilingAccountService efilingAccountService;
@@ -20,7 +18,7 @@ public class AccountServiceImpl implements AccountService {
 
     @Override
     @Cacheable(cacheNames = "accountDetails", key = "#universalId", cacheManager = "accountDetailsCacheManager", unless = "#result == null || #result.getInternalClientNumber() == null")
-    public AccountDetails getCsoAccountDetails(UUID universalId) {
+    public AccountDetails getCsoAccountDetails(String universalId) {
         return efilingAccountService.getAccountDetails(universalId);
     }
 
@@ -31,7 +29,7 @@ public class AccountServiceImpl implements AccountService {
 
     @Override
     @Cacheable(cacheNames = "accountDetails", key = "#universalId", cacheManager = "accountDetailsCacheManager", unless = "#result == null || #result.getInternalClientNumber() == null")
-    public AccountDetails createAccount(UUID universalId, CreateCsoAccountRequest createCsoAccountRequest) {
+    public AccountDetails createAccount(String universalId, CreateCsoAccountRequest createCsoAccountRequest) {
         return efilingAccountService.createAccount(createAccountRequestMapper.toCreateAccountRequest(universalId, createCsoAccountRequest));
     }
 

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/filingpackage/FilingpackageApiDelegateImpl.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/filingpackage/FilingpackageApiDelegateImpl.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Service;
 import javax.annotation.security.RolesAllowed;
 import java.math.BigDecimal;
 import java.util.Optional;
-import java.util.UUID;
 
 @Service
 public class FilingpackageApiDelegateImpl implements FilingpackageApiDelegate {
@@ -30,7 +29,7 @@ public class FilingpackageApiDelegateImpl implements FilingpackageApiDelegate {
     @RolesAllowed("efiling-user")
     public ResponseEntity<FilingPackage> getFilingPackage(BigDecimal packageIdentifier) {
 
-        Optional<UUID> universalId = SecurityUtils.getUniversalIdFromContext();
+        Optional<String> universalId = SecurityUtils.getUniversalIdFromContext();
 
         if(!universalId.isPresent()) return new ResponseEntity(
                 EfilingErrorBuilder.builder().errorResponse(ErrorResponse.MISSING_UNIVERSAL_ID).create(), HttpStatus.FORBIDDEN);
@@ -47,7 +46,7 @@ public class FilingpackageApiDelegateImpl implements FilingpackageApiDelegate {
     @RolesAllowed("efiling-user")
     public ResponseEntity<Resource> getSubmissionSheet(BigDecimal packageIdentifier) {
 
-        Optional<UUID> universalId = SecurityUtils.getUniversalIdFromContext();
+        Optional<String> universalId = SecurityUtils.getUniversalIdFromContext();
 
         if(!universalId.isPresent()) return new ResponseEntity(
                 EfilingErrorBuilder.builder().errorResponse(ErrorResponse.MISSING_UNIVERSAL_ID).create(), HttpStatus.FORBIDDEN);

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/filingpackage/service/FilingPackageService.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/filingpackage/service/FilingPackageService.java
@@ -4,11 +4,10 @@ import ca.bc.gov.open.jag.efilingapi.api.model.FilingPackage;
 
 import java.math.BigDecimal;
 import java.util.Optional;
-import java.util.UUID;
 
 public interface FilingPackageService {
 
-    Optional<FilingPackage> getCSOFilingPackage(UUID universalId, BigDecimal packageNumber);
+    Optional<FilingPackage> getCSOFilingPackage(String universalId, BigDecimal packageNumber);
 
     Optional<byte[]> getSubmissionSheet(BigDecimal packageNumber);
 }

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/filingpackage/service/FilingPackageServiceImpl.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/filingpackage/service/FilingPackageServiceImpl.java
@@ -10,7 +10,6 @@ import ca.bc.gov.open.jag.efilingcommons.submission.models.review.ReviewFilingPa
 
 import java.math.BigDecimal;
 import java.util.Optional;
-import java.util.UUID;
 
 public class FilingPackageServiceImpl implements FilingPackageService {
 
@@ -28,7 +27,8 @@ public class FilingPackageServiceImpl implements FilingPackageService {
 
 
     @Override
-    public Optional<FilingPackage> getCSOFilingPackage(UUID universalId, BigDecimal packageNumber) {
+    public Optional<FilingPackage> getCSOFilingPackage(String universalId, BigDecimal packageNumber) {
+
         AccountDetails accountDetails = accountService.getCsoAccountDetails(universalId);
 
         if (accountDetails.getClientId() == null) return Optional.empty();

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImpl.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImpl.java
@@ -82,7 +82,7 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
             logger.error("Universal ID is required");
             return new ResponseEntity(
                     EfilingErrorBuilder.builder().errorResponse(ErrorResponse.INVALIDUNIVERSAL).create(),
-                    HttpStatus.BAD_REQUEST);
+                    HttpStatus.FORBIDDEN);
         }
 
         SubmissionKey submissionKey = new SubmissionKey(

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImpl.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImpl.java
@@ -45,6 +45,7 @@ import java.util.UUID;
 @EnableConfigurationProperties(NavigationProperties.class)
 public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
 
+    private static final String UNIVERSAL_ID_IS_REQUIRED = "universal Id is required.";
     Logger logger = LoggerFactory.getLogger(SubmissionApiDelegateImpl.class);
 
     private final SubmissionService submissionService;
@@ -79,7 +80,7 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
     public ResponseEntity<UploadSubmissionDocumentsResponse> uploadSubmissionDocuments(UUID xTransactionId, String xUserId, List<MultipartFile> files) {
 
         if(StringUtils.isBlank(xUserId)) {
-            logger.error("Universal ID is required");
+            logger.error(UNIVERSAL_ID_IS_REQUIRED);
             return new ResponseEntity(
                     EfilingErrorBuilder.builder().errorResponse(ErrorResponse.INVALIDUNIVERSAL).create(),
                     HttpStatus.FORBIDDEN);
@@ -113,7 +114,7 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
 
         if(!universalId.isPresent()) {
 
-            logger.error("Universal ID is required");
+            logger.error(UNIVERSAL_ID_IS_REQUIRED);
 
             return new ResponseEntity(
                     EfilingErrorBuilder.builder().errorResponse(ErrorResponse.INVALIDUNIVERSAL).create(),
@@ -149,7 +150,7 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
 
         if(!universalId.isPresent()) {
 
-            logger.error("Universal ID is required");
+            logger.error(UNIVERSAL_ID_IS_REQUIRED);
 
             return new ResponseEntity(
                     EfilingErrorBuilder.builder().errorResponse(ErrorResponse.INVALIDUNIVERSAL).create(),
@@ -202,7 +203,7 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
 
         if(!universalId.isPresent()) {
 
-            logger.error("Universal ID is required");
+            logger.error(UNIVERSAL_ID_IS_REQUIRED);
 
             return new ResponseEntity(
                     EfilingErrorBuilder.builder().errorResponse(ErrorResponse.INVALIDUNIVERSAL).create(),
@@ -235,7 +236,7 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
 
         if (StringUtils.isBlank(xUserId)) {
 
-            logger.error("Universal ID is required");
+            logger.error(UNIVERSAL_ID_IS_REQUIRED);
 
             return new ResponseEntity(
                     EfilingErrorBuilder.builder().errorResponse(ErrorResponse.INVALIDUNIVERSAL).create(),
@@ -305,7 +306,7 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
 
         if (!universalId.isPresent()) {
 
-            logger.error("Universal ID is required");
+            logger.error(UNIVERSAL_ID_IS_REQUIRED);
 
             return new ResponseEntity(
                     EfilingErrorBuilder.builder().errorResponse(ErrorResponse.MISSING_UNIVERSAL_ID).create(), HttpStatus.FORBIDDEN);
@@ -346,7 +347,7 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
 
         if(!universalId.isPresent()) {
 
-            logger.error("Universal ID is required");
+            logger.error(UNIVERSAL_ID_IS_REQUIRED);
 
             return new ResponseEntity(
                     EfilingErrorBuilder.builder().errorResponse(ErrorResponse.INVALIDUNIVERSAL).create(),
@@ -379,7 +380,7 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
 
         if(!universalId.isPresent()) {
 
-            logger.error("Universal ID is required");
+            logger.error(UNIVERSAL_ID_IS_REQUIRED);
 
             return new ResponseEntity(
                     EfilingErrorBuilder.builder().errorResponse(ErrorResponse.INVALIDUNIVERSAL).create(),
@@ -410,7 +411,7 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
 
         if(!universalId.isPresent()) {
 
-            logger.error("Universal ID is required");
+            logger.error(UNIVERSAL_ID_IS_REQUIRED);
 
             return new ResponseEntity(
                     EfilingErrorBuilder.builder().errorResponse(ErrorResponse.INVALIDUNIVERSAL).create(),

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImpl.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImpl.java
@@ -21,6 +21,7 @@ import ca.bc.gov.open.jag.efilingapi.utils.Notification;
 import ca.bc.gov.open.jag.efilingapi.utils.SecurityUtils;
 import ca.bc.gov.open.jag.efilingapi.utils.TikaAnalysis;
 import ca.bc.gov.open.jag.efilingcommons.exceptions.*;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -77,26 +78,21 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
     @RolesAllowed({"efiling-client", "efiling-admin"})
     public ResponseEntity<UploadSubmissionDocumentsResponse> uploadSubmissionDocuments(UUID xTransactionId, String xUserId, List<MultipartFile> files) {
 
-        Optional<UUID> universalId = SecurityUtils.stringToUUID(xUserId);
-
-        if(!universalId.isPresent())
+        if(StringUtils.isBlank(xUserId)) {
+            logger.error("Universal ID is required");
             return new ResponseEntity(
                     EfilingErrorBuilder.builder().errorResponse(ErrorResponse.INVALIDUNIVERSAL).create(),
                     HttpStatus.BAD_REQUEST);
+        }
 
         SubmissionKey submissionKey = new SubmissionKey(
-                universalId.get(),
+                xUserId,
                 xTransactionId,
                 UUID.randomUUID());
 
         MdcUtils.setClientMDC(submissionKey.getSubmissionId(), xTransactionId);
 
         logger.info("attempting to upload original document [{}]", submissionKey.getSubmissionId());
-
-        if (!universalId.isPresent())
-            return new ResponseEntity(
-                    EfilingErrorBuilder.builder().errorResponse(ErrorResponse.INVALIDUNIVERSAL).create(),
-                    HttpStatus.FORBIDDEN);
 
         ResponseEntity response = storeDocuments(submissionKey, files);
 
@@ -113,7 +109,7 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
     public ResponseEntity<UploadSubmissionDocumentsResponse> uploadAdditionalSubmissionDocuments(UUID submissionId, UUID xTransactionId, List<MultipartFile> files) {
 
 
-        Optional<UUID> universalId = SecurityUtils.getUniversalIdFromContext();
+        Optional<String> universalId = SecurityUtils.getUniversalIdFromContext();
 
         if(!universalId.isPresent())
             return new ResponseEntity(
@@ -145,7 +141,7 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
     public ResponseEntity<UpdateDocumentResponse> updateDocumentProperties(UUID submissionId, UUID
             xTransactionId, UpdateDocumentRequest updateDocumentRequest) {
 
-        Optional<UUID> universalId = SecurityUtils.getUniversalIdFromContext();
+        Optional<String> universalId = SecurityUtils.getUniversalIdFromContext();
 
         if(!universalId.isPresent())
             return new ResponseEntity(
@@ -194,7 +190,7 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
 
         logger.info("getSubmission document for transaction [{}]", xTransactionId);
 
-        Optional<UUID> universalId = SecurityUtils.getUniversalIdFromContext();
+        Optional<String> universalId = SecurityUtils.getUniversalIdFromContext();
 
         if(!universalId.isPresent())
             return new ResponseEntity(
@@ -225,9 +221,7 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
 
         logger.info("Attempting to generate Url Request Received");
 
-        Optional<UUID> universalId = SecurityUtils.stringToUUID(xUserId);
-
-        if (!universalId.isPresent())
+        if (StringUtils.isBlank(xUserId))
             return new ResponseEntity(
                     EfilingErrorBuilder.builder().errorResponse(ErrorResponse.INVALIDUNIVERSAL).create(),
                     HttpStatus.FORBIDDEN);
@@ -251,13 +245,13 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
                     HttpStatus.BAD_REQUEST);
 
 
-        if (accountService.getCsoAccountDetails(universalId.get()) != null &&
-                !accountService.getCsoAccountDetails(universalId.get()).isFileRolePresent())
+        if (accountService.getCsoAccountDetails(xUserId) != null &&
+                !accountService.getCsoAccountDetails(xUserId).isFileRolePresent())
             return new ResponseEntity(
                     EfilingErrorBuilder.builder().errorResponse(ErrorResponse.INVALIDROLE).create(),
                     HttpStatus.FORBIDDEN);
 
-        SubmissionKey submissionKey = new SubmissionKey(universalId.get(), xTransactionId, submissionId);
+        SubmissionKey submissionKey = new SubmissionKey(xUserId, xTransactionId, submissionId);
 
         ResponseEntity response;
 
@@ -291,7 +285,7 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
     @RolesAllowed("efiling-user")
     public ResponseEntity<GetSubmissionConfigResponse> getSubmissionConfig(UUID submissionId, UUID xTransactionId) {
 
-        Optional<UUID> universalId = SecurityUtils.getUniversalIdFromContext();
+        Optional<String> universalId = SecurityUtils.getUniversalIdFromContext();
 
         if (!universalId.isPresent()) return new ResponseEntity(
                 EfilingErrorBuilder.builder().errorResponse(ErrorResponse.MISSING_UNIVERSAL_ID).create(), HttpStatus.FORBIDDEN);
@@ -327,7 +321,7 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
     @RolesAllowed("efiling-user")
     public ResponseEntity<FilingPackage> getSubmissionFilingPackage(UUID xTransactionId, UUID submissionId) {
 
-        Optional<UUID> universalId = SecurityUtils.getUniversalIdFromContext();
+        Optional<String> universalId = SecurityUtils.getUniversalIdFromContext();
 
         if(!universalId.isPresent())
             return new ResponseEntity(
@@ -356,7 +350,7 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
     @RolesAllowed("efiling-user")
     public ResponseEntity<Void> deleteSubmission(UUID submissionId, UUID xTransactionId) {
 
-        Optional<UUID> universalId = SecurityUtils.getUniversalIdFromContext();
+        Optional<String> universalId = SecurityUtils.getUniversalIdFromContext();
 
         if(!universalId.isPresent())
             return new ResponseEntity(
@@ -383,7 +377,7 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
     @RolesAllowed("efiling-user")
     public ResponseEntity<SubmitResponse> submit(UUID xTransactionId, UUID submissionId, Object body) {
 
-        Optional<UUID> universalId = SecurityUtils.getUniversalIdFromContext();
+        Optional<String> universalId = SecurityUtils.getUniversalIdFromContext();
 
         if(!universalId.isPresent())
             return new ResponseEntity(

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImpl.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionApiDelegateImpl.java
@@ -111,10 +111,14 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
 
         Optional<String> universalId = SecurityUtils.getUniversalIdFromContext();
 
-        if(!universalId.isPresent())
+        if(!universalId.isPresent()) {
+
+            logger.error("Universal ID is required");
+
             return new ResponseEntity(
                     EfilingErrorBuilder.builder().errorResponse(ErrorResponse.INVALIDUNIVERSAL).create(),
                     HttpStatus.FORBIDDEN);
+        }
 
         SubmissionKey submissionKey = new SubmissionKey(universalId.get(), xTransactionId, submissionId);
 
@@ -143,10 +147,14 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
 
         Optional<String> universalId = SecurityUtils.getUniversalIdFromContext();
 
-        if(!universalId.isPresent())
+        if(!universalId.isPresent()) {
+
+            logger.error("Universal ID is required");
+
             return new ResponseEntity(
                     EfilingErrorBuilder.builder().errorResponse(ErrorResponse.INVALIDUNIVERSAL).create(),
                     HttpStatus.FORBIDDEN);
+        }
 
         MdcUtils.setUserMDC(submissionId, xTransactionId);
 
@@ -192,10 +200,14 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
 
         Optional<String> universalId = SecurityUtils.getUniversalIdFromContext();
 
-        if(!universalId.isPresent())
+        if(!universalId.isPresent()) {
+
+            logger.error("Universal ID is required");
+
             return new ResponseEntity(
                     EfilingErrorBuilder.builder().errorResponse(ErrorResponse.INVALIDUNIVERSAL).create(),
                     HttpStatus.FORBIDDEN);
+        }
 
         SubmissionKey submissionKey = new SubmissionKey(universalId.get(), xTransactionId, submissionId);
 
@@ -221,10 +233,14 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
 
         logger.info("Attempting to generate Url Request Received");
 
-        if (StringUtils.isBlank(xUserId))
+        if (StringUtils.isBlank(xUserId)) {
+
+            logger.error("Universal ID is required");
+
             return new ResponseEntity(
                     EfilingErrorBuilder.builder().errorResponse(ErrorResponse.INVALIDUNIVERSAL).create(),
                     HttpStatus.FORBIDDEN);
+        }
 
         Optional<String> applicationCode = SecurityUtils.getApplicationCode();
 
@@ -287,8 +303,13 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
 
         Optional<String> universalId = SecurityUtils.getUniversalIdFromContext();
 
-        if (!universalId.isPresent()) return new ResponseEntity(
-                EfilingErrorBuilder.builder().errorResponse(ErrorResponse.MISSING_UNIVERSAL_ID).create(), HttpStatus.FORBIDDEN);
+        if (!universalId.isPresent()) {
+
+            logger.error("Universal ID is required");
+
+            return new ResponseEntity(
+                    EfilingErrorBuilder.builder().errorResponse(ErrorResponse.MISSING_UNIVERSAL_ID).create(), HttpStatus.FORBIDDEN);
+        }
 
         SubmissionKey submissionKey = new SubmissionKey(universalId.get(), xTransactionId, submissionId);
 
@@ -323,10 +344,14 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
 
         Optional<String> universalId = SecurityUtils.getUniversalIdFromContext();
 
-        if(!universalId.isPresent())
+        if(!universalId.isPresent()) {
+
+            logger.error("Universal ID is required");
+
             return new ResponseEntity(
                     EfilingErrorBuilder.builder().errorResponse(ErrorResponse.INVALIDUNIVERSAL).create(),
                     HttpStatus.FORBIDDEN);
+        }
 
         SubmissionKey submissionKey = new SubmissionKey(universalId.get(), xTransactionId, submissionId);
 
@@ -352,10 +377,14 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
 
         Optional<String> universalId = SecurityUtils.getUniversalIdFromContext();
 
-        if(!universalId.isPresent())
+        if(!universalId.isPresent()) {
+
+            logger.error("Universal ID is required");
+
             return new ResponseEntity(
                     EfilingErrorBuilder.builder().errorResponse(ErrorResponse.INVALIDUNIVERSAL).create(),
                     HttpStatus.FORBIDDEN);
+        }
 
         SubmissionKey submissionKey = new SubmissionKey(universalId.get(), xTransactionId, submissionId);
 
@@ -379,10 +408,14 @@ public class SubmissionApiDelegateImpl implements SubmissionApiDelegate {
 
         Optional<String> universalId = SecurityUtils.getUniversalIdFromContext();
 
-        if(!universalId.isPresent())
+        if(!universalId.isPresent()) {
+
+            logger.error("Universal ID is required");
+
             return new ResponseEntity(
                     EfilingErrorBuilder.builder().errorResponse(ErrorResponse.INVALIDUNIVERSAL).create(),
                     HttpStatus.FORBIDDEN);
+        }
 
         SubmissionKey submissionKey = new SubmissionKey(universalId.get(), xTransactionId, submissionId);
 

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionKey.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/SubmissionKey.java
@@ -4,17 +4,17 @@ import java.util.UUID;
 
 public class SubmissionKey {
 
-    private UUID universalId;
+    private String universalId;
     private UUID transactionId;
     private UUID submissionId;
 
-    public SubmissionKey(UUID universalId, UUID transactionId, UUID submissionId) {
+    public SubmissionKey(String universalId, UUID transactionId, UUID submissionId) {
         this.universalId = universalId;
         this.transactionId = transactionId;
         this.submissionId = submissionId;
     }
 
-    public UUID getUniversalId() {
+    public String getUniversalId() {
         return universalId;
     }
 

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/mappers/SubmissionMapper.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/mappers/SubmissionMapper.java
@@ -21,7 +21,7 @@ public interface SubmissionMapper {
     @Mapping(source = "filingPackage", target = "filingPackage")
     @Mapping(source = "expiryDate", target = "expiryDate")
     Submission toSubmission(
-            UUID universalId,
+            String universalId,
             UUID submissionId,
             UUID transactionId,
             GenerateUrlRequest generateUrlRequest,

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/models/Submission.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/submission/models/Submission.java
@@ -16,7 +16,7 @@ public class Submission {
 
     private UUID transactionId;
 
-    private UUID universalId;
+    private String universalId;
 
     private long expiryDate;
 
@@ -44,7 +44,7 @@ public class Submission {
     public Submission(
             @JsonProperty("id") UUID id,
             @JsonProperty("transactionId") UUID transactionId,
-            @JsonProperty("universalId") UUID universalId,
+            @JsonProperty("universalId") String universalId,
             @JsonProperty("clientAppName") String clientAppName,
             @JsonProperty("filingPackage") FilingPackage filingPackage,
             @JsonProperty("navigationUrls") NavigationUrls navigationUrls,
@@ -62,7 +62,7 @@ public class Submission {
 
     public UUID getTransactionId() { return transactionId; }
 
-    public UUID getUniversalId() { return universalId; }
+    public String getUniversalId() { return universalId; }
 
     public String getClientAppName() { return clientAppName; }
 
@@ -80,7 +80,7 @@ public class Submission {
 
         private UUID id;
         private UUID transactionId;
-        private UUID universalId;
+        private String universalId;
         private FilingPackage filingPackage;
         private NavigationUrls navigationUrls;
         private long expiryDate;
@@ -103,7 +103,7 @@ public class Submission {
             return this;
         }
 
-        public Builder universalId(UUID universalId) {
+        public Builder universalId(String universalId) {
             this.universalId = universalId;
             return this;
         }

--- a/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/utils/SecurityUtils.java
+++ b/src/backend/efiling-api/src/main/java/ca/bc/gov/open/jag/efilingapi/utils/SecurityUtils.java
@@ -5,17 +5,16 @@ import org.keycloak.KeycloakPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.Optional;
-import java.util.UUID;
 
 public class SecurityUtils {
 
     private SecurityUtils() {
     }
 
-    public static Optional<UUID> getUniversalIdFromContext() {
+    public static Optional<String> getUniversalIdFromContext() {
 
         try {
-            return stringToUUID(((KeycloakPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal())
+            return Optional.of(((KeycloakPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal())
                             .getKeycloakSecurityContext().getToken().getOtherClaims().get(Keys.UNIVERSAL_ID_CLAIM_KEY).toString());
         } catch (Exception e) {
             return Optional.empty();
@@ -35,16 +34,6 @@ public class SecurityUtils {
         try {
             return Optional.of(((KeycloakPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal())
                     .getKeycloakSecurityContext().getToken().getOtherClaims().get(Keys.CSO_APPLICATION_CODE).toString());
-        } catch (Exception e) {
-            return Optional.empty();
-        }
-    }
-
-    public static Optional<UUID> stringToUUID(String id) {
-        try {
-            return Optional.of(UUID.fromString(id.replaceFirst(
-                    "(\\p{XDigit}{8})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}+)", "$1-$2-$3-$4-$5"
-            )));
         } catch (Exception e) {
             return Optional.empty();
         }

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/TestHelpers.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/TestHelpers.java
@@ -1,14 +1,13 @@
 package ca.bc.gov.open.jag.efilingapi;
 
 
-import ca.bc.gov.open.jag.efilingapi.api.model.*;
-import ca.bc.gov.open.jag.efilingcommons.model.AccountDetails;
-import ca.bc.gov.open.jag.efilingapi.submission.models.*;
-import ca.bc.gov.open.jag.efilingcommons.model.Court;
-import ca.bc.gov.open.jag.efilingcommons.model.Document;
-import ca.bc.gov.open.jag.efilingcommons.model.DocumentType;
+import ca.bc.gov.open.jag.efilingapi.api.model.DocumentProperties;
+import ca.bc.gov.open.jag.efilingapi.api.model.InitialPackage;
+import ca.bc.gov.open.jag.efilingapi.api.model.NavigationUrls;
+import ca.bc.gov.open.jag.efilingapi.submission.models.Submission;
+import ca.bc.gov.open.jag.efilingapi.submission.models.SubmissionConstants;
+import ca.bc.gov.open.jag.efilingcommons.model.*;
 import ca.bc.gov.open.jag.efilingcommons.submission.models.FilingPackage;
-import ca.bc.gov.open.jag.efilingcommons.model.Party;
 import com.google.gson.JsonObject;
 
 import java.math.BigDecimal;
@@ -24,6 +23,12 @@ public class TestHelpers {
     public static final UUID CASE_3 = UUID.fromString("77da92db-0791-491e-8c58-1a969e67d2fb");
     public static final UUID CASE_4 = UUID.fromString("77da92db-0791-491e-8c58-1a969e67d2fc");
     public static final UUID CASE_5 = UUID.fromString("77da92db-0791-491e-8c58-1a969e67d2fd");
+
+    public static final String CASE_1_STRING = CASE_1.toString();
+    public static final String CASE_2_STRING = CASE_2.toString();
+    public static final String CASE_3_STRING = CASE_3.toString();
+    public static final String CASE_4_STRING = CASE_4.toString();
+    public static final String CASE_5_STRING = CASE_5.toString();
 
     public static final String DIVISION = "DIVISION";
     public static final String FILENUMBER = "FILENUMBER";

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/account/AccountConfigTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/account/AccountConfigTest.java
@@ -27,7 +27,7 @@ public class AccountConfigTest {
         public EfilingAccountService efilingAccountService() {
             return new EfilingAccountService() {
                 @Override
-                public AccountDetails getAccountDetails(UUID userGuid) {
+                public AccountDetails getAccountDetails(String userGuid) {
                     return null;
                 }
 

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/account/CsoAccountApiDelegateImplTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/account/CsoAccountApiDelegateImplTest.java
@@ -74,29 +74,28 @@ public class CsoAccountApiDelegateImplTest {
                 .accountId(BigDecimal.ONE)
                 .clientId(BigDecimal.TEN)
                 .cardRegistered(true)
-                .universalId(UUID.randomUUID())
                 .internalClientNumber(INTERNAL_CLIENT_NUMBER)
-                .universalId(TestHelpers.CASE_1).create();
+                .universalId(TestHelpers.CASE_1_STRING).create();
 
         Mockito
                 .doReturn(accountDetails)
                 .when(accountServiceMock)
-                .createAccount(Mockito.eq(TestHelpers.CASE_1), Mockito.any());
+                .createAccount(Mockito.eq(TestHelpers.CASE_1_STRING), Mockito.any());
 
         Mockito
                 .doReturn(accountDetails)
                 .when(accountServiceMock)
-                .getCsoAccountDetails(Mockito.eq(TestHelpers.CASE_1));
+                .getCsoAccountDetails(Mockito.eq(TestHelpers.CASE_1_STRING));
 
         Mockito
                 .doReturn(null)
                 .when(accountServiceMock)
-                .getCsoAccountDetails(Mockito.eq(TestHelpers.CASE_2));
+                .getCsoAccountDetails(Mockito.eq(TestHelpers.CASE_2_STRING));
 
         Mockito
                 .doThrow(new EfilingAccountServiceException("random"))
                 .when(accountServiceMock)
-                .createAccount(Mockito.eq(TestHelpers.CASE_2), Mockito.any());
+                .createAccount(Mockito.eq(TestHelpers.CASE_2_STRING), Mockito.any());
 
 
         Mockito.doNothing().when(accountServiceMock).updateClient(

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/account/service/AccountServiceImplTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/account/service/AccountServiceImplTest.java
@@ -39,7 +39,7 @@ public class AccountServiceImplTest {
 
 
         Mockito
-                .when(efilingAccountServiceMock.getAccountDetails(Mockito.eq(TestHelpers.CASE_1)))
+                .when(efilingAccountServiceMock.getAccountDetails(Mockito.eq(TestHelpers.CASE_1_STRING)))
                 .thenReturn(accountDetails);
 
         Mockito
@@ -59,7 +59,7 @@ public class AccountServiceImplTest {
     @DisplayName("OK: should return an account")
     public void withRequestShouldReturnAnAccount() {
 
-        AccountDetails actual = sut.getCsoAccountDetails(TestHelpers.CASE_1);
+        AccountDetails actual = sut.getCsoAccountDetails(TestHelpers.CASE_1_STRING);
         Assertions.assertEquals(BigDecimal.TEN, actual.getAccountId());
 
     }
@@ -80,7 +80,7 @@ public class AccountServiceImplTest {
     @Test
     @DisplayName("OK: should Create an account")
     public void withRequestShouldCreateAnAccount() {
-        AccountDetails actual = sut.createAccount(UUID.randomUUID(), new CreateCsoAccountRequest());
+        AccountDetails actual = sut.createAccount(UUID.randomUUID().toString(), new CreateCsoAccountRequest());
         Mockito.verify(efilingAccountServiceMock,Mockito.times(1)).createAccount(any());
 
         Assertions.assertEquals(BigDecimal.TEN, actual.getAccountId());

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/document/DocumentStoreImplTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/document/DocumentStoreImplTest.java
@@ -50,7 +50,7 @@ public class DocumentStoreImplTest {
     @DisplayName("OK: put document should return byte array")
     public void withoutCacheShouldReturnIt() {
 
-        byte[] actual = sut.put(new SubmissionKey(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()), "filename.txt", DUMMY_CONTENT.getBytes());
+        byte[] actual = sut.put(new SubmissionKey(UUID.randomUUID().toString(), UUID.randomUUID(), UUID.randomUUID()), "filename.txt", DUMMY_CONTENT.getBytes());
 
         Assertions.assertEquals(DUMMY_CONTENT, new String(actual));
     }
@@ -58,13 +58,13 @@ public class DocumentStoreImplTest {
     @Test
     @DisplayName("OK: get document by Id should return null")
     public void withoutCacheShouldReturnNull() {
-        Assertions.assertNull(sut.get(new SubmissionKey(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()), "filename.txt"));
+        Assertions.assertNull(sut.get(new SubmissionKey(UUID.randomUUID().toString(), UUID.randomUUID(), UUID.randomUUID()), "filename.txt"));
     }
 
     @Test
     @DisplayName("OK: evict should delete submission")
     public void withoutCacheNotThrowException() {
-        Assertions.assertDoesNotThrow(() -> sut.evict(new SubmissionKey(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()), "filename.txt"));
+        Assertions.assertDoesNotThrow(() -> sut.evict(new SubmissionKey(UUID.randomUUID().toString(), UUID.randomUUID(), UUID.randomUUID()), "filename.txt"));
     }
 
     @Test

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/filingpackage/FilingPackageConfigTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/filingpackage/FilingPackageConfigTest.java
@@ -36,7 +36,7 @@ public class FilingPackageConfigTest {
             return new AccountService() {
 
                 @Override
-                public AccountDetails getCsoAccountDetails(UUID universalId) {
+                public AccountDetails getCsoAccountDetails(String universalId) {
                     return null;
                 }
 
@@ -46,7 +46,7 @@ public class FilingPackageConfigTest {
                 }
 
                 @Override
-                public AccountDetails createAccount(UUID universalId, CreateCsoAccountRequest createAccountRequest) {
+                public AccountDetails createAccount(String universalId, CreateCsoAccountRequest createAccountRequest) {
                     return null;
                 }
             };

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/filingpackage/filingpackageApiDelegateImpl/GetFilingPackageTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/filingpackage/filingpackageApiDelegateImpl/GetFilingPackageTest.java
@@ -1,6 +1,7 @@
 package ca.bc.gov.open.jag.efilingapi.filingpackage.filingpackageApiDelegateImpl;
 
 import ca.bc.gov.open.jag.efilingapi.Keys;
+import ca.bc.gov.open.jag.efilingapi.TestHelpers;
 import ca.bc.gov.open.jag.efilingapi.api.model.FilingPackage;
 import ca.bc.gov.open.jag.efilingapi.filingpackage.FilingpackageApiDelegateImpl;
 import ca.bc.gov.open.jag.efilingapi.filingpackage.service.FilingPackageService;
@@ -22,15 +23,10 @@ import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
-
-import static org.mockito.AdditionalMatchers.eq;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @DisplayName("FilepackageApiDelegateImplTest")
 public class GetFilingPackageTest {
-    public static final UUID CASE_1 = UUID.randomUUID();
-    public static final UUID CASE_2 = UUID.randomUUID();
 
 
     FilingpackageApiDelegateImpl sut;
@@ -65,10 +61,10 @@ public class GetFilingPackageTest {
 
         SecurityContextHolder.setContext(securityContextMock);
 
-        Mockito.when(filingPackageService.getCSOFilingPackage(ArgumentMatchers.eq(CASE_1), ArgumentMatchers.eq(BigDecimal.ONE))).thenReturn(Optional.of(new FilingPackage()));
+        Mockito.when(filingPackageService.getCSOFilingPackage(ArgumentMatchers.eq(TestHelpers.CASE_1_STRING), ArgumentMatchers.eq(BigDecimal.ONE))).thenReturn(Optional.of(new FilingPackage()));
 
 
-        Mockito.when(filingPackageService.getCSOFilingPackage(ArgumentMatchers.eq(CASE_2), ArgumentMatchers.eq(BigDecimal.TEN))).thenReturn(Optional.empty());
+        Mockito.when(filingPackageService.getCSOFilingPackage(ArgumentMatchers.eq(TestHelpers.CASE_2_STRING), ArgumentMatchers.eq(BigDecimal.TEN))).thenReturn(Optional.empty());
 
         sut = new FilingpackageApiDelegateImpl(filingPackageService);
     }
@@ -78,7 +74,7 @@ public class GetFilingPackageTest {
     public void withValidRequestReturnFilingPackage() {
 
         Map<String, Object> otherClaims = new HashMap<>();
-        otherClaims.put(Keys.UNIVERSAL_ID_CLAIM_KEY, CASE_1);
+        otherClaims.put(Keys.UNIVERSAL_ID_CLAIM_KEY, TestHelpers.CASE_1_STRING);
         Mockito.when(tokenMock.getOtherClaims()).thenReturn(otherClaims);
 
         ResponseEntity<FilingPackage> result = sut.getFilingPackage(BigDecimal.ONE);
@@ -104,7 +100,7 @@ public class GetFilingPackageTest {
     public void withValidRequestFilingPackageNotFound() {
 
         Map<String, Object> otherClaims = new HashMap<>();
-        otherClaims.put(Keys.UNIVERSAL_ID_CLAIM_KEY, CASE_2);
+        otherClaims.put(Keys.UNIVERSAL_ID_CLAIM_KEY, TestHelpers.CASE_2_STRING);
         Mockito.when(tokenMock.getOtherClaims()).thenReturn(otherClaims);
 
         ResponseEntity<FilingPackage> result = sut.getFilingPackage(BigDecimal.TEN);

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/filingpackage/service/filingPackageServiceImpl/GetCSOFilingPackage.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/filingpackage/service/filingPackageServiceImpl/GetCSOFilingPackage.java
@@ -63,9 +63,9 @@ public class GetCSOFilingPackage {
 
         MockitoAnnotations.openMocks(this);
 
-        Mockito.when(accountServiceMock.getCsoAccountDetails(ArgumentMatchers.eq(TestHelpers.CASE_1))).thenReturn(createAccount(BigDecimal.ONE));
+        Mockito.when(accountServiceMock.getCsoAccountDetails(ArgumentMatchers.eq(TestHelpers.CASE_1_STRING))).thenReturn(createAccount(BigDecimal.ONE));
 
-        Mockito.when(accountServiceMock.getCsoAccountDetails(ArgumentMatchers.eq(TestHelpers.CASE_2))).thenReturn(createAccount(null));
+        Mockito.when(accountServiceMock.getCsoAccountDetails(ArgumentMatchers.eq(TestHelpers.CASE_2_STRING))).thenReturn(createAccount(null));
 
         sut = new FilingPackageServiceImpl(efilingReviewServiceMock, accountServiceMock, new FilingPackageMapperImpl());
     }
@@ -76,7 +76,7 @@ public class GetCSOFilingPackage {
 
         Mockito.when(efilingReviewServiceMock.findStatusByPackage(ArgumentMatchers.any())).thenReturn(Optional.of(createFilingPackage()));
 
-        Optional<FilingPackage> result = sut.getCSOFilingPackage(TestHelpers.CASE_1, BigDecimal.ONE);
+        Optional<FilingPackage> result = sut.getCSOFilingPackage(TestHelpers.CASE_1_STRING, BigDecimal.ONE);
 
         Assertions.assertTrue(result.isPresent());
         //FilingPackage
@@ -128,7 +128,7 @@ public class GetCSOFilingPackage {
     @Test
     @DisplayName("Not found: missing account")
     public void withValidRequestButMissingAccountReturnEmpty() {
-        Optional<FilingPackage> result = sut.getCSOFilingPackage(TestHelpers.CASE_2, BigDecimal.ONE);
+        Optional<FilingPackage> result = sut.getCSOFilingPackage(TestHelpers.CASE_2_STRING, BigDecimal.ONE);
 
         Assertions.assertFalse(result.isPresent());
     }
@@ -140,7 +140,7 @@ public class GetCSOFilingPackage {
 
         Mockito.when(efilingReviewServiceMock.findStatusByPackage(ArgumentMatchers.any())).thenReturn(Optional.empty());
 
-        Optional<FilingPackage> result = sut.getCSOFilingPackage(TestHelpers.CASE_1, BigDecimal.TEN);
+        Optional<FilingPackage> result = sut.getCSOFilingPackage(TestHelpers.CASE_1_STRING, BigDecimal.TEN);
 
         Assertions.assertFalse(result.isPresent());
     }
@@ -152,9 +152,9 @@ public class GetCSOFilingPackage {
                 .accountId(BigDecimal.ONE)
                 .clientId(clientId)
                 .cardRegistered(true)
-                .universalId(UUID.randomUUID())
+                .universalId(UUID.randomUUID().toString())
                 .internalClientNumber(null)
-                .universalId(TestHelpers.CASE_1).create();
+                .universalId(TestHelpers.CASE_1_STRING).create();
 
     }
 

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/models/SubmissionTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/models/SubmissionTest.java
@@ -16,13 +16,6 @@ public class SubmissionTest {
     private static final String CASE_1 = "CASE1";
     private static final String CANCEL = "CANCEL";
     private static final String ERROR = "ERROR";
-    private static final String TYPE = "TYPE";
-    private static final String FIRST_NAME = "firstName";
-    private static final String LAST_NAME = "lastName";
-    private static final String MIDDLE_NAME = "middleName";
-    private static final String EMAIL = "email";
-    private static final String DISPLAYNAME = "DISPLAYNAME";
-    private static final String INTERNAL_CLIENT_NUMBER = "INTERNALCLIENT";
     private static final String CLIENT_APP_NAME = "appName";
 
     @Test
@@ -32,7 +25,7 @@ public class SubmissionTest {
         Submission actual = new Submission(
                 UUID.randomUUID(),
                 UUID.randomUUID(),
-                UUID.randomUUID(),
+                UUID.randomUUID().toString(),
                 CLIENT_APP_NAME,
                 TestHelpers.createPackage(TestHelpers.createCourt(), TestHelpers.createDocumentList(), TestHelpers.createPartyList()),
                 TestHelpers.createNavigation(CASE_1, CANCEL, ERROR),

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/service/submissionServiceImpl/CreateSubmissionTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/service/submissionServiceImpl/CreateSubmissionTest.java
@@ -92,7 +92,7 @@ public class CreateSubmissionTest {
                         .fileRolePresent(true)
                         .accountId(BigDecimal.ONE)
                         .cardRegistered(true)
-                        .universalId(UUID.randomUUID())
+                        .universalId(UUID.randomUUID().toString())
                         .clientId(BigDecimal.TEN)
                         .internalClientNumber(INTERNAL_CLIENT_NUMBER)
                         .create(), false);
@@ -116,7 +116,7 @@ public class CreateSubmissionTest {
                         .fileRolePresent(true)
                         .accountId(BigDecimal.ONE)
                         .cardRegistered(true)
-                        .universalId(UUID.randomUUID())
+                        .universalId(UUID.randomUUID().toString())
                         .clientId(BigDecimal.TEN)
                         .internalClientNumber(INTERNAL_CLIENT_NUMBER)
                         .create(), true);

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/service/submissionServiceImpl/GenerateFromRequestTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/service/submissionServiceImpl/GenerateFromRequestTest.java
@@ -110,7 +110,7 @@ public class GenerateFromRequestTest {
         Mockito.when(efilingCourtService.checkValidCourtFileNumber(any(), any(), any(), any(), any())).thenReturn(true);
         Mockito.when(efilingDocumentService.getDocumentTypes(any(), any())).thenReturn(TestHelpers.createValidDocumentTypesList());
 
-        Submission actual = sut.generateFromRequest(APP_CODE, new SubmissionKey(TestHelpers.CASE_1, TestHelpers.CASE_1, TestHelpers.CASE_1), request);
+        Submission actual = sut.generateFromRequest(APP_CODE, new SubmissionKey(TestHelpers.CASE_1_STRING, TestHelpers.CASE_1, TestHelpers.CASE_1), request);
 
         Assertions.assertEquals(TestHelpers.ERROR_URL, actual.getNavigationUrls().getError());
         Assertions.assertEquals(TestHelpers.CANCEL_URL, actual.getNavigationUrls().getCancel());
@@ -170,7 +170,7 @@ public class GenerateFromRequestTest {
         Mockito.when(efilingLookupService.getValidPartyRoles(any(), any(), any())).thenReturn(TestHelpers.createValidPartyRoles());
         Mockito.when(efilingDocumentService.getDocumentTypes(any(), any())).thenReturn(TestHelpers.createValidDocumentTypesList());
 
-        Submission actual = sut.generateFromRequest(APP_CODE, new SubmissionKey(TestHelpers.CASE_1, TestHelpers.CASE_1, TestHelpers.CASE_1), request);
+        Submission actual = sut.generateFromRequest(APP_CODE, new SubmissionKey(TestHelpers.CASE_1_STRING, TestHelpers.CASE_1, TestHelpers.CASE_1), request);
 
         Assertions.assertEquals(TestHelpers.ERROR_URL, actual.getNavigationUrls().getError());
         Assertions.assertEquals(TestHelpers.CANCEL_URL, actual.getNavigationUrls().getCancel());
@@ -225,7 +225,7 @@ public class GenerateFromRequestTest {
         Mockito.when(efilingCourtService.checkValidCourtFileNumber(any(), any(), any(), any(), any())).thenReturn(true);
         Mockito.when(efilingDocumentService.getDocumentTypes(any(), any())).thenReturn(TestHelpers.createValidDocumentTypesList());
 
-        Submission actual = sut.generateFromRequest(APP_CODE, new SubmissionKey(TestHelpers.CASE_1, TestHelpers.CASE_1, TestHelpers.CASE_1), request);
+        Submission actual = sut.generateFromRequest(APP_CODE, new SubmissionKey(TestHelpers.CASE_1_STRING, TestHelpers.CASE_1, TestHelpers.CASE_1), request);
 
         Assertions.assertEquals(TestHelpers.ERROR_URL, actual.getNavigationUrls().getError());
         Assertions.assertEquals(TestHelpers.CANCEL_URL, actual.getNavigationUrls().getCancel());
@@ -277,7 +277,7 @@ public class GenerateFromRequestTest {
         Mockito.when(efilingCourtService.checkValidCourtFileNumber(any(), any(), any(), any(), any())).thenReturn(true);
         Mockito.when(efilingDocumentService.getDocumentTypes(any(), any())).thenReturn(TestHelpers.createValidDocumentTypesList());
 
-        Assertions.assertThrows(StoreException.class, () -> sut.generateFromRequest(APP_CODE, new SubmissionKey(TestHelpers.CASE_2, TestHelpers.CASE_2, TestHelpers.CASE_2), request));
+        Assertions.assertThrows(StoreException.class, () -> sut.generateFromRequest(APP_CODE, new SubmissionKey(TestHelpers.CASE_2_STRING, TestHelpers.CASE_2, TestHelpers.CASE_2), request));
     }
 
     private void configureCase1(ServiceFees fee) {

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/service/submissionServiceImpl/UpdateDocumentsTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/service/submissionServiceImpl/UpdateDocumentsTest.java
@@ -85,7 +85,7 @@ public class UpdateDocumentsTest {
         updateDocumentRequest.addDocumentsItem(documentProperties);
 
         Submission submission = TestHelpers.buildSubmission();
-        Submission actual = sut.updateDocuments(submission, updateDocumentRequest, new SubmissionKey(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()));
+        Submission actual = sut.updateDocuments(submission, updateDocumentRequest, new SubmissionKey(UUID.randomUUID().toString(), UUID.randomUUID(), UUID.randomUUID()));
 
         Assertions.assertEquals(2, actual.getFilingPackage().getDocuments().size());
         Assertions.assertEquals(TestHelpers.DESCRIPTION, actual.getFilingPackage().getDocuments().get(0).getDescription());

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/service/submissionStore/DeleteByKeyTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/service/submissionStore/DeleteByKeyTest.java
@@ -22,7 +22,7 @@ public class DeleteByKeyTest {
     @Test
     @DisplayName("OK: evict should do nothing")
     public void testEvict() {
-        Assertions.assertDoesNotThrow(() -> sut.evict(new SubmissionKey( UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID())));
+        Assertions.assertDoesNotThrow(() -> sut.evict(new SubmissionKey( UUID.randomUUID().toString(), UUID.randomUUID(), UUID.randomUUID())));
     }
 
 }

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/service/submissionStore/GetByKeyTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/service/submissionStore/GetByKeyTest.java
@@ -32,7 +32,7 @@ public class GetByKeyTest {
     @DisplayName("CASE 1: without cache always return empty")
     public void withExistingIdShouldReturnSubmission() {
 
-        Optional<Submission> actual = sut.get(new SubmissionKey(TestHelpers.CASE_1, UUID.randomUUID(), UUID.randomUUID()));
+        Optional<Submission> actual = sut.get(new SubmissionKey(TestHelpers.CASE_1_STRING, UUID.randomUUID(), UUID.randomUUID()));
         Assertions.assertEquals(Optional.empty(), actual);
 
     }

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/submissionApiDelegateImpl/DeleteSubmissionTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/submissionApiDelegateImpl/DeleteSubmissionTest.java
@@ -89,7 +89,7 @@ public class DeleteSubmissionTest {
 
         Submission submission = Submission
                 .builder()
-                .universalId(UUID.randomUUID())
+                .universalId(UUID.randomUUID().toString())
                 .filingPackage(TestHelpers.createPackage(TestHelpers.createCourt(), createDocumentList(), TestHelpers.createPartyList()))
                 .create();
 

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/submissionApiDelegateImpl/GenerateUrlTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/submissionApiDelegateImpl/GenerateUrlTest.java
@@ -1,7 +1,7 @@
 package ca.bc.gov.open.jag.efilingapi.submission.submissionApiDelegateImpl;
 
-import ca.bc.gov.open.jag.efilingapi.Keys;
 import ca.bc.gov.open.clamav.starter.ClamAvService;
+import ca.bc.gov.open.jag.efilingapi.Keys;
 import ca.bc.gov.open.jag.efilingapi.TestHelpers;
 import ca.bc.gov.open.jag.efilingapi.account.service.AccountService;
 import ca.bc.gov.open.jag.efilingapi.api.model.*;
@@ -36,10 +36,11 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import javax.validation.Valid;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
-import static ca.bc.gov.open.jag.efilingapi.error.ErrorResponse.INVALIDUNIVERSAL;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @DisplayName("SubmissionApiDelegateImpl test suite")
@@ -47,8 +48,8 @@ public class GenerateUrlTest {
 
     private static final String CODE = "CODE";
     private static final String CLIENT_APP_NAME = "clientAppName";
-    private static final UUID USER_WITH_CSO_ACCOUNT = UUID.fromString("1593769b-ac4b-43d9-9e81-38877eefcca5");
-    private static final UUID USER_WITH_NO_CSO_ACCOUNT = UUID.fromString("1593769b-ac4b-43d9-9e81-38877eefcca6");
+    private static final String USER_WITH_CSO_ACCOUNT = "1593769b-ac4b-43d9-9e81-38877eefcca5";
+    private static final String USER_WITH_NO_CSO_ACCOUNT = "1593769b-ac4b-43d9-9e81-38877eefcca6";
 
 
     private SubmissionApiDelegateImpl sut;
@@ -379,18 +380,6 @@ public class GenerateUrlTest {
         Assertions.assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, actual.getStatusCode());
         Assertions.assertEquals(ErrorResponse.DOCUMENT_TYPE_ERROR.getErrorCode(), actualError.getError());
         Assertions.assertEquals(ErrorResponse.DOCUMENT_TYPE_ERROR.getErrorMessage(), actualError.getMessage());
-    }
-
-    @Test
-    @DisplayName("403: with invalid userId then return forbidden 403")
-    public void withInvalidUserIDThenReturnForbidden() {
-
-
-        ResponseEntity actual = sut.generateUrl(UUID.randomUUID(), "BADUUID", UUID.randomUUID(), null);
-
-        Assertions.assertEquals(HttpStatus.FORBIDDEN, actual.getStatusCode());
-        Assertions.assertEquals(INVALIDUNIVERSAL.getErrorCode(), ((EfilingError)actual.getBody()).getError());
-        Assertions.assertEquals(INVALIDUNIVERSAL.getErrorMessage(), ((EfilingError)actual.getBody()).getMessage());
     }
 
 

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/submissionApiDelegateImpl/GenerateUrlTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/submissionApiDelegateImpl/GenerateUrlTest.java
@@ -51,7 +51,6 @@ public class GenerateUrlTest {
     private static final String USER_WITH_CSO_ACCOUNT = "1593769b-ac4b-43d9-9e81-38877eefcca5";
     private static final String USER_WITH_NO_CSO_ACCOUNT = "1593769b-ac4b-43d9-9e81-38877eefcca6";
 
-
     private SubmissionApiDelegateImpl sut;
 
     @Mock
@@ -380,6 +379,28 @@ public class GenerateUrlTest {
         Assertions.assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, actual.getStatusCode());
         Assertions.assertEquals(ErrorResponse.DOCUMENT_TYPE_ERROR.getErrorCode(), actualError.getError());
         Assertions.assertEquals(ErrorResponse.DOCUMENT_TYPE_ERROR.getErrorMessage(), actualError.getMessage());
+    }
+
+    @Test
+    @DisplayName("403: with no user id it should return forbidden")
+    public void withNoUserIdShouldReturnForbidden() {
+        @Valid GenerateUrlRequest generateUrlRequest = new GenerateUrlRequest();
+
+        generateUrlRequest.setClientAppName(CLIENT_APP_NAME);
+        generateUrlRequest.setNavigationUrls(TestHelpers.createNavigation(TestHelpers.SUCCESS_URL, TestHelpers.CANCEL_URL, TestHelpers.ERROR_URL));
+        InitialPackage initialPackage = new InitialPackage();
+        CourtBase court = new CourtBase();
+        court.setLocation("valid");
+        initialPackage.setCourt(court);
+        generateUrlRequest.setFilingPackage(initialPackage);
+
+        ResponseEntity actual = sut.generateUrl(UUID.randomUUID(), "  ", TestHelpers.CASE_5, generateUrlRequest);
+
+        EfilingError actualError = (EfilingError) actual.getBody();
+
+        Assertions.assertEquals(HttpStatus.FORBIDDEN, actual.getStatusCode());
+        Assertions.assertEquals(ErrorResponse.INVALIDUNIVERSAL.getErrorCode(), actualError.getError());
+        Assertions.assertEquals(ErrorResponse.INVALIDUNIVERSAL.getErrorMessage(), actualError.getMessage());
     }
 
 

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/submissionApiDelegateImpl/GetSubmissionTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/submissionApiDelegateImpl/GetSubmissionTest.java
@@ -128,12 +128,12 @@ public class GetSubmissionTest {
                 .get(ArgumentMatchers.argThat(x -> x.getSubmissionId().equals(TestHelpers.CASE_4)));
 
 
-        Mockito.when(accountServiceMock.getCsoAccountDetails(Mockito.eq(TestHelpers.CASE_2)))
+        Mockito.when(accountServiceMock.getCsoAccountDetails(Mockito.eq(TestHelpers.CASE_2_STRING)))
                 .thenReturn(AccountDetails
                         .builder()
                         .clientId(BigDecimal.TEN)
                         .internalClientNumber(INTERNAL_CLIENT_NUMBER)
-                        .universalId(TestHelpers.CASE_2)
+                        .universalId(TestHelpers.CASE_2_STRING)
                         .accountId(BigDecimal.TEN)
                         .fileRolePresent(true)
                         .cardRegistered(true)
@@ -152,7 +152,9 @@ public class GetSubmissionTest {
         otherClaims.put(Keys.UNIVERSAL_ID_CLAIM_KEY, UUID.randomUUID());
         Mockito.when(tokenMock.getOtherClaims()).thenReturn(otherClaims);
 
-        ResponseEntity<GetSubmissionConfigResponse> actual = sut.getSubmissionConfig(UUID.randomUUID(), TestHelpers.CASE_1);
+        ResponseEntity<GetSubmissionConfigResponse> actual = sut.getSubmissionConfig(
+                UUID.randomUUID(), 
+                TestHelpers.CASE_1);
         assertEquals(HttpStatus.NOT_FOUND, actual.getStatusCode());
     }
 
@@ -164,7 +166,9 @@ public class GetSubmissionTest {
         otherClaims.put(Keys.UNIVERSAL_ID_CLAIM_KEY, TestHelpers.CASE_2);
         Mockito.when(tokenMock.getOtherClaims()).thenReturn(otherClaims);
 
-        ResponseEntity<GetSubmissionConfigResponse> actual = sut.getSubmissionConfig(TestHelpers.CASE_2, TestHelpers.CASE_2);
+        ResponseEntity<GetSubmissionConfigResponse> actual = sut.getSubmissionConfig(UUID.fromString(
+                TestHelpers.CASE_2_STRING), 
+                TestHelpers.CASE_2);
         assertEquals(HttpStatus.OK, actual.getStatusCode());
         assertEquals(TestHelpers.SUCCESS_URL, actual.getBody().getNavigationUrls().getSuccess());
         assertEquals(TestHelpers.CANCEL_URL, actual.getBody().getNavigationUrls().getCancel());
@@ -182,7 +186,9 @@ public class GetSubmissionTest {
         otherClaims.put(Keys.UNIVERSAL_ID_CLAIM_KEY, UUID.randomUUID());
         Mockito.when(tokenMock.getOtherClaims()).thenReturn(otherClaims);
 
-        ResponseEntity<GetSubmissionConfigResponse> actual = sut.getSubmissionConfig(TestHelpers.CASE_3, UUID.randomUUID());
+        ResponseEntity<GetSubmissionConfigResponse> actual = sut.getSubmissionConfig(
+                TestHelpers.CASE_3, 
+                UUID.randomUUID());
         assertEquals(HttpStatus.OK, actual.getStatusCode());
         assertEquals(TestHelpers.SUCCESS_URL, actual.getBody().getNavigationUrls().getSuccess());
         assertEquals(TestHelpers.CANCEL_URL, actual.getBody().getNavigationUrls().getCancel());
@@ -198,7 +204,9 @@ public class GetSubmissionTest {
         otherClaims.put(Keys.UNIVERSAL_ID_CLAIM_KEY, UUID.randomUUID());
         Mockito.when(tokenMock.getOtherClaims()).thenReturn(otherClaims);
 
-        ResponseEntity<GetSubmissionConfigResponse> actual = sut.getSubmissionConfig(TestHelpers.CASE_4, UUID.randomUUID());
+        ResponseEntity<GetSubmissionConfigResponse> actual = sut.getSubmissionConfig(
+                TestHelpers.CASE_4, 
+                UUID.randomUUID());
         assertEquals(HttpStatus.OK, actual.getStatusCode());
         assertEquals(TestHelpers.SUCCESS_URL, actual.getBody().getNavigationUrls().getSuccess());
         assertEquals(TestHelpers.CANCEL_URL, actual.getBody().getNavigationUrls().getCancel());
@@ -214,8 +222,8 @@ public class GetSubmissionTest {
 
         ResponseEntity actual = sut.getSubmissionConfig(UUID.randomUUID(), TestHelpers.CASE_5);
         assertEquals(HttpStatus.FORBIDDEN, actual.getStatusCode());
-        assertEquals("MISSING_UNIVERSAL_ID", ((EfilingError)actual.getBody()).getError());
-        assertEquals("universal-id claim missing in jwt token.", ((EfilingError)actual.getBody()).getMessage());
+        assertEquals("MISSING_UNIVERSAL_ID", ((EfilingError) actual.getBody()).getError());
+        assertEquals("universal-id claim missing in jwt token.", ((EfilingError) actual.getBody()).getMessage());
 
 
     }

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/submissionApiDelegateImpl/UploadAdditionalSubmissionDocumentsTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/submissionApiDelegateImpl/UploadAdditionalSubmissionDocumentsTest.java
@@ -259,4 +259,28 @@ public class UploadAdditionalSubmissionDocumentsTest {
         Assertions.assertEquals(DOCUMENT_STORAGE_FAILURE.getErrorCode(), ((EfilingError)actual.getBody()).getError());
         Assertions.assertEquals(DOCUMENT_STORAGE_FAILURE.getErrorMessage(), ((EfilingError)actual.getBody()).getMessage());
     }
+
+    @Test
+    @DisplayName("403: without universalId should return forbidden")
+    public void withoutUniversalIdShouldReturnForbidden() throws VirusDetectedException, IOException {
+
+        Map<String, Object> otherClaims = new HashMap<>();
+        Mockito.when(tokenMock.getOtherClaims()).thenReturn(otherClaims);
+
+        File file = new File("src/test/resources/test.pdf");
+
+        List<MultipartFile> files = new ArrayList<>();
+        MultipartFile multipartFile = new MockMultipartFile("test.pdf", new FileInputStream(file));
+        files.add(multipartFile);
+        files.add(multipartFile);
+
+        Mockito.doThrow(VirusDetectedException.class).when(clamAvServiceMock).scan(any());
+
+        ResponseEntity actual = sut.uploadAdditionalSubmissionDocuments(TestHelpers.CASE_1, UUID.randomUUID(), files);
+
+        Assertions.assertEquals(HttpStatus.FORBIDDEN, actual.getStatusCode());
+        Assertions.assertEquals(INVALIDUNIVERSAL.getErrorCode(), ((EfilingError)actual.getBody()).getError());
+        Assertions.assertEquals(INVALIDUNIVERSAL.getErrorMessage(), ((EfilingError)actual.getBody()).getMessage());
+    }
+
 }

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/submissionApiDelegateImpl/UploadSubmissionDocumentsTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/submissionApiDelegateImpl/UploadSubmissionDocumentsTest.java
@@ -184,4 +184,25 @@ public class UploadSubmissionDocumentsTest {
         Assertions.assertEquals(DOCUMENT_STORAGE_FAILURE.getErrorMessage(), ((EfilingError)actual.getBody()).getMessage());
     }
 
+    @Test
+    @DisplayName("400: with missing id should return 400")
+    public void withBlankIdShouldReturn400() throws VirusDetectedException, IOException {
+
+
+        File file = new File("src/test/resources/test.pdf");
+
+        List<MultipartFile> files = new ArrayList<>();
+        MultipartFile multipartFile = new MockMultipartFile("test.pdf", new FileInputStream(file));
+        files.add(multipartFile);
+        files.add(multipartFile);
+
+        Mockito.doThrow(VirusDetectedException.class).when(clamAvServiceMock).scan(any());
+
+        ResponseEntity actual = sut.uploadSubmissionDocuments(UUID.randomUUID(), "  ", files);
+
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST, actual.getStatusCode());
+        Assertions.assertEquals(INVALIDUNIVERSAL.getErrorCode(), ((EfilingError)actual.getBody()).getError());
+        Assertions.assertEquals(INVALIDUNIVERSAL.getErrorMessage(), ((EfilingError)actual.getBody()).getMessage());
+    }
+
 }

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/submissionApiDelegateImpl/UploadSubmissionDocumentsTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/submissionApiDelegateImpl/UploadSubmissionDocumentsTest.java
@@ -184,16 +184,4 @@ public class UploadSubmissionDocumentsTest {
         Assertions.assertEquals(DOCUMENT_STORAGE_FAILURE.getErrorMessage(), ((EfilingError)actual.getBody()).getMessage());
     }
 
-    @Test
-    @DisplayName("400: with invalid userId then return BAD REQUEST 400")
-    public void withInvalidUserIDThenReturnBadRequest() {
-
-        List<MultipartFile> files = new ArrayList<>();
-        files.add(multipartFileMock);
-        ResponseEntity actual = sut.uploadSubmissionDocuments(UUID.randomUUID(), "BADUUID", files);
-
-        Assertions.assertEquals(HttpStatus.BAD_REQUEST, actual.getStatusCode());
-        Assertions.assertEquals(INVALIDUNIVERSAL.getErrorCode(), ((EfilingError)actual.getBody()).getError());
-        Assertions.assertEquals(INVALIDUNIVERSAL.getErrorMessage(), ((EfilingError)actual.getBody()).getMessage());
-    }
 }

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/submissionApiDelegateImpl/UploadSubmissionDocumentsTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/submission/submissionApiDelegateImpl/UploadSubmissionDocumentsTest.java
@@ -185,7 +185,7 @@ public class UploadSubmissionDocumentsTest {
     }
 
     @Test
-    @DisplayName("400: with missing id should return 400")
+    @DisplayName("403: with missing id should return 403")
     public void withBlankIdShouldReturn400() throws VirusDetectedException, IOException {
 
 
@@ -200,7 +200,7 @@ public class UploadSubmissionDocumentsTest {
 
         ResponseEntity actual = sut.uploadSubmissionDocuments(UUID.randomUUID(), "  ", files);
 
-        Assertions.assertEquals(HttpStatus.BAD_REQUEST, actual.getStatusCode());
+        Assertions.assertEquals(HttpStatus.FORBIDDEN, actual.getStatusCode());
         Assertions.assertEquals(INVALIDUNIVERSAL.getErrorCode(), ((EfilingError)actual.getBody()).getError());
         Assertions.assertEquals(INVALIDUNIVERSAL.getErrorMessage(), ((EfilingError)actual.getBody()).getMessage());
     }

--- a/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/utils/SecurityUtilsTest.java
+++ b/src/backend/efiling-api/src/test/java/ca/bc/gov/open/jag/efilingapi/utils/SecurityUtilsTest.java
@@ -53,14 +53,14 @@ public class SecurityUtilsTest {
     @Test
     public void shouldConvertToUUID() {
 
-        UUID expectedUUID = UUID.randomUUID();
+        String expectedUUID = UUID.randomUUID().toString();
 
         Map<String, Object> otherClaims = new HashMap<>();
-        otherClaims.put(Keys.UNIVERSAL_ID_CLAIM_KEY, expectedUUID.toString().replace("-", "").toUpperCase());
+        otherClaims.put(Keys.UNIVERSAL_ID_CLAIM_KEY, expectedUUID);
         Mockito.when(tokenMock.getOtherClaims()).thenReturn(otherClaims);
 
 
-        Optional<UUID> actual = SecurityUtils.getUniversalIdFromContext();
+        Optional<String> actual = SecurityUtils.getUniversalIdFromContext();
 
         Assertions.assertTrue(actual.isPresent());
         Assertions.assertEquals(expectedUUID, actual.get());

--- a/src/backend/libs/efiling-commons/src/main/java/ca/bc/gov/open/jag/efilingcommons/model/AccountDetails.java
+++ b/src/backend/libs/efiling-commons/src/main/java/ca/bc/gov/open/jag/efilingcommons/model/AccountDetails.java
@@ -4,11 +4,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.math.BigDecimal;
-import java.util.UUID;
 
 public class AccountDetails {
 
-    private UUID universalId;
+    private String universalId;
     private BigDecimal accountId;
     private BigDecimal clientId;
     private String internalClientNumber;
@@ -33,7 +32,7 @@ public class AccountDetails {
 
     @JsonCreator
     public AccountDetails(
-            @JsonProperty("universalId") UUID universalId,
+            @JsonProperty("universalId") String universalId,
             @JsonProperty("accountId") BigDecimal accountId,
             @JsonProperty("clientId") BigDecimal clientId,
             @JsonProperty("internalClientNumber") String internalClientNumber,
@@ -51,7 +50,7 @@ public class AccountDetails {
         this.cardRegistered = cardRegistered;
     }
 
-    public UUID getUniversalId() {
+    public String getUniversalId() {
         return universalId;
     }
 
@@ -78,7 +77,7 @@ public class AccountDetails {
 
     public static class Builder {
 
-        private UUID universalId;
+        private String universalId;
         private BigDecimal accountId;
         private BigDecimal clientId;
         private String internalClientNumber;
@@ -86,7 +85,7 @@ public class AccountDetails {
         private boolean cardRegistered;
 
 
-        public Builder universalId(UUID universalId) {
+        public Builder universalId(String universalId) {
             this.universalId = universalId;
             return this;
         }

--- a/src/backend/libs/efiling-commons/src/main/java/ca/bc/gov/open/jag/efilingcommons/model/CreateAccountRequest.java
+++ b/src/backend/libs/efiling-commons/src/main/java/ca/bc/gov/open/jag/efilingcommons/model/CreateAccountRequest.java
@@ -1,13 +1,11 @@
 package ca.bc.gov.open.jag.efilingcommons.model;
 
-import java.util.UUID;
-
 /**
  * Represents a request to create an account
  */
 public class CreateAccountRequest {
 
-    private UUID universalId;
+    private String universalId;
     private String firstName;
     private String lastName;
     private String middleName;
@@ -31,7 +29,7 @@ public class CreateAccountRequest {
      * Get the universalId
      * @return
      */
-    public UUID getUniversalId() {
+    public String getUniversalId() {
         return universalId;
     }
 
@@ -69,13 +67,13 @@ public class CreateAccountRequest {
 
     public static class Builder {
 
-        private UUID universalId;
+        private String universalId;
         private String firstName;
         private String lastName;
         private String middleName;
         private String email;
 
-        public Builder universalId(UUID universalId) {
+        public Builder universalId(String universalId) {
             this.universalId = universalId;
             return this;
         }

--- a/src/backend/libs/efiling-commons/src/main/java/ca/bc/gov/open/jag/efilingcommons/service/EfilingAccountService.java
+++ b/src/backend/libs/efiling-commons/src/main/java/ca/bc/gov/open/jag/efilingcommons/service/EfilingAccountService.java
@@ -3,9 +3,6 @@ package ca.bc.gov.open.jag.efilingcommons.service;
 import ca.bc.gov.open.jag.efilingcommons.model.AccountDetails;
 import ca.bc.gov.open.jag.efilingcommons.model.CreateAccountRequest;
 
-import java.math.BigDecimal;
-import java.util.UUID;
-
 /**
  * Interface for getting account details based on a user GUID
  */
@@ -16,7 +13,7 @@ public interface EfilingAccountService {
      * @param universalId
      * @return
      */
-    AccountDetails getAccountDetails(UUID universalId);
+    AccountDetails getAccountDetails(String universalId);
 
     /**
      * Creates a new account

--- a/src/backend/libs/efiling-cso-client/src/main/java/ca/bc/gov/open/jag/efilingcsoclient/CsoAccountServiceImpl.java
+++ b/src/backend/libs/efiling-cso-client/src/main/java/ca/bc/gov/open/jag/efilingcsoclient/CsoAccountServiceImpl.java
@@ -38,7 +38,7 @@ public class CsoAccountServiceImpl implements EfilingAccountService {
     }
 
     @Override
-    public AccountDetails getAccountDetails(UUID universalId) {
+    public AccountDetails getAccountDetails(String universalId) {
 
         AccountDetails accountDetails = getCsoDetails(universalId);
         return accountDetails;
@@ -107,7 +107,7 @@ public class CsoAccountServiceImpl implements EfilingAccountService {
         }
     }
 
-    private AccountDetails getCsoDetails(UUID universalId)  {
+    private AccountDetails getCsoDetails(String universalId)  {
 
         AccountDetails accountDetails = null;
         List<ClientProfile> profiles = new ArrayList<>();

--- a/src/backend/libs/efiling-cso-client/src/main/java/ca/bc/gov/open/jag/efilingcsoclient/CsoHelpers.java
+++ b/src/backend/libs/efiling-cso-client/src/main/java/ca/bc/gov/open/jag/efilingcsoclient/CsoHelpers.java
@@ -5,7 +5,6 @@ import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
-import java.util.UUID;
 
 /**
  * Helper class for CSO
@@ -19,8 +18,8 @@ public class CsoHelpers {
      * @param id
      * @return
      */
-    public static String formatUserGuid(UUID id) {
-        return id.toString().replace("-", "").toUpperCase();
+    public static String formatUserGuid(String id) {
+        return id.replace("-", "").toUpperCase();
     }
 
     /**

--- a/src/backend/libs/efiling-cso-client/src/main/java/ca/bc/gov/open/jag/efilingcsoclient/mappers/AccountDetailsMapper.java
+++ b/src/backend/libs/efiling-cso-client/src/main/java/ca/bc/gov/open/jag/efilingcsoclient/mappers/AccountDetailsMapper.java
@@ -5,8 +5,6 @@ import ca.bc.gov.open.jag.efilingcommons.model.AccountDetails;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-import java.util.UUID;
-
 @Mapper
 public interface AccountDetailsMapper {
 
@@ -16,12 +14,12 @@ public interface AccountDetailsMapper {
     @Mapping(target = "fileRolePresent", source = "fileRolePresent")
     @Mapping(target = "universalId", source = "universalId")
     @Mapping(target = "cardRegistered", source = "clientProfile.client.registeredCreditCardYnBoolean")
-    AccountDetails toAccountDetails(UUID universalId, ClientProfile clientProfile, Boolean fileRolePresent);
+    AccountDetails toAccountDetails(String universalId, ClientProfile clientProfile, Boolean fileRolePresent);
 
     @Mapping(target = "accountId", defaultValue = "0")
     @Mapping(target = "clientId", defaultValue = "0")
     @Mapping(target = "fileRolePresent", defaultValue = "false")
     @Mapping(target = "universalId", source = "universalId")
-    AccountDetails toAccountDetails(UUID universalId);
+    AccountDetails toAccountDetails(String universalId);
 
 }

--- a/src/backend/libs/efiling-cso-client/src/test/java/ca/bc/gov/open/jag/efilingcsoclient/csoAccountServiceImpl/CreateAccountTest.java
+++ b/src/backend/libs/efiling-cso-client/src/test/java/ca/bc/gov/open/jag/efilingcsoclient/csoAccountServiceImpl/CreateAccountTest.java
@@ -19,7 +19,6 @@ import org.mockito.MockitoAnnotations;
 import javax.xml.datatype.DatatypeConfigurationException;
 import java.math.BigDecimal;
 import java.util.Date;
-import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 
@@ -27,7 +26,7 @@ import static org.mockito.ArgumentMatchers.any;
 @DisplayName("Create Account Test Suite")
 public class CreateAccountTest {
 
-    public static final UUID UNIVERSAL_ID = UUID.fromString("77da92db-0791-491e-8c58-1a969e67d2fe");
+    public static final String UNIVERSAL_ID = "77da92db-0791-491e-8c58-1a969e67d2fe";
     private static final String FIRST_NAME = "FIRSTNAME";
     private static final String LAST_NAME = "LASTNAME";
     private static final String EMAIL = "EMAIL";

--- a/src/backend/libs/efiling-cso-client/src/test/java/ca/bc/gov/open/jag/efilingcsoclient/csoAccountServiceImpl/GetAccountDetailsTest.java
+++ b/src/backend/libs/efiling-cso-client/src/test/java/ca/bc/gov/open/jag/efilingcsoclient/csoAccountServiceImpl/GetAccountDetailsTest.java
@@ -28,11 +28,11 @@ import java.util.UUID;
 @DisplayName("Get Account Details Test Suite")
 public class GetAccountDetailsTest {
 
-    private static final UUID USER_GUID_NO_ROLE = UUID.randomUUID();
-    private static final UUID USER_GUID_WITH_FILE_ROLE = UUID.randomUUID();
-    private static final UUID USER_GUID_WITH_NO_CSO = UUID.randomUUID();
-    private static final UUID USER_GUID_WITH_EJB_EXCEPTION = UUID.randomUUID();
-    private static final UUID USER_GUID_WITH_MULTI_PROFILE = UUID.randomUUID();
+    private static final String USER_GUID_NO_ROLE = UUID.randomUUID().toString();
+    private static final String USER_GUID_WITH_FILE_ROLE = UUID.randomUUID().toString();
+    private static final String USER_GUID_WITH_NO_CSO = UUID.randomUUID().toString();
+    private static final String USER_GUID_WITH_EJB_EXCEPTION = UUID.randomUUID().toString();
+    private static final String USER_GUID_WITH_MULTI_PROFILE = UUID.randomUUID().toString();
     public static final String DOMAIN = "Courts";
     public static final String APPLICATION = "CSO";
     public static final String IDENTIFIER_TYPE = "CAP";
@@ -106,16 +106,16 @@ public class GetAccountDetailsTest {
         Mockito.when(roleRegistryPortTypeMock.getRolesForIdentifier(DOMAIN, APPLICATION, CsoHelpers.formatUserGuid(USER_GUID_WITH_FILE_ROLE), IDENTIFIER_TYPE)).thenReturn(userRolesWithFileRole);
         Mockito.when(roleRegistryPortTypeMock.getRolesForIdentifier(DOMAIN, APPLICATION, CsoHelpers.formatUserGuid(USER_GUID_NO_ROLE), IDENTIFIER_TYPE)).thenReturn(userRolesWithoutFileRole);
 
-        AccountDetails csoUserDetailsWithRole = new AccountDetails(UUID.randomUUID(), BigDecimal.TEN, BigDecimal.TEN, INTERNAL_CLIENT_NUMBER ,true, "firstName", "lastName", "middleName", "email", true);
+        AccountDetails csoUserDetailsWithRole = new AccountDetails(UUID.randomUUID().toString(), BigDecimal.TEN, BigDecimal.TEN, INTERNAL_CLIENT_NUMBER ,true, "firstName", "lastName", "middleName", "email", true);
         Mockito.when(accountDetailsMapperMock.toAccountDetails(Mockito.any(), Mockito.any(), Mockito.eq(true))).thenReturn(csoUserDetailsWithRole);
 
-        AccountDetails csoUserDetailsWithoutRole = new AccountDetails(UUID.randomUUID(),BigDecimal.TEN, BigDecimal.TEN, INTERNAL_CLIENT_NUMBER ,false, "firstName", "lastName", "middleName","email", true);
+        AccountDetails csoUserDetailsWithoutRole = new AccountDetails(UUID.randomUUID().toString(),BigDecimal.TEN, BigDecimal.TEN, INTERNAL_CLIENT_NUMBER ,false, "firstName", "lastName", "middleName","email", true);
         Mockito.when(accountDetailsMapperMock.toAccountDetails(Mockito.any(), Mockito.any(), Mockito.eq(false))).thenReturn(csoUserDetailsWithoutRole);
     }
 
     private void initBceIdAccountMocks() {
 
-        AccountDetails accountDetailsWithNoCso = new AccountDetails(UUID.randomUUID(), BigDecimal.ZERO, BigDecimal.ZERO, INTERNAL_CLIENT_NUMBER, false, "firstName", "lastName", "middleName","email", true);
+        AccountDetails accountDetailsWithNoCso = new AccountDetails(UUID.randomUUID().toString(), BigDecimal.ZERO, BigDecimal.ZERO, INTERNAL_CLIENT_NUMBER, false, "firstName", "lastName", "middleName","email", true);
         Mockito.when(accountDetailsMapperMock.toAccountDetails(Mockito.any())).thenReturn(accountDetailsWithNoCso);
     }
 

--- a/src/backend/libs/efiling-cso-client/src/test/java/ca/bc/gov/open/jag/efilingcsoclient/csoSubmissionServiceImpl/SubmitFilingPackageTest.java
+++ b/src/backend/libs/efiling-cso-client/src/test/java/ca/bc/gov/open/jag/efilingcsoclient/csoSubmissionServiceImpl/SubmitFilingPackageTest.java
@@ -43,7 +43,7 @@ public class SubmitFilingPackageTest {
     private static final DateTime PROCESS_DT = DateTime.now();
     private static final DateTime ENT_DTM = DateTime.now();
     private static final String APPROVED = "Approved";
-    private static final UUID UNIVERSAL_ID = UUID.randomUUID();
+    private static final String UNIVERSAL_ID = UUID.randomUUID().toString();
     private static final String LOCATION = "LOCATION";
     private static final String BAD_LOCATION = "BADLOCATION";
     private static final String COURT_CLASS = "courtClass";

--- a/src/backend/libs/efiling-demo-starter/src/main/java/ca/bc/gov/open/jag/efiling/demo/AccountDetailsCache.java
+++ b/src/backend/libs/efiling-demo-starter/src/main/java/ca/bc/gov/open/jag/efiling/demo/AccountDetailsCache.java
@@ -2,13 +2,11 @@ package ca.bc.gov.open.jag.efiling.demo;
 
 import ca.bc.gov.open.jag.efilingcommons.model.AccountDetails;
 
-import java.util.UUID;
-
 public interface AccountDetailsCache {
 
 
     AccountDetails put(AccountDetails accountDetails);
 
-    AccountDetails get(UUID userGuid);
+    AccountDetails get(String userGuid);
 
 }

--- a/src/backend/libs/efiling-demo-starter/src/main/java/ca/bc/gov/open/jag/efiling/demo/AccountDetailsCacheImpl.java
+++ b/src/backend/libs/efiling-demo-starter/src/main/java/ca/bc/gov/open/jag/efiling/demo/AccountDetailsCacheImpl.java
@@ -4,8 +4,6 @@ import ca.bc.gov.open.jag.efilingcommons.model.AccountDetails;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 
-import java.util.UUID;
-
 public class AccountDetailsCacheImpl implements AccountDetailsCache {
 
     @Override
@@ -16,7 +14,7 @@ public class AccountDetailsCacheImpl implements AccountDetailsCache {
 
     @Override
     @Cacheable(cacheNames = "account", key = "#userGuid", cacheManager = "demoAccountCacheManager", unless="#result == null")
-    public AccountDetails get(UUID userGuid) {
+    public AccountDetails get(String userGuid) {
         return null;
     }
 

--- a/src/backend/libs/efiling-demo-starter/src/main/java/ca/bc/gov/open/jag/efiling/demo/EfilingAccountServiceDemoImpl.java
+++ b/src/backend/libs/efiling-demo-starter/src/main/java/ca/bc/gov/open/jag/efiling/demo/EfilingAccountServiceDemoImpl.java
@@ -8,7 +8,6 @@ import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 
 import java.math.BigDecimal;
-import java.util.UUID;
 
 public class EfilingAccountServiceDemoImpl implements EfilingAccountService {
 
@@ -19,7 +18,7 @@ public class EfilingAccountServiceDemoImpl implements EfilingAccountService {
     }
 
     @Cacheable(cacheNames = "account", key = "#userGuid", unless="#result == null", cacheManager = "demoAccountCacheManager")
-    public AccountDetails getAccountDetails(UUID userGuid) {
+    public AccountDetails getAccountDetails(String userGuid) {
 
         return accountDetailsCache.get(userGuid);
 

--- a/src/backend/libs/efiling-demo-starter/src/main/java/ca/bc/gov/open/jag/efiling/demo/Keys.java
+++ b/src/backend/libs/efiling-demo-starter/src/main/java/ca/bc/gov/open/jag/efiling/demo/Keys.java
@@ -1,12 +1,10 @@
 package ca.bc.gov.open.jag.efiling.demo;
 
-import java.util.UUID;
-
 public class Keys {
 
     protected Keys() {};
 
-    public static UUID ACCOUNT_WITH_EFILING_ROLE = UUID.fromString("77da92db-0791-491e-8c58-1a969e67d2fa");
-    public static UUID ACCOUNT_WITHOUT_EFILING_ROLE = UUID.fromString("77da92db-0791-491e-8c58-1a969e67d2fb");
+    public static String ACCOUNT_WITH_EFILING_ROLE = "77da92db-0791-491e-8c58-1a969e67d2fa";
+    public static String ACCOUNT_WITHOUT_EFILING_ROLE = "77da92db-0791-491e-8c58-1a969e67d2fb";
 
 }

--- a/src/backend/libs/efiling-demo-starter/src/test/java/ca/bc/gov/open/jag/efiling/demo/AccountDetailsCacheImplTest.java
+++ b/src/backend/libs/efiling-demo-starter/src/test/java/ca/bc/gov/open/jag/efiling/demo/AccountDetailsCacheImplTest.java
@@ -15,7 +15,7 @@ public class AccountDetailsCacheImplTest {
     @DisplayName("Cache test are useles")
     public void testCache() {
         sut = new AccountDetailsCacheImpl();
-        Assertions.assertDoesNotThrow(() -> sut.get(UUID.randomUUID()));
+        Assertions.assertDoesNotThrow(() -> sut.get(UUID.randomUUID().toString()));
         Assertions.assertDoesNotThrow(() -> sut.put(AccountDetails.builder().clientId(BigDecimal.TEN).create()));
 
     }

--- a/src/backend/libs/efiling-demo-starter/src/test/java/ca/bc/gov/open/jag/efiling/demo/EfilingAccountServiceDemoImplTest.java
+++ b/src/backend/libs/efiling-demo-starter/src/test/java/ca/bc/gov/open/jag/efiling/demo/EfilingAccountServiceDemoImplTest.java
@@ -9,13 +9,12 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.math.BigDecimal;
-import java.util.UUID;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class EfilingAccountServiceDemoImplTest {
 
-    public static final UUID ACCOUNT_ID = UUID.fromString("77da92db-0791-491e-8c58-1a969e67d2fa");
-    public static final UUID ACCOUNT_ID_NOT_EXIST = UUID.fromString("17da92db-0791-491e-8c58-1a969e67d2fa");
+    public static final String ACCOUNT_ID = "77da92db-0791-491e-8c58-1a969e67d2fa";
+    public static final String ACCOUNT_ID_NOT_EXIST = "17da92db-0791-491e-8c58-1a969e67d2fa";
     public static final String FIRST_NAME = "firstName";
 
     private EfilingAccountServiceDemoImpl sut;

--- a/src/backend/libs/efiling-demo-starter/src/test/java/ca/bc/gov/open/jag/efiling/demo/SeedAccountTest.java
+++ b/src/backend/libs/efiling-demo-starter/src/test/java/ca/bc/gov/open/jag/efiling/demo/SeedAccountTest.java
@@ -27,7 +27,7 @@ public class SeedAccountTest {
     @BeforeAll
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        Mockito.when(efilingAccountServiceMock.createAccount(Mockito.any())).thenReturn(AccountDetails.builder().universalId(UUID.randomUUID()).create());
+        Mockito.when(efilingAccountServiceMock.createAccount(Mockito.any())).thenReturn(AccountDetails.builder().universalId(UUID.randomUUID().toString()).create());
         sut = new SeedAccount(efilingAccountServiceMock);
     }
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- FLA-703 - Adapt backend api to accept BCSC universal Id

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Running unit tests locally

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
