### PR TITLE
Added Documents tab content on SubmissionReview page

### DIFF
--- a/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.css
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.css
@@ -1,25 +1,25 @@
-.header {
+.document-list .header {
   display: flex;
   flex-wrap: wrap;
   font-weight: bold;
 }
-.label {
+.document-list .label {
   font-weight: bold;
   margin-bottom: 0px;
 }
-ul {
+.document-list ul {
   margin: 5px 0px;
   padding: 0px;
 }
-li {
+.document-list li {
   display: flex;
   flex-wrap: wrap;
   list-style-type: none;
-  border: 1px solid #BFBFBF;
+  border: 1px solid #bfbfbf;
   padding: 10px 0px;
   margin: 10px 0px;
 }
-li span {
+.document-list li span {
   text-overflow: ellipsis;
   overflow: hidden;
 }

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.css
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.css
@@ -1,20 +1,26 @@
 .header {
-    display: flex;
-    flex-wrap: wrap;
-    font-weight: bold;
+  display: flex;
+  flex-wrap: wrap;
+  font-weight: bold;
 }
 .label {
-    font-weight: bold;
-    margin-bottom: 0px;
+  font-weight: bold;
+  margin-bottom: 0px;
 }
 ul {
-    margin: 5px 0px;
-    padding: 0px;
+  margin: 5px 0px;
+  padding: 0px;
 }
 li {
-    display: flex;
-    flex-wrap: wrap;
-    list-style-type: none;
-    border: 2px solid #E1BEBD;
-    padding: 10px 0px;
+  display: flex;
+  flex-wrap: wrap;
+  list-style-type: none;
+  border: 2px solid #e1bebd;
+  padding: 10px 0px;
+  margin: 10px 0px;
+}
+li span {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.css
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.css
@@ -15,12 +15,11 @@ li {
   display: flex;
   flex-wrap: wrap;
   list-style-type: none;
-  border: 2px solid #e1bebd;
+  border: 1px solid #BFBFBF;
   padding: 10px 0px;
   margin: 10px 0px;
 }
 li span {
-  white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
 }

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.js
@@ -7,25 +7,25 @@ export default function DocumentList({ documents }) {
   return (
     <div>
       <div className="header">
-        <span className="d-none d-md-inline col-md-3">Document Type</span>
-        <span className="d-none d-md-inline col-md-3">File Name</span>
-        <span className="d-none d-md-inline col-md-3">Status</span>
-        <span className="d-none d-md-inline col-md-3">Action (s)</span>
+        <span className="d-none d-lg-inline col-lg-3">Document Type</span>
+        <span className="d-none d-lg-inline col-lg-4">File Name</span>
+        <span className="d-none d-lg-inline col-lg-3">Status</span>
+        <span className="d-none d-lg-inline col-lg-2">Action (s)</span>
       </div>
       <ul>
         {documents &&
           documents.map((document) => (
             <li key={document.identifier}>
-              <span className="label col-sm-4 d-md-none">Document Type:</span>
-              <span className="col-sm-8 col-md-3">{document.type}</span>
-              <span className="label col-sm-4 d-md-none">File Name:</span>
-              <span className="col-sm-8 col-md-3">{document.name}</span>
-              <span className="label col-sm-4 d-md-none">Status:</span>
-              <span className="col-sm-8 col-md-3">
+              <span className="label col-sm-4 d-lg-none">Document Type:</span>
+              <span className="col-sm-8 col-lg-3">{document.description}</span>
+              <span className="label col-sm-4 d-lg-none">File Name:</span>
+              <span className="col-sm-8 col-lg-4">{document.name}</span>
+              <span className="label col-sm-4 d-lg-none">Status:</span>
+              <span className="col-sm-8 col-lg-3">
                 {document.status.description}
               </span>
-              <span className="label col-sm-4 d-md-none">Action (s):</span>
-              <span className="col-sm-8 col-md-3">withdraw</span>
+              <span className="label col-sm-4 d-lg-none">Action (s):</span>
+              <span className="col-sm-8 col-lg-2">withdraw</span>
             </li>
           ))}
       </ul>

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.js
@@ -5,7 +5,7 @@ import "./DocumentList.css";
 
 export default function DocumentList({ documents }) {
   return (
-    <div>
+    <div className="document-list">
       <div className="header">
         <span className="d-none d-lg-inline col-lg-3">Document Type</span>
         <span className="d-none d-lg-inline col-lg-4">File Name</span>

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.js
@@ -15,7 +15,7 @@ export default function DocumentList({ documents }) {
       <ul>
         {documents &&
           documents.map((document) => (
-            <li key={document.name}>
+            <li key={document.identifier}>
               <span className="label col-sm-4 d-md-none">Document Type:</span>
               <span className="col-sm-8 col-md-3">{document.type}</span>
               <span className="label col-sm-4 d-md-none">File Name:</span>
@@ -36,6 +36,7 @@ export default function DocumentList({ documents }) {
 DocumentList.propTypes = {
   documents: PropTypes.arrayOf(
     PropTypes.shape({
+      identifier: PropTypes.string.isRequired,
       type: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,
       status: PropTypes.shape({

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.stories.storyshot
@@ -271,7 +271,9 @@ exports[`Storyshots PackageReview Default 1`] = `
             role="tabpanel"
           >
             <br />
-            <div>
+            <div
+              class="document-list"
+            >
               <div
                 class="header"
               >
@@ -693,7 +695,9 @@ exports[`Storyshots PackageReview Mobile 1`] = `
             role="tabpanel"
           >
             <br />
-            <div>
+            <div
+              class="document-list"
+            >
               <div
                 class="header"
               >

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.stories.storyshot
@@ -276,22 +276,22 @@ exports[`Storyshots PackageReview Default 1`] = `
                 class="header"
               >
                 <span
-                  class="d-none d-md-inline col-md-3"
+                  class="d-none d-lg-inline col-lg-3"
                 >
                   Document Type
                 </span>
                 <span
-                  class="d-none d-md-inline col-md-3"
+                  class="d-none d-lg-inline col-lg-4"
                 >
                   File Name
                 </span>
                 <span
-                  class="d-none d-md-inline col-md-3"
+                  class="d-none d-lg-inline col-lg-3"
                 >
                   Status
                 </span>
                 <span
-                  class="d-none d-md-inline col-md-3"
+                  class="d-none d-lg-inline col-lg-2"
                 >
                   Action (s)
                 </span>
@@ -698,22 +698,22 @@ exports[`Storyshots PackageReview Mobile 1`] = `
                 class="header"
               >
                 <span
-                  class="d-none d-md-inline col-md-3"
+                  class="d-none d-lg-inline col-lg-3"
                 >
                   Document Type
                 </span>
                 <span
-                  class="d-none d-md-inline col-md-3"
+                  class="d-none d-lg-inline col-lg-4"
                 >
                   File Name
                 </span>
                 <span
-                  class="d-none d-md-inline col-md-3"
+                  class="d-none d-lg-inline col-lg-3"
                 >
                   Status
                 </span>
                 <span
-                  class="d-none d-md-inline col-md-3"
+                  class="d-none d-lg-inline col-lg-2"
                 >
                   Action (s)
                 </span>

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.test.js.snap
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.test.js.snap
@@ -247,7 +247,9 @@ exports[`PackageReview Component Matches the snapshot 1`] = `
             role="tabpanel"
           >
             <br />
-            <div>
+            <div
+              class="document-list"
+            >
               <div
                 class="header"
               >

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.test.js.snap
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.test.js.snap
@@ -252,22 +252,22 @@ exports[`PackageReview Component Matches the snapshot 1`] = `
                 class="header"
               >
                 <span
-                  class="d-none d-md-inline col-md-3"
+                  class="d-none d-lg-inline col-lg-3"
                 >
                   Document Type
                 </span>
                 <span
-                  class="d-none d-md-inline col-md-3"
+                  class="d-none d-lg-inline col-lg-4"
                 >
                   File Name
                 </span>
                 <span
-                  class="d-none d-md-inline col-md-3"
+                  class="d-none d-lg-inline col-lg-3"
                 >
                   Status
                 </span>
                 <span
-                  class="d-none d-md-inline col-md-3"
+                  class="d-none d-lg-inline col-lg-2"
                 >
                   Action (s)
                 </span>
@@ -275,42 +275,40 @@ exports[`PackageReview Component Matches the snapshot 1`] = `
               <ul>
                 <li>
                   <span
-                    class="label col-sm-4 d-md-none"
+                    class="label col-sm-4 d-lg-none"
                   >
                     Document Type:
                   </span>
                   <span
-                    class="col-sm-8 col-md-3"
-                  >
-                    AFF
-                  </span>
+                    class="col-sm-8 col-lg-3"
+                  />
                   <span
-                    class="label col-sm-4 d-md-none"
+                    class="label col-sm-4 d-lg-none"
                   >
                     File Name:
                   </span>
                   <span
-                    class="col-sm-8 col-md-3"
+                    class="col-sm-8 col-lg-4"
                   >
                     test-document.pdf
                   </span>
                   <span
-                    class="label col-sm-4 d-md-none"
+                    class="label col-sm-4 d-lg-none"
                   >
                     Status:
                   </span>
                   <span
-                    class="col-sm-8 col-md-3"
+                    class="col-sm-8 col-lg-3"
                   >
                     Submitted
                   </span>
                   <span
-                    class="label col-sm-4 d-md-none"
+                    class="label col-sm-4 d-lg-none"
                   >
                     Action (s):
                   </span>
                   <span
-                    class="col-sm-8 col-md-3"
+                    class="col-sm-8 col-lg-2"
                   >
                     withdraw
                   </span>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

FLA-731
- When file names are too long, render them with an ellipse
- Fixed key value on DocumentList to be the document identifier

![image](https://user-images.githubusercontent.com/55215368/106790219-169b9a80-6608-11eb-90ca-b42561c6a03a.png)
![image](https://user-images.githubusercontent.com/55215368/106790287-3206a580-6608-11eb-9522-945f34e57af9.png)

@yousiefc, do you know of an easy way to provide a full filename tooltip on the ellipse?

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

yarn lint
yarn test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
