### PR TITLE
FLA-767 added confirm popup to withdrawl

### DIFF
--- a/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.js
@@ -1,7 +1,11 @@
-import React from "react";
+/* eslint-disable react/jsx-one-expression-per-line */
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { MdHelp } from "react-icons/md";
+import moment from "moment";
 
+import Modal from "react-bootstrap/Modal";
+import { Button } from "shared-components";
 import { errorRedirect } from "../../../modules/helpers/errorRedirect";
 import { withdrawTooltipData } from "../../../modules/test-data/withdrawTooltipData";
 import {
@@ -16,6 +20,25 @@ export default function DocumentList({
   documents,
   reloadDocumentList,
 }) {
+  const [showModal, setShowModal] = useState(false);
+  const [modalData, setModalData] = useState({
+    description: "",
+    documentProperties: {
+      name: "",
+    },
+    filingDate: "",
+    status: "",
+  });
+
+  const handleModalClose = () => setShowModal(false);
+  const handleModalConfirm = () => {
+    setShowModal(false);
+
+    withdrawSubmittedDocument(packageId, modalData)
+      .then(() => reloadDocumentList())
+      .catch((err) => errorRedirect(sessionStorage.getItem("errorUrl"), err));
+  };
+
   function isClick(e) {
     return e && e.type === "click";
   }
@@ -34,9 +57,8 @@ export default function DocumentList({
 
   function handleWithdrawFileEvent(e, document) {
     if (isClick(e) || isEnter(e)) {
-      withdrawSubmittedDocument(packageId, document)
-        .then(() => reloadDocumentList())
-        .catch((err) => errorRedirect(sessionStorage.getItem("errorUrl"), err));
+      setModalData(document);
+      setShowModal(true);
     }
   }
 
@@ -98,6 +120,59 @@ export default function DocumentList({
             </li>
           ))}
       </ul>
+
+      <Modal show={showModal} onHide={handleModalClose}>
+        <Modal.Header closeButton>
+          <Modal.Title>Withdraw Document</Modal.Title>
+        </Modal.Header>
+
+        <Modal.Body>
+          <p className="modalBody">
+            Please confirm the withdrawl of document{" "}
+            {modalData.documentProperties.name} from your latest submission.
+            This will remove the document permanently from your submitted
+            package number
+            {packageId}.
+          </p>
+
+          <div className="row">
+            <div className="col-sm-4">Package Number:</div>
+            <div className="col-sm-8 data">{packageId}</div>
+          </div>
+          <div className="row">
+            <div className="col-sm-4">Document Status:</div>
+            <div className="col-sm-8 data">{modalData.status.description}</div>
+          </div>
+          <div className="row">
+            <div className="col-sm-4">Date Filed:</div>
+            <div className="col-sm-8 data">
+              {moment(modalData.filingDate).format("DD-MMM-YYYY")}
+            </div>
+          </div>
+          <div className="row">
+            <div className="col-sm-4">Document Type:</div>
+            <div className="col-sm-8 data">{modalData.description}</div>
+          </div>
+          <div className="row">
+            <div className="col-sm-4">File Name:</div>
+            <div className="col-sm-8 data">
+              {modalData.documentProperties.name}
+            </div>
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button
+            onClick={handleModalClose}
+            label="Cancel"
+            styling="btn btn-secondary"
+          />
+          <Button
+            onClick={handleModalConfirm}
+            label="Confirm"
+            styling="btn btn-primary"
+          />
+        </Modal.Footer>
+      </Modal>
     </div>
   );
 }

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.js
@@ -121,13 +121,13 @@ export default function DocumentList({
           ))}
       </ul>
 
-      <Modal show={showModal} onHide={handleModalClose}>
+      <Modal show={showModal} onHide={handleModalClose} className="dl-modal">
         <Modal.Header closeButton>
           <Modal.Title>Withdraw Document</Modal.Title>
         </Modal.Header>
 
         <Modal.Body>
-          <p className="modalBody">
+          <p>
             Please confirm the withdrawl of document{" "}
             {modalData.documentProperties.name} from your latest submission.
             This will remove the document permanently from your submitted
@@ -164,12 +164,12 @@ export default function DocumentList({
           <Button
             onClick={handleModalClose}
             label="Cancel"
-            styling="btn btn-secondary"
+            styling="btn btn-secondary pull-left"
           />
           <Button
             onClick={handleModalConfirm}
             label="Confirm"
-            styling="btn btn-primary"
+            styling="btn btn-primary pull-right"
           />
         </Modal.Footer>
       </Modal>

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.js
@@ -121,7 +121,11 @@ export default function DocumentList({
           ))}
       </ul>
 
-      <Modal show={showModal} onHide={handleModalClose} className="dl-modal">
+      <Modal
+        show={showModal}
+        onHide={handleModalClose}
+        className="ct-document-list"
+      >
         <Modal.Header closeButton>
           <Modal.Title>Withdraw Document</Modal.Title>
         </Modal.Header>

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.scss
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.scss
@@ -1,4 +1,4 @@
-.ct-document-list {
+.documentList {
   .header {
     display: flex;
     flex-wrap: wrap;
@@ -27,14 +27,28 @@
   li span.file-cell {
     padding-top: 1px;
   }
+  .hidden {
+    display: none;
+  }
 }
-.hidden {
-  display: none;
-}
-.modal-body p, .modal-body .row div {
-  text-overflow: ellipsis;
-  overflow: hidden;
-}
-.modal-body .data {
-  font-weight: bold;
+.dl-modal {
+  .modal-body p,
+  .modal-body .row div {
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+  .modal-body .data {
+    font-weight: bold;
+  }
+  .modal-footer {
+    display: block;
+    align-items: normal;
+    justify-content: normal;
+  }
+  .pull-left {
+    float: left;
+  }
+  .pull-right {
+    float: right;
+  }
 }

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.scss
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.scss
@@ -28,3 +28,13 @@
     padding-top: 1px;
   }
 }
+.hidden {
+  display: none;
+}
+.modal-body p, .modal-body .row div {
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+.modal-body .data {
+  font-weight: bold;
+}

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.scss
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.scss
@@ -1,4 +1,4 @@
-.documentList {
+.ct-document-list {
   .header {
     display: flex;
     flex-wrap: wrap;
@@ -30,8 +30,6 @@
   .hidden {
     display: none;
   }
-}
-.dl-modal {
   .modal-body p,
   .modal-body .row div {
     text-overflow: ellipsis;

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.test.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.test.js
@@ -9,6 +9,7 @@ describe("DocumentList Component Testsuite", () => {
   const documents = [
     {
       identifier: "1",
+      filingDate: "2020-05-05T00:00:00.000Z",
       documentProperties: {
         type: "AFF",
         name: "test-document.pdf",
@@ -16,7 +17,6 @@ describe("DocumentList Component Testsuite", () => {
       status: {
         description: "Submitted",
       },
-      filingDate: "2020-05-05T00:00:00.000Z",
     },
   ];
   const reloadDocumentList = jest.fn();

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.test.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/DocumentList.test.js
@@ -16,6 +16,7 @@ describe("DocumentList Component Testsuite", () => {
       status: {
         description: "Submitted",
       },
+      filingDate: "2020-05-05T00:00:00.000Z",
     },
   ];
   const reloadDocumentList = jest.fn();
@@ -173,7 +174,7 @@ describe("DocumentList Component Testsuite", () => {
     );
   });
 
-  test("Delete document (click) success", async () => {
+  test("Withdraw document (click) success", async () => {
     // stub out service to return valid response.
     pkgRvwService.withdrawSubmittedDocument = jest.fn(() => Promise.resolve());
 
@@ -194,7 +195,7 @@ describe("DocumentList Component Testsuite", () => {
     expect(pkgRvwService.withdrawSubmittedDocument()).resolves.not.toThrow();
   });
 
-  test("Delete document (click) fail", async () => {
+  test("Withdraw document (click) fail", async () => {
     const errorMessage = "Network Error";
     // stub out service to return failed response.
     pkgRvwService.withdrawSubmittedDocument = jest.fn(() =>
@@ -220,7 +221,7 @@ describe("DocumentList Component Testsuite", () => {
     );
   });
 
-  test("Delete document (keyDown=13) success", async () => {
+  test("Withdraw document (keyDown=13) success", async () => {
     // stub out service to return valid response.
     pkgRvwService.withdrawSubmittedDocument = jest.fn(() => Promise.resolve());
 
@@ -251,7 +252,7 @@ describe("DocumentList Component Testsuite", () => {
     expect(pkgRvwService.withdrawSubmittedDocument()).resolves.not.toThrow();
   });
 
-  test("Delete document (keyDown) fail", async () => {
+  test("Withdraw document (keyDown) fail", async () => {
     const errorMessage = "Network Error";
     // stub out service to return failed response.
     pkgRvwService.withdrawSubmittedDocument = jest.fn(() =>

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.test.js.snap
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.test.js.snap
@@ -522,7 +522,7 @@ exports[`PackageReview Component Reload Document trigger 1`] = `
       </nav>
     </header>
     <div
-      class="page"
+      class="ct-package-review page"
     >
       <div
         class="content col-md-8"
@@ -575,6 +575,7 @@ exports[`PackageReview Component Reload Document trigger 1`] = `
         <br />
         <div
           class="row"
+          data-test-id="detailsTable"
         >
           <div
             class="col-sm-12 col-lg-6"
@@ -723,7 +724,7 @@ exports[`PackageReview Component Reload Document trigger 1`] = `
           >
             <br />
             <div
-              class="documentList"
+              class="ct-document-list"
             >
               <div
                 class="header"
@@ -993,7 +994,7 @@ exports[`PackageReview Component Withdraw document network error 1`] = `
       </nav>
     </header>
     <div
-      class="page"
+      class="ct-package-review page"
     >
       <div
         class="content col-md-8"
@@ -1046,6 +1047,7 @@ exports[`PackageReview Component Withdraw document network error 1`] = `
         <br />
         <div
           class="row"
+          data-test-id="detailsTable"
         >
           <div
             class="col-sm-12 col-lg-6"
@@ -1194,7 +1196,7 @@ exports[`PackageReview Component Withdraw document network error 1`] = `
           >
             <br />
             <div
-              class="documentList"
+              class="ct-document-list"
             >
               <div
                 class="header"

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.test.js.snap
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.test.js.snap
@@ -723,7 +723,9 @@ exports[`PackageReview Component Reload Document trigger 1`] = `
             role="tabpanel"
           >
             <br />
-            <div>
+            <div
+              class="documentList"
+            >
               <div
                 class="header"
               >
@@ -1175,7 +1177,9 @@ exports[`PackageReview Component Withdraw document network error 1`] = `
             role="tabpanel"
           >
             <br />
-            <div>
+            <div
+              class="documentList"
+            >
               <div
                 class="header"
               >

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.test.js.snap
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.test.js.snap
@@ -707,7 +707,6 @@ exports[`PackageReview Component Reload Document trigger 1`] = `
             href="#"
             id="uncontrolled-tab-tab-comments"
             role="tab"
-            tabindex="-1"
           >
             Filing Comments
           </a>
@@ -802,6 +801,24 @@ exports[`PackageReview Component Reload Document trigger 1`] = `
                     >
                       withdraw
                     </span>
+                    <svg
+                      fill="currentColor"
+                      height="1em"
+                      id="withdraw-tooltip"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      style="color: rgb(117, 152, 202); font-size: 20px; margin-left: 10px;"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+                      />
+                    </svg>
+                    <div
+                      class="bcgov-withdraw-tooltip "
+                    />
                   </span>
                 </li>
               </ul>
@@ -1161,7 +1178,6 @@ exports[`PackageReview Component Withdraw document network error 1`] = `
             href="#"
             id="uncontrolled-tab-tab-comments"
             role="tab"
-            tabindex="-1"
           >
             Filing Comments
           </a>
@@ -1256,6 +1272,24 @@ exports[`PackageReview Component Withdraw document network error 1`] = `
                     >
                       withdraw
                     </span>
+                    <svg
+                      fill="currentColor"
+                      height="1em"
+                      id="withdraw-tooltip"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      style="color: rgb(117, 152, 202); font-size: 20px; margin-left: 10px;"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+                      />
+                    </svg>
+                    <div
+                      class="bcgov-withdraw-tooltip "
+                    />
                   </span>
                 </li>
               </ul>

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.test.js.snap
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.test.js.snap
@@ -475,3 +475,907 @@ Duis aute irure dolor.
   </main>
 </DocumentFragment>
 `;
+
+exports[`PackageReview Component Reload Document trigger 1`] = `
+<DocumentFragment>
+  <main>
+    <header
+      class="bcgov-header"
+    >
+      <nav
+        aria-label="Header"
+        class="container-fluid navbar navbar-expand-lg navbar-dark"
+      >
+        <div
+          aria-labelledby="title"
+          class="navbar-brand bcgov-pointer"
+        />
+        <img
+          alt="B.C. Government Logo"
+          class="img-fluid d-none d-md-block bcgov-pointer"
+          height="44"
+          src="undefined/images/bcid-logo-rev-en.svg"
+          width="181"
+        />
+        <img
+          alt="B.C. Government Logo"
+          class="img-fluid d-md-none bcgov-pointer"
+          height="44"
+          src="undefined/images/bcid-symbol-rev.svg"
+          width="64"
+        />
+        <div
+          aria-labelledby="title"
+          class="bcgov-pointer navbar-brand nav-item nav-link"
+        />
+        <div
+          class="bcgov-flex-spacing"
+        >
+          <div
+            class="navbar-brand bcgov-vertical-center"
+            id="title"
+          >
+            eFiling Frontend
+          </div>
+          <div />
+        </div>
+      </nav>
+    </header>
+    <div
+      class="page"
+    >
+      <div
+        class="content col-md-8"
+      >
+        <h1>
+          View Recently Submitted Package # 1
+        </h1>
+        <br />
+        <div
+          class="row"
+        >
+          <h2
+            class="col-sm-6"
+          >
+            Package Details
+          </h2>
+          <div
+            class="col-sm-6 text-sm-right mt-3 mt-sm-0"
+          >
+            <span
+              class="file-href"
+              role="button"
+              tabindex="0"
+            >
+              Print Submission Sheet
+            </span>
+            <svg
+              class="align-icon"
+              color="#7F7F7F"
+              fill="currentColor"
+              height="24"
+              stroke="currentColor"
+              stroke-width="0"
+              style="color: rgb(127, 127, 127);"
+              viewBox="0 0 16 16"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10.5 8a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0z"
+              />
+              <path
+                clip-rule="evenodd"
+                d="M0 8s3-5.5 8-5.5S16 8 16 8s-3 5.5-8 5.5S0 8 0 8zm8 3.5a3.5 3.5 0 100-7 3.5 3.5 0 000 7z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </div>
+        </div>
+        <br />
+        <div
+          class="row"
+        >
+          <div
+            class="col-sm-12 col-lg-6"
+          >
+            <div
+              class="bcgov-table "
+            >
+              <b />
+              <div
+                class="bcgov-table-body"
+              >
+                <div
+                  class="bcgov-row "
+                >
+                  <div
+                    class="bcgov-fill-width"
+                  >
+                    Submitted By:
+                  </div>
+                  <div
+                    class="bcgov-table-value "
+                  >
+                    <b>
+                      Han Solo
+                    </b>
+                  </div>
+                </div>
+                <div
+                  class="bcgov-row "
+                >
+                  <div
+                    class="bcgov-fill-width"
+                  >
+                    Submitted Date:
+                  </div>
+                  <div
+                    class="bcgov-table-value "
+                  >
+                    <b>
+                      14-Jan-2021 10:57
+                    </b>
+                  </div>
+                </div>
+                <div
+                  class="bcgov-row "
+                >
+                  <div
+                    class="bcgov-fill-width"
+                  >
+                    Submitted To:
+                  </div>
+                  <div
+                    class="bcgov-table-value "
+                  >
+                    <b>
+                      Kelowna Law Courts
+                    </b>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="col-sm-12 col-lg-6"
+          >
+            <div
+              class="bcgov-table "
+            >
+              <b />
+              <div
+                class="bcgov-table-body"
+              >
+                <div
+                  class="bcgov-row "
+                >
+                  <div
+                    class="bcgov-fill-width"
+                  >
+                    Package Number:
+                  </div>
+                  <div
+                    class="bcgov-table-value "
+                  >
+                    <b>
+                      1
+                    </b>
+                  </div>
+                </div>
+                <div
+                  class="bcgov-row "
+                >
+                  <div
+                    class="bcgov-fill-width"
+                  >
+                    Court File Number:
+                  </div>
+                  <div
+                    class="bcgov-table-value "
+                  >
+                    <b>
+                      Court file number
+                    </b>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <br />
+        <nav
+          class="nav nav-tabs"
+          role="tablist"
+        >
+          <a
+            aria-controls="uncontrolled-tab-tabpane-documents"
+            aria-selected="true"
+            class="nav-item nav-link active"
+            data-rb-event-key="documents"
+            href="#"
+            id="uncontrolled-tab-tab-documents"
+            role="tab"
+          >
+            Documents
+          </a>
+          <a
+            aria-controls="uncontrolled-tab-tabpane-comments"
+            aria-selected="false"
+            class="nav-item nav-link"
+            data-rb-event-key="comments"
+            href="#"
+            id="uncontrolled-tab-tab-comments"
+            role="tab"
+            tabindex="-1"
+          >
+            Filing Comments
+          </a>
+        </nav>
+        <div
+          class="tab-content"
+        >
+          <div
+            aria-hidden="false"
+            aria-labelledby="uncontrolled-tab-tab-documents"
+            class="fade tab-pane active show"
+            id="uncontrolled-tab-tabpane-documents"
+            role="tabpanel"
+          >
+            <br />
+            <div>
+              <div
+                class="header"
+              >
+                <span
+                  class="d-none d-lg-inline col-lg-3"
+                >
+                  Document Type
+                </span>
+                <span
+                  class="d-none d-lg-inline col-lg-4"
+                >
+                  File Name
+                </span>
+                <span
+                  class="d-none d-lg-inline col-lg-3"
+                >
+                  Status
+                </span>
+                <span
+                  class="d-none d-lg-inline col-lg-2"
+                >
+                  Action (s)
+                </span>
+              </div>
+              <ul>
+                <li>
+                  <span
+                    class="label col-sm-4 d-lg-none"
+                  >
+                    Document Type:
+                  </span>
+                  <span
+                    class="col-sm-8 col-lg-3"
+                  />
+                  <span
+                    class="label col-sm-4 d-lg-none"
+                  >
+                    File Name:
+                  </span>
+                  <span
+                    class="col-sm-8 col-lg-4 file-cell"
+                  >
+                    <span
+                      class="file-href"
+                      role="button"
+                      tabindex="0"
+                    >
+                      test-document.pdf
+                    </span>
+                  </span>
+                  <span
+                    class="label col-sm-4 d-lg-none"
+                  >
+                    Status:
+                  </span>
+                  <span
+                    class="col-sm-8 col-lg-3"
+                  >
+                    Submitted
+                  </span>
+                  <span
+                    class="label col-sm-4 d-lg-none"
+                  >
+                    Action (s):
+                  </span>
+                  <span
+                    class="col-sm-8 col-lg-2 file-cell"
+                  >
+                    <span
+                      class="file-href"
+                      id="withdraw_1"
+                      role="button"
+                      tabindex="0"
+                    >
+                      withdraw
+                    </span>
+                  </span>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div
+            aria-hidden="true"
+            aria-labelledby="uncontrolled-tab-tab-comments"
+            class="fade tab-pane"
+            id="uncontrolled-tab-tabpane-comments"
+            role="tabpanel"
+          >
+            <br />
+            <h4>
+              Filing Comments
+            </h4>
+            <div
+              class="tabContent"
+              id="filingComments"
+            />
+          </div>
+        </div>
+        <br />
+        <section
+          class="buttons pt-2"
+        >
+          <button
+            class="bcgov-button normal-white btn"
+            data-test-id=""
+            type="button"
+          >
+            Cancel and Return to Parent App
+          </button>
+        </section>
+      </div>
+    </div>
+    <footer
+      class="bcgov-footer"
+    >
+      <nav
+        aria-label="Footer"
+        class="navbar navbar-expand-sm navbar-dark justify-content-end"
+      >
+        <button
+          class="navbar-toggler"
+          data-target="#footerBar"
+          data-toggle="collapse"
+          type="button"
+        >
+          <span
+            class="navbar-toggler-icon"
+          />
+        </button>
+        <div
+          class="collapse navbar-collapse flex-grow-0"
+          id="footerBar"
+        >
+          <ul
+            class="navbar-nav text-right"
+          >
+            <li
+              class="nav-item m-1"
+            >
+              <a
+                class="nav-link"
+                href="https://www2.gov.bc.ca"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                BC Government
+              </a>
+            </li>
+            <li
+              class="nav-item m-1"
+            >
+              <a
+                class="nav-link"
+                href="https://www2.gov.bc.ca/gov/content/home/disclaimer"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Disclaimer
+              </a>
+            </li>
+            <li
+              class="nav-item m-1"
+            >
+              <a
+                class="nav-link"
+                href="https://www2.gov.bc.ca/gov/content/home/privacy"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Privacy
+              </a>
+            </li>
+            <li
+              class="nav-item m-1"
+            >
+              <a
+                class="nav-link"
+                href="https://www2.gov.bc.ca/gov/content/home/accessibility"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Accessibility
+              </a>
+            </li>
+            <li
+              class="nav-item m-1"
+            >
+              <a
+                class="nav-link"
+                href="https://www2.gov.bc.ca/gov/content/home/copyright"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Copyright
+              </a>
+            </li>
+          </ul>
+        </div>
+      </nav>
+    </footer>
+  </main>
+</DocumentFragment>
+`;
+
+exports[`PackageReview Component Withdraw document network error 1`] = `
+<DocumentFragment>
+  <main>
+    <header
+      class="bcgov-header"
+    >
+      <nav
+        aria-label="Header"
+        class="container-fluid navbar navbar-expand-lg navbar-dark"
+      >
+        <div
+          aria-labelledby="title"
+          class="navbar-brand bcgov-pointer"
+        />
+        <img
+          alt="B.C. Government Logo"
+          class="img-fluid d-none d-md-block bcgov-pointer"
+          height="44"
+          src="undefined/images/bcid-logo-rev-en.svg"
+          width="181"
+        />
+        <img
+          alt="B.C. Government Logo"
+          class="img-fluid d-md-none bcgov-pointer"
+          height="44"
+          src="undefined/images/bcid-symbol-rev.svg"
+          width="64"
+        />
+        <div
+          aria-labelledby="title"
+          class="bcgov-pointer navbar-brand nav-item nav-link"
+        />
+        <div
+          class="bcgov-flex-spacing"
+        >
+          <div
+            class="navbar-brand bcgov-vertical-center"
+            id="title"
+          >
+            eFiling Frontend
+          </div>
+          <div />
+        </div>
+      </nav>
+    </header>
+    <div
+      class="page"
+    >
+      <div
+        class="content col-md-8"
+      >
+        <h1>
+          View Recently Submitted Package # 1
+        </h1>
+        <br />
+        <div
+          class="row"
+        >
+          <h2
+            class="col-sm-6"
+          >
+            Package Details
+          </h2>
+          <div
+            class="col-sm-6 text-sm-right mt-3 mt-sm-0"
+          >
+            <span
+              class="file-href"
+              role="button"
+              tabindex="0"
+            >
+              Print Submission Sheet
+            </span>
+            <svg
+              class="align-icon"
+              color="#7F7F7F"
+              fill="currentColor"
+              height="24"
+              stroke="currentColor"
+              stroke-width="0"
+              style="color: rgb(127, 127, 127);"
+              viewBox="0 0 16 16"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10.5 8a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0z"
+              />
+              <path
+                clip-rule="evenodd"
+                d="M0 8s3-5.5 8-5.5S16 8 16 8s-3 5.5-8 5.5S0 8 0 8zm8 3.5a3.5 3.5 0 100-7 3.5 3.5 0 000 7z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </div>
+        </div>
+        <br />
+        <div
+          class="row"
+        >
+          <div
+            class="col-sm-12 col-lg-6"
+          >
+            <div
+              class="bcgov-table "
+            >
+              <b />
+              <div
+                class="bcgov-table-body"
+              >
+                <div
+                  class="bcgov-row "
+                >
+                  <div
+                    class="bcgov-fill-width"
+                  >
+                    Submitted By:
+                  </div>
+                  <div
+                    class="bcgov-table-value "
+                  >
+                    <b>
+                      Han Solo
+                    </b>
+                  </div>
+                </div>
+                <div
+                  class="bcgov-row "
+                >
+                  <div
+                    class="bcgov-fill-width"
+                  >
+                    Submitted Date:
+                  </div>
+                  <div
+                    class="bcgov-table-value "
+                  >
+                    <b>
+                      14-Jan-2021 10:57
+                    </b>
+                  </div>
+                </div>
+                <div
+                  class="bcgov-row "
+                >
+                  <div
+                    class="bcgov-fill-width"
+                  >
+                    Submitted To:
+                  </div>
+                  <div
+                    class="bcgov-table-value "
+                  >
+                    <b>
+                      Kelowna Law Courts
+                    </b>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="col-sm-12 col-lg-6"
+          >
+            <div
+              class="bcgov-table "
+            >
+              <b />
+              <div
+                class="bcgov-table-body"
+              >
+                <div
+                  class="bcgov-row "
+                >
+                  <div
+                    class="bcgov-fill-width"
+                  >
+                    Package Number:
+                  </div>
+                  <div
+                    class="bcgov-table-value "
+                  >
+                    <b>
+                      1
+                    </b>
+                  </div>
+                </div>
+                <div
+                  class="bcgov-row "
+                >
+                  <div
+                    class="bcgov-fill-width"
+                  >
+                    Court File Number:
+                  </div>
+                  <div
+                    class="bcgov-table-value "
+                  >
+                    <b>
+                      Court file number
+                    </b>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <br />
+        <nav
+          class="nav nav-tabs"
+          role="tablist"
+        >
+          <a
+            aria-controls="uncontrolled-tab-tabpane-documents"
+            aria-selected="true"
+            class="nav-item nav-link active"
+            data-rb-event-key="documents"
+            href="#"
+            id="uncontrolled-tab-tab-documents"
+            role="tab"
+          >
+            Documents
+          </a>
+          <a
+            aria-controls="uncontrolled-tab-tabpane-comments"
+            aria-selected="false"
+            class="nav-item nav-link"
+            data-rb-event-key="comments"
+            href="#"
+            id="uncontrolled-tab-tab-comments"
+            role="tab"
+            tabindex="-1"
+          >
+            Filing Comments
+          </a>
+        </nav>
+        <div
+          class="tab-content"
+        >
+          <div
+            aria-hidden="false"
+            aria-labelledby="uncontrolled-tab-tab-documents"
+            class="fade tab-pane active show"
+            id="uncontrolled-tab-tabpane-documents"
+            role="tabpanel"
+          >
+            <br />
+            <div>
+              <div
+                class="header"
+              >
+                <span
+                  class="d-none d-lg-inline col-lg-3"
+                >
+                  Document Type
+                </span>
+                <span
+                  class="d-none d-lg-inline col-lg-4"
+                >
+                  File Name
+                </span>
+                <span
+                  class="d-none d-lg-inline col-lg-3"
+                >
+                  Status
+                </span>
+                <span
+                  class="d-none d-lg-inline col-lg-2"
+                >
+                  Action (s)
+                </span>
+              </div>
+              <ul>
+                <li>
+                  <span
+                    class="label col-sm-4 d-lg-none"
+                  >
+                    Document Type:
+                  </span>
+                  <span
+                    class="col-sm-8 col-lg-3"
+                  />
+                  <span
+                    class="label col-sm-4 d-lg-none"
+                  >
+                    File Name:
+                  </span>
+                  <span
+                    class="col-sm-8 col-lg-4 file-cell"
+                  >
+                    <span
+                      class="file-href"
+                      role="button"
+                      tabindex="0"
+                    >
+                      test-document.pdf
+                    </span>
+                  </span>
+                  <span
+                    class="label col-sm-4 d-lg-none"
+                  >
+                    Status:
+                  </span>
+                  <span
+                    class="col-sm-8 col-lg-3"
+                  >
+                    Submitted
+                  </span>
+                  <span
+                    class="label col-sm-4 d-lg-none"
+                  >
+                    Action (s):
+                  </span>
+                  <span
+                    class="col-sm-8 col-lg-2 file-cell"
+                  >
+                    <span
+                      class="file-href"
+                      id="withdraw_1"
+                      role="button"
+                      tabindex="0"
+                    >
+                      withdraw
+                    </span>
+                  </span>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div
+            aria-hidden="true"
+            aria-labelledby="uncontrolled-tab-tab-comments"
+            class="fade tab-pane"
+            id="uncontrolled-tab-tabpane-comments"
+            role="tabpanel"
+          >
+            <br />
+            <h4>
+              Filing Comments
+            </h4>
+            <div
+              class="tabContent"
+              id="filingComments"
+            />
+          </div>
+        </div>
+        <br />
+        <section
+          class="buttons pt-2"
+        >
+          <button
+            class="bcgov-button normal-white btn"
+            data-test-id=""
+            type="button"
+          >
+            Cancel and Return to Parent App
+          </button>
+        </section>
+      </div>
+    </div>
+    <footer
+      class="bcgov-footer"
+    >
+      <nav
+        aria-label="Footer"
+        class="navbar navbar-expand-sm navbar-dark justify-content-end"
+      >
+        <button
+          class="navbar-toggler"
+          data-target="#footerBar"
+          data-toggle="collapse"
+          type="button"
+        >
+          <span
+            class="navbar-toggler-icon"
+          />
+        </button>
+        <div
+          class="collapse navbar-collapse flex-grow-0"
+          id="footerBar"
+        >
+          <ul
+            class="navbar-nav text-right"
+          >
+            <li
+              class="nav-item m-1"
+            >
+              <a
+                class="nav-link"
+                href="https://www2.gov.bc.ca"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                BC Government
+              </a>
+            </li>
+            <li
+              class="nav-item m-1"
+            >
+              <a
+                class="nav-link"
+                href="https://www2.gov.bc.ca/gov/content/home/disclaimer"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Disclaimer
+              </a>
+            </li>
+            <li
+              class="nav-item m-1"
+            >
+              <a
+                class="nav-link"
+                href="https://www2.gov.bc.ca/gov/content/home/privacy"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Privacy
+              </a>
+            </li>
+            <li
+              class="nav-item m-1"
+            >
+              <a
+                class="nav-link"
+                href="https://www2.gov.bc.ca/gov/content/home/accessibility"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Accessibility
+              </a>
+            </li>
+            <li
+              class="nav-item m-1"
+            >
+              <a
+                class="nav-link"
+                href="https://www2.gov.bc.ca/gov/content/home/copyright"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Copyright
+              </a>
+            </li>
+          </ul>
+        </div>
+      </nav>
+    </footer>
+  </main>
+</DocumentFragment>
+`;


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

https://justice.gov.bc.ca/jira/browse/FLA-767
- Added confirmation modal dialog to withdraw link
- Converted DocumentList to use scss instead of craco (argh, css issues).
- Added unit tests
- Tried to use bcgov styles instead of wireframe or shared-components

For some reason I'm not showing 100% coverage, but I don't know what is missing.

TODO: move the modal to a common BCGov component

![image](https://user-images.githubusercontent.com/55215368/107563170-95a74a80-6b95-11eb-9a8d-d5445e445632.png)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

yarn lint
yarn test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
