### PR TITLE
Added Documents tab content on SubmissionReview page

### DIFF
--- a/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.css
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.css
@@ -1,0 +1,20 @@
+.header {
+    display: flex;
+    flex-wrap: wrap;
+    font-weight: bold;
+}
+.label {
+    font-weight: bold;
+    margin-bottom: 0px;
+}
+ul {
+    margin: 5px 0px;
+    padding: 0px;
+}
+li {
+    display: flex;
+    flex-wrap: wrap;
+    list-style-type: none;
+    border: 2px solid #E1BEBD;
+    padding: 10px 0px;
+}

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.js
@@ -13,20 +13,21 @@ export default function DocumentList({ documents }) {
         <span className="d-none d-md-inline col-md-3">Action (s)</span>
       </div>
       <ul>
-        {documents && documents.map((document) => (
-          <li key={document.name}>
-            <span className="label col-sm-4 d-md-none">Document Type:</span>
-            <span className="col-sm-8 col-md-3">{document.type}</span>
-            <span className="label col-sm-4 d-md-none">File Name:</span>
-            <span className="col-sm-8 col-md-3">{document.name}</span>
-            <span className="label col-sm-4 d-md-none">Status:</span>
-            <span className="col-sm-8 col-md-3">
-              {document.status.description}
-            </span>
-            <span className="label col-sm-4 d-md-none">Action (s):</span>
-            <span className="col-sm-8 col-md-3">withdraw</span>
-          </li>
-        ))}
+        {documents &&
+          documents.map((document) => (
+            <li key={document.name}>
+              <span className="label col-sm-4 d-md-none">Document Type:</span>
+              <span className="col-sm-8 col-md-3">{document.type}</span>
+              <span className="label col-sm-4 d-md-none">File Name:</span>
+              <span className="col-sm-8 col-md-3">{document.name}</span>
+              <span className="label col-sm-4 d-md-none">Status:</span>
+              <span className="col-sm-8 col-md-3">
+                {document.status.description}
+              </span>
+              <span className="label col-sm-4 d-md-none">Action (s):</span>
+              <span className="col-sm-8 col-md-3">withdraw</span>
+            </li>
+          ))}
       </ul>
     </div>
   );

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.js
@@ -1,0 +1,37 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import "./DocumentList.css";
+
+export default function DocumentList({ documents }) {
+  return (
+    <div>
+      <div className="header">
+        <span className="d-none d-md-inline col-md-3">Document Type</span>
+        <span className="d-none d-md-inline col-md-3">File Name</span>
+        <span className="d-none d-md-inline col-md-3">Status</span>
+        <span className="d-none d-md-inline col-md-3">Action (s)</span>
+      </div>
+      <ul>
+        {documents && documents.map((document) => (
+          <li key={document.name}>
+            <span className="label col-sm-4 d-md-none">Document Type:</span>
+            <span className="col-sm-8 col-md-3">{document.type}</span>
+            <span className="label col-sm-4 d-md-none">File Name:</span>
+            <span className="col-sm-8 col-md-3">{document.name}</span>
+            <span className="label col-sm-4 d-md-none">Status:</span>
+            <span className="col-sm-8 col-md-3">
+              {document.status.description}
+            </span>
+            <span className="label col-sm-4 d-md-none">Action (s):</span>
+            <span className="col-sm-8 col-md-3">withdraw</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+DocumentList.propTypes = {
+  documents: PropTypes.array.isRequired,
+};

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.js
@@ -13,6 +13,7 @@ import { errorRedirect } from "../../../modules/helpers/errorRedirect";
 import { getFilingPackage, getSubmissionSheet } from "./PackageReviewService";
 
 import "./PackageReview.css";
+import DocumentList from "./DocumentList";
 
 export default function PackageReview({ page: { header, packageId } }) {
   const [error, setError] = useState(false);
@@ -41,6 +42,7 @@ export default function PackageReview({ page: { header, packageId } }) {
     },
   ]);
   const [filingComments, setFilingComments] = useState("");
+  const [documents, setDocuments] = useState([]);
 
   useEffect(() => {
     getFilingPackage(packageId)
@@ -96,6 +98,7 @@ export default function PackageReview({ page: { header, packageId } }) {
             },
           ]);
           setFilingComments(response.data.filingComments);
+          setDocuments(response.data.documents);
         } catch (err) {
           setError(true);
         }
@@ -162,7 +165,7 @@ export default function PackageReview({ page: { header, packageId } }) {
           <Tabs defaultActiveKey="documents" id="uncontrolled-tab">
             <Tab eventKey="documents" title="Documents">
               <br />
-              Documents coming ...
+              <DocumentList documents={documents} />
             </Tab>
             <Tab eventKey="comments" title="Filing Comments">
               <br />

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.test.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.test.js
@@ -23,6 +23,15 @@ describe("PackageReview Component", () => {
   const submittedBy = { firstName: "Han", lastName: "Solo" };
   const filingComments =
     "Lorem ipsum dolor sit amet.<script>alert('Hi');</script>\n\nDuis aute irure dolor.";
+  const documents = [
+    {
+      type: "AFF",
+      name: "test-document.pdf",
+      status: {
+        description: "Submitted",
+      },
+    },
+  ];
 
   const page = {
     header,
@@ -46,6 +55,7 @@ describe("PackageReview Component", () => {
       submittedBy,
       submittedDate,
       filingComments,
+      documents,
     });
 
     const { asFragment } = render(<PackageReview page={page} />);

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.stories.storyshot
@@ -271,7 +271,33 @@ exports[`Storyshots PackageReview Default 1`] = `
             role="tabpanel"
           >
             <br />
-            Documents coming ...
+            <div>
+              <div
+                class="header"
+              >
+                <span
+                  class="d-none d-md-inline col-md-3"
+                >
+                  Document Type
+                </span>
+                <span
+                  class="d-none d-md-inline col-md-3"
+                >
+                  File Name
+                </span>
+                <span
+                  class="d-none d-md-inline col-md-3"
+                >
+                  Status
+                </span>
+                <span
+                  class="d-none d-md-inline col-md-3"
+                >
+                  Action (s)
+                </span>
+              </div>
+              <ul />
+            </div>
           </div>
           <div
             aria-hidden="true"
@@ -667,7 +693,33 @@ exports[`Storyshots PackageReview Mobile 1`] = `
             role="tabpanel"
           >
             <br />
-            Documents coming ...
+            <div>
+              <div
+                class="header"
+              >
+                <span
+                  class="d-none d-md-inline col-md-3"
+                >
+                  Document Type
+                </span>
+                <span
+                  class="d-none d-md-inline col-md-3"
+                >
+                  File Name
+                </span>
+                <span
+                  class="d-none d-md-inline col-md-3"
+                >
+                  Status
+                </span>
+                <span
+                  class="d-none d-md-inline col-md-3"
+                >
+                  Action (s)
+                </span>
+              </div>
+              <ul />
+            </div>
           </div>
           <div
             aria-hidden="true"

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.test.js.snap
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.test.js.snap
@@ -247,7 +247,76 @@ exports[`PackageReview Component Matches the snapshot 1`] = `
             role="tabpanel"
           >
             <br />
-            Documents coming ...
+            <div>
+              <div
+                class="header"
+              >
+                <span
+                  class="d-none d-md-inline col-md-3"
+                >
+                  Document Type
+                </span>
+                <span
+                  class="d-none d-md-inline col-md-3"
+                >
+                  File Name
+                </span>
+                <span
+                  class="d-none d-md-inline col-md-3"
+                >
+                  Status
+                </span>
+                <span
+                  class="d-none d-md-inline col-md-3"
+                >
+                  Action (s)
+                </span>
+              </div>
+              <ul>
+                <li>
+                  <span
+                    class="label col-sm-4 d-md-none"
+                  >
+                    Document Type:
+                  </span>
+                  <span
+                    class="col-sm-8 col-md-3"
+                  >
+                    AFF
+                  </span>
+                  <span
+                    class="label col-sm-4 d-md-none"
+                  >
+                    File Name:
+                  </span>
+                  <span
+                    class="col-sm-8 col-md-3"
+                  >
+                    test-document.pdf
+                  </span>
+                  <span
+                    class="label col-sm-4 d-md-none"
+                  >
+                    Status:
+                  </span>
+                  <span
+                    class="col-sm-8 col-md-3"
+                  >
+                    Submitted
+                  </span>
+                  <span
+                    class="label col-sm-4 d-md-none"
+                  >
+                    Action (s):
+                  </span>
+                  <span
+                    class="col-sm-8 col-md-3"
+                  >
+                    withdraw
+                  </span>
+                </li>
+              </ul>
+            </div>
           </div>
           <div
             aria-hidden="true"


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

https://justice.gov.bc.ca/jira/browse/FLA-731

- Populated Documents tab with a document list stylized per wireframe mockups
- created a subcomponent to handle document list
- updated unit tests

_Widescreen:_
![2021-02-01_154510](https://user-images.githubusercontent.com/55215368/106532477-19ca4580-64a5-11eb-961d-5d7871162490.png)

_Medium:_
![2021-02-01_154535](https://user-images.githubusercontent.com/55215368/106532519-2d75ac00-64a5-11eb-8a4b-e9938e99f23a.png)

_Mobile:_
![2021-02-01_154554](https://user-images.githubusercontent.com/55215368/106532525-30709c80-64a5-11eb-91b9-39af53b0f8c2.png)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

yarn lint
yarn test -u
yarn test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes