### PR TITLE
Add new endpoint in Efiling-Reviewer-Api to capture document status event changes

### DIFF
--- a/src/backend/efiling-reviewer-api/jag-reviewer-api.yaml
+++ b/src/backend/efiling-reviewer-api/jag-reviewer-api.yaml
@@ -40,6 +40,22 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+  "/documents/event":
+    post:
+      summary: to inform api on a document event
+      operationId: DocumentEvent
+      tags:
+        - document
+      parameters:
+        - $ref: "#/components/parameters/xTransactionId"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DocumentEvent"
+      responses:
+        "204":
+          description: Document Event acknoledged
 components:
   parameters:
     xTransactionId:
@@ -58,17 +74,19 @@ components:
       schema:
         type: string
   schemas:
-    DocumentExtractResponse:
-      type: object
-      description: Review upload response
+    ApiError:
       required:
-        - extract
-        - document
+        - error
+        - message
       properties:
-        extract:
-          $ref: "#/components/schemas/Extract"
-        document:
-          $ref: "#/components/schemas/Document"
+        error:
+          type: string
+        message:
+          type: string
+        details:
+          type: array
+          items:
+            type: string
     Document:
       type: object
       required:
@@ -86,6 +104,25 @@ components:
           format: integer
         contentType:
           type: string
+    DocumentExtractResponse:
+      type: object
+      description: Review upload response
+      required:
+        - extract
+        - document
+      properties:
+        extract:
+          $ref: "#/components/schemas/Extract"
+        document:
+          $ref: "#/components/schemas/Document"
+    DocumentEvent:
+      type: object
+      properties:
+        status:
+          type: string
+        documentId:
+          type: number
+          format: integer
     Extract:
       type: object
       required:
@@ -98,16 +135,4 @@ components:
         transactionId:
           type: string
           format: uuid
-    ApiError:
-      required:
-        - error
-        - message
-      properties:
-        error:
-          type: string
-        message:
-          type: string
-        details:
-          type: array
-          items:
-            type: string
+    

--- a/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/document/DocumentsApiDelegateImpl.java
+++ b/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/document/DocumentsApiDelegateImpl.java
@@ -1,10 +1,10 @@
-package ca.bc.gov.open.jag.efilingreviewerapi.extract;
+package ca.bc.gov.open.jag.efilingreviewerapi.document;
 
 import ca.bc.gov.open.clamav.starter.ClamAvService;
 import ca.bc.gov.open.clamav.starter.VirusDetectedException;
 import ca.bc.gov.open.efilingdiligenclient.diligen.DiligenService;
-import ca.bc.gov.open.efilingdiligenclient.exception.DiligenDocumentException;
 import ca.bc.gov.open.jag.efilingreviewerapi.api.DocumentsApiDelegate;
+import ca.bc.gov.open.jag.efilingreviewerapi.api.model.DocumentEvent;
 import ca.bc.gov.open.jag.efilingreviewerapi.api.model.DocumentExtractResponse;
 import ca.bc.gov.open.jag.efilingreviewerapi.error.AiReviewerDocumentException;
 import ca.bc.gov.open.jag.efilingreviewerapi.error.AiReviewerVirusFoundException;
@@ -15,6 +15,7 @@ import ca.bc.gov.open.jag.efilingreviewerapi.extract.models.ExtractRequest;
 import ca.bc.gov.open.jag.efilingreviewerapi.extract.store.ExtractStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -67,6 +68,14 @@ public class DocumentsApiDelegateImpl implements DocumentsApiDelegate {
             throw new AiReviewerCacheException("Could not cache extract request");
 
         return ResponseEntity.ok(extractRequestMapper.toDocumentExtractResponse(extractRequestCached.get()));
+
+    }
+
+    @Override
+    public ResponseEntity<Void> documentEvent(UUID xTransactionId, DocumentEvent documentEvent) {
+
+        logger.info("document {} status has changed to {}", documentEvent.getDocumentId(), documentEvent.getStatus());
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
 
     }
 }

--- a/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/error/AiReviewerControllerAdvisor.java
+++ b/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/error/AiReviewerControllerAdvisor.java
@@ -1,12 +1,8 @@
-package ca.bc.gov.open.jag.efilingreviewerapi.extract;
+package ca.bc.gov.open.jag.efilingreviewerapi.error;
 
 import ca.bc.gov.open.efilingdiligenclient.exception.DiligenAuthenticationException;
 import ca.bc.gov.open.efilingdiligenclient.exception.DiligenDocumentException;
-import ca.bc.gov.open.jag.efilingreviewerapi.error.AiReviewerDocumentException;
-import ca.bc.gov.open.jag.efilingreviewerapi.error.AiReviewerVirusFoundException;
 import ca.bc.gov.open.jag.efilingreviewerapi.api.model.ApiError;
-import ca.bc.gov.open.jag.efilingreviewerapi.error.AiReviewerCacheException;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -14,7 +10,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 
 @ControllerAdvice
-public class DiligenControllerAdvisor {
+public class AiReviewerControllerAdvisor {
 
     @ExceptionHandler(DiligenDocumentException.class)
     public ResponseEntity<Object> handleDiligenDocumentException(DiligenDocumentException ex, WebRequest request) {

--- a/src/backend/efiling-reviewer-api/src/test/java/ca/bc/gov/open/jag/efilingreviewerapi/document/documentsApiDelegateImpl/DocumentEventTest.java
+++ b/src/backend/efiling-reviewer-api/src/test/java/ca/bc/gov/open/jag/efilingreviewerapi/document/documentsApiDelegateImpl/DocumentEventTest.java
@@ -1,0 +1,57 @@
+package ca.bc.gov.open.jag.efilingreviewerapi.document.documentsApiDelegateImpl;
+
+import ca.bc.gov.open.clamav.starter.ClamAvService;
+import ca.bc.gov.open.efilingdiligenclient.diligen.DiligenService;
+import ca.bc.gov.open.jag.efilingreviewerapi.api.model.DocumentEvent;
+import ca.bc.gov.open.jag.efilingreviewerapi.document.DocumentsApiDelegateImpl;
+import ca.bc.gov.open.jag.efilingreviewerapi.extract.mappers.ExtractMapper;
+import ca.bc.gov.open.jag.efilingreviewerapi.extract.mappers.ExtractMapperImpl;
+import ca.bc.gov.open.jag.efilingreviewerapi.extract.mappers.ExtractRequestMapper;
+import ca.bc.gov.open.jag.efilingreviewerapi.extract.mappers.ExtractRequestMapperImpl;
+import ca.bc.gov.open.jag.efilingreviewerapi.extract.store.ExtractStore;
+import org.junit.jupiter.api.*;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class DocumentEventTest {
+
+    private DocumentsApiDelegateImpl sut;
+    @Mock
+    private DiligenService diligenServiceMock;
+    @Mock
+    private ExtractStore extractStoreMock;
+    @Mock
+    private ClamAvService clamAvServiceMock;
+
+    @BeforeAll
+    public void beforeAll() {
+
+        MockitoAnnotations.openMocks(this);
+
+        ExtractMapper extractMapper = new ExtractMapperImpl();
+        ExtractRequestMapper extratRequestMapper = new ExtractRequestMapperImpl(extractMapper);
+        sut = new DocumentsApiDelegateImpl(diligenServiceMock, extratRequestMapper, extractStoreMock, clamAvServiceMock);
+
+    }
+
+    @Test()
+    @DisplayName("204: accept any event")
+    public void testAnyEvent() {
+
+        DocumentEvent documentEvent = new DocumentEvent();
+        documentEvent.setDocumentId(BigDecimal.ONE);
+        documentEvent.setStatus("Processed");
+        ResponseEntity<Void> actual = sut.documentEvent(UUID.randomUUID(), documentEvent);
+
+        Assertions.assertEquals(HttpStatus.NO_CONTENT, actual.getStatusCode());
+
+    }
+
+
+}

--- a/src/backend/efiling-reviewer-api/src/test/java/ca/bc/gov/open/jag/efilingreviewerapi/document/documentsApiDelegateImpl/ExtractDocumentFormDataTest.java
+++ b/src/backend/efiling-reviewer-api/src/test/java/ca/bc/gov/open/jag/efilingreviewerapi/document/documentsApiDelegateImpl/ExtractDocumentFormDataTest.java
@@ -1,14 +1,13 @@
-package ca.bc.gov.open.jag.efilingreviewerapi.extract.documentsApiDelegateImpl;
+package ca.bc.gov.open.jag.efilingreviewerapi.document.documentsApiDelegateImpl;
 
 import ca.bc.gov.open.clamav.starter.ClamAvService;
 import ca.bc.gov.open.clamav.starter.VirusDetectedException;
 import ca.bc.gov.open.efilingdiligenclient.diligen.DiligenService;
-import ca.bc.gov.open.efilingdiligenclient.exception.DiligenDocumentException;
 import ca.bc.gov.open.jag.efilingreviewerapi.api.model.DocumentExtractResponse;
 import ca.bc.gov.open.jag.efilingreviewerapi.error.AiReviewerDocumentException;
 import ca.bc.gov.open.jag.efilingreviewerapi.error.AiReviewerVirusFoundException;
 import ca.bc.gov.open.jag.efilingreviewerapi.error.AiReviewerCacheException;
-import ca.bc.gov.open.jag.efilingreviewerapi.extract.DocumentsApiDelegateImpl;
+import ca.bc.gov.open.jag.efilingreviewerapi.document.DocumentsApiDelegateImpl;
 import ca.bc.gov.open.jag.efilingreviewerapi.extract.mappers.ExtractMapperImpl;
 import ca.bc.gov.open.jag.efilingreviewerapi.extract.mappers.ExtractRequestMapper;
 import ca.bc.gov.open.jag.efilingreviewerapi.extract.mappers.ExtractRequestMapperImpl;

--- a/src/backend/efiling-reviewer-api/src/test/java/ca/bc/gov/open/jag/efilingreviewerapi/error/AiReviewerControllerAdvisorTest.java
+++ b/src/backend/efiling-reviewer-api/src/test/java/ca/bc/gov/open/jag/efilingreviewerapi/error/AiReviewerControllerAdvisorTest.java
@@ -1,11 +1,8 @@
-package ca.bc.gov.open.jag.efilingreviewerapi.extract;
+package ca.bc.gov.open.jag.efilingreviewerapi.error;
 
 import ca.bc.gov.open.efilingdiligenclient.exception.DiligenAuthenticationException;
 import ca.bc.gov.open.efilingdiligenclient.exception.DiligenDocumentException;
-import ca.bc.gov.open.jag.efilingreviewerapi.error.AiReviewerDocumentException;
-import ca.bc.gov.open.jag.efilingreviewerapi.error.AiReviewerVirusFoundException;
 import ca.bc.gov.open.jag.efilingreviewerapi.api.model.ApiError;
-import ca.bc.gov.open.jag.efilingreviewerapi.error.AiReviewerCacheException;
 import org.junit.jupiter.api.*;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -16,9 +13,9 @@ import org.springframework.web.context.request.WebRequest;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @DisplayName("DiligenControllerAdvisor test suite")
-public class DiligenControllerAdvisorTest {
+public class AiReviewerControllerAdvisorTest {
 
-    public DiligenControllerAdvisor sut;
+    public AiReviewerControllerAdvisor sut;
 
     @Mock
     private WebRequest webRequestMock;
@@ -27,7 +24,7 @@ public class DiligenControllerAdvisorTest {
     public void beforeEach() {
         MockitoAnnotations.openMocks(this);
 
-        sut = new DiligenControllerAdvisor();
+        sut = new AiReviewerControllerAdvisor();
 
     }
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- FLA-850 Add new endpoint in Efiling-Reviewer-Api to capture document status event changes

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
