### PR TITLE
adjusted line breaks to look like paragraphs

### DIFF
--- a/src/backend/libs/efiling-demo-starter/src/main/java/ca/bc/gov/open/jag/efiling/demo/EfilingReviewServiceDemoImpl.java
+++ b/src/backend/libs/efiling-demo-starter/src/main/java/ca/bc/gov/open/jag/efiling/demo/EfilingReviewServiceDemoImpl.java
@@ -50,7 +50,7 @@ public class EfilingReviewServiceDemoImpl implements EfilingReviewService {
         ReviewFilingPackage reviewFilingPackage = new ReviewFilingPackage();
         reviewFilingPackage.setFirstName("Han");
         reviewFilingPackage.setLastName("Solo");
-        reviewFilingPackage.setFilingCommentsTxt(MessageFormat.format("Lorem ipsum dolor sit amet, {0} consectetur adipiscing elit, {1} sed do eiusmod tempor incididunt {0} ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi {0} ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse {0} cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.", System.lineSeparator(), "<script>alert(\"Hello\");</script>"));
+        reviewFilingPackage.setFilingCommentsTxt(MessageFormat.format("Lorem ipsum dolor sit amet, consectetur adipiscing elit, {1} sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.{0}{0}Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.", System.lineSeparator(), "<script>alert(\"Hello\");</script>"));
         reviewFilingPackage.setHasChecklist(false);
         reviewFilingPackage.setHasRegistryNotice(false);
         reviewFilingPackage.setPackageNo("1");

--- a/src/backend/libs/efiling-demo-starter/src/test/java/ca/bc/gov/open/jag/efiling/demo/EfilingReviewServiceDemoImplTest.java
+++ b/src/backend/libs/efiling-demo-starter/src/test/java/ca/bc/gov/open/jag/efiling/demo/EfilingReviewServiceDemoImplTest.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class EfilingReviewServiceDemoImplTest {
     public static final String DESCRIPTION = "DESCRIPTION";
-    public static final String COMMENTS = MessageFormat.format("Lorem ipsum dolor sit amet, {0} consectetur adipiscing elit, {1} sed do eiusmod tempor incididunt {0} ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi {0} ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse {0} cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.", System.lineSeparator(), "<script>alert(\"Hello\");</script>");
+    public static final String COMMENTS = MessageFormat.format("Lorem ipsum dolor sit amet, consectetur adipiscing elit, {1} sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.{0}{0}Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.", System.lineSeparator(), "<script>alert(\"Hello\");</script>");
     EfilingReviewServiceDemoImpl sut;
 
     @BeforeAll


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

small tweak to line breaks so the sample filing comments appear as 2 paragraphs.

![2021-01-28_120221](https://user-images.githubusercontent.com/55215368/106210694-28022400-617c-11eb-89c7-a30af9ba36fa.png)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
