### PR TITLE
fixed the Return home button on Package Review

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -178,8 +178,9 @@ The efiling Package Review screen shows the details of a submitted package.
 
 https://dev.justice.gov.bc.ca/efilinghub/packagereview/:packageId?returnUrl=
 
-The returnUrl parameter is optional, but if an encoded URL is supplied, the page will render with a button 
-that will return the user to the given URL (i.e., parent application).
+The returnUrl parameter is optional, but if an encoded URL is supplied, the
+page will render with a button that will return the user to the given URL
+(i.e., parent application).
 
 ### Api Documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -172,6 +172,15 @@ The `organizationParties` array represents a list of organization parties for th
 | roleType   | string | true     | the party role, see [Party Role](data.md#Party-Role)                                            |
 | name       | string | true     | the organization name                                                                            |
 
+### Package Review
+
+The efiling Package Review screen shows the details of a submitted package.
+
+https://dev.justice.gov.bc.ca/efilinghub/packagereview/:packageId?returnUrl=
+
+The returnUrl parameter is optional, but if an encoded URL is supplied, the page will render with a button 
+that will return the user to the given URL (i.e., parent application).
+
 ### Api Documentation
 
 eFiling API is documented using [openapi](http://editor.swagger.io/?url=https://raw.githubusercontent.com/bcgov/jag-file-submission/master/src/backend/efiling-api/jag-efiling-api.yaml) and we have a [postman collection](https://raw.githubusercontent.com/bcgov/jag-file-submission/master/src/backend/jag-efiling-api/src/test/jag-efiling-api.postman_collection.json) that you can use to test the eFiling API

--- a/src/frontend/efiling-demo/.gitignore
+++ b/src/frontend/efiling-demo/.gitignore
@@ -23,3 +23,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.vscode/launch.json

--- a/src/frontend/efiling-demo/src/components/page/success/Success.js
+++ b/src/frontend/efiling-demo/src/components/page/success/Success.js
@@ -6,7 +6,9 @@ import { propTypes } from "../../../types/propTypes";
 export default function Success({ page: { header, packageRef } }) {
   const openPackageRef = () => {
     const buff = Buffer.from(packageRef, "base64");
-    const url = buff.toString("ascii");
+    const returnUrl =
+      "https%3A%2F%2Fwww.google.ca%2Fsearch%3Fq%3Dbob%2Bross%26tbm%3Disch";
+    const url = `${buff.toString("ascii")}?returnUrl=${returnUrl}`;
     window.open(url);
   };
 

--- a/src/frontend/efiling-demo/src/components/page/success/Success.test.js
+++ b/src/frontend/efiling-demo/src/components/page/success/Success.test.js
@@ -10,7 +10,9 @@ const header = {
 
 const packageRef = "aHR0cHM6L2thZ2VObz0xMTQzMA==";
 const buff = Buffer.from(packageRef, "base64");
-const url = buff.toString("ascii");
+const returnUrl =
+  "https%3A%2F%2Fwww.google.ca%2Fsearch%3Fq%3Dbob%2Bross%26tbm%3Disch";
+const url = `${buff.toString("ascii")}?returnUrl=${returnUrl}`;
 
 const page = { header, packageRef };
 

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.js
@@ -9,6 +9,7 @@ import { BsEyeFill } from "react-icons/bs";
 import { MdCancel } from "react-icons/md";
 import { useLocation, useParams } from "react-router-dom";
 import queryString from "query-string";
+import validator from "validator";
 import { errorRedirect } from "../../../modules/helpers/errorRedirect";
 import { getSidecardData } from "../../../modules/helpers/sidecardData";
 import {
@@ -239,7 +240,7 @@ export default function PackageReview() {
           >
             view all your previously submitted packages.
           </span>
-          {returnUrl && (
+          {returnUrl && validator.isURL(returnUrl) && (
             <>
               <br />
               <section className="buttons pt-2">

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.js
@@ -23,7 +23,6 @@ import DocumentList from "./DocumentList";
 import PartyList from "./PartyList";
 import PaymentList from "./PaymentList";
 import { isClick, isEnter } from "../../../modules/helpers/eventUtil";
-import { redirectToParentApp } from "../../../modules/helpers/RoutingUtil";
 
 export default function PackageReview() {
   const params = useParams();

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.js
@@ -21,6 +21,7 @@ import DocumentList from "./DocumentList";
 import PartyList from "./PartyList";
 import PaymentList from "./PaymentList";
 import { isClick, isEnter } from "../../../modules/helpers/eventUtil";
+import { redirectToParentApp } from "../../../modules/helpers/RoutingUtil";
 
 export default function PackageReview() {
   const params = useParams();
@@ -234,9 +235,9 @@ export default function PackageReview() {
           </span>
           <section className="buttons pt-2">
             <Button
-              label="Cancel and Return to Parent App"
-              onClick={() => window.open("http://google.com", "_self")}
-              styling="normal-white btn"
+              label="Return to Parent App"
+              onClick={() => redirectToParentApp()}
+              styling="bcgov-normal-white btn"
             />
           </section>
         </div>

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.js
@@ -7,7 +7,8 @@ import Tab from "react-bootstrap/Tab"; /* TODO: replace with shared-components *
 import { Alert, Button, Sidecard, Table } from "shared-components";
 import { BsEyeFill } from "react-icons/bs";
 import { MdCancel } from "react-icons/md";
-import { useParams } from "react-router-dom";
+import { useLocation, useParams } from "react-router-dom";
+import queryString from "query-string";
 import { errorRedirect } from "../../../modules/helpers/errorRedirect";
 import { getSidecardData } from "../../../modules/helpers/sidecardData";
 import {
@@ -26,6 +27,11 @@ import { redirectToParentApp } from "../../../modules/helpers/RoutingUtil";
 export default function PackageReview() {
   const params = useParams();
   const packageId = Number(params.packageId);
+
+  const location = useLocation();
+  const queryParams = queryString.parse(location.search);
+  const { returnUrl } = queryParams;
+
   const [error, setError] = useState(false);
   const [packageDetails, setPackageDetails] = useState([
     { name: "Submitted By:", value: "", isNameBold: false, isValueBold: true },
@@ -233,13 +239,18 @@ export default function PackageReview() {
           >
             view all your previously submitted packages.
           </span>
-          <section className="buttons pt-2">
-            <Button
-              label="Return to Parent App"
-              onClick={() => redirectToParentApp()}
-              styling="bcgov-normal-white btn"
-            />
-          </section>
+          {returnUrl && (
+            <>
+              <br />
+              <section className="buttons pt-2">
+                <Button
+                  label="Return to Parent App"
+                  onClick={() => window.open(returnUrl, "_self")}
+                  styling="bcgov-normal-white btn"
+                />
+              </section>
+            </>
+          )}
         </div>
         <div className="sidecard">
           <Sidecard sideCard={csoAccountDetailsSidecard} />

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.stories.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.stories.js
@@ -4,6 +4,9 @@ import PackageReview from "./PackageReview";
 jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),
   useParams: jest.fn().mockReturnValue({ packageId: 1 }),
+  useLocation: jest
+    .fn()
+    .mockReturnValue({ search: "?returnUrl=http://www.google.com" }),
 }));
 
 export default {

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.stories.storyshot
@@ -467,6 +467,7 @@ exports[`Storyshots PackageReview Default 1`] = `
       >
         view all your previously submitted packages.
       </span>
+      <br />
       <section
         class="buttons pt-2"
       >
@@ -1102,6 +1103,7 @@ exports[`Storyshots PackageReview Mobile 1`] = `
       >
         view all your previously submitted packages.
       </span>
+      <br />
       <section
         class="buttons pt-2"
       >

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.stories.storyshot
@@ -471,11 +471,11 @@ exports[`Storyshots PackageReview Default 1`] = `
         class="buttons pt-2"
       >
         <button
-          class="bcgov-button normal-white btn"
+          class="bcgov-button bcgov-normal-white btn"
           data-test-id=""
           type="button"
         >
-          Cancel and Return to Parent App
+          Return to Parent App
         </button>
       </section>
     </div>
@@ -1106,11 +1106,11 @@ exports[`Storyshots PackageReview Mobile 1`] = `
         class="buttons pt-2"
       >
         <button
-          class="bcgov-button normal-white btn"
+          class="bcgov-button bcgov-normal-white btn"
           data-test-id=""
           type="button"
         >
-          Cancel and Return to Parent App
+          Return to Parent App
         </button>
       </section>
     </div>

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/PackageReview.test.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/PackageReview.test.js
@@ -9,6 +9,7 @@ import PackageReview from "../PackageReview";
 import { getCourtData } from "../../../../modules/test-data/courtTestData";
 import * as packageReviewTestData from "../../../../modules/test-data/packageReviewTestData";
 import { generateJWTToken } from "../../../../modules/helpers/authentication-helper/authenticationHelper";
+import { getNavigationData } from "../../../../modules/test-data/navigationTestData";
 
 const mockHelper = require("../../../../modules/helpers/mockHelper");
 
@@ -24,6 +25,7 @@ describe("PackageReview Component", () => {
   const packageId = "1";
   const links = { packageHistoryUrl: "http://google.com" };
   const courtData = getCourtData();
+  const navigationUrls = getNavigationData();
   const submittedDate = new Date("2021-01-14T18:57:43.602Z").toISOString();
   const submittedBy = { firstName: "Han", lastName: "Solo" };
   const filingComments =
@@ -75,12 +77,15 @@ describe("PackageReview Component", () => {
   });
 
   test("Clicking cancel takes user back to parent app", async () => {
+    const parentAppUrl = navigationUrls.cancel;
+    sessionStorage.setItem("cancelUrl", parentAppUrl);
+
     const { getByText } = render(<PackageReview />);
     await waitFor(() => {});
 
-    fireEvent.click(getByText("Cancel and Return to Parent App"));
+    fireEvent.click(getByText("Return to Parent App"));
 
-    expect(window.open).toHaveBeenCalledWith("http://google.com", "_self");
+    expect(window.open).toHaveBeenCalledWith(parentAppUrl, "_self");
   });
 
   test("Api called successfully when page loads with valid packageId", async () => {

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/PackageReview.test.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/PackageReview.test.js
@@ -95,7 +95,9 @@ describe("PackageReview Component", () => {
     const encodedUrlWithParams = encodeURIComponent(
       "https://www.google.ca/search?q=bob+ross&tbm=isch"
     );
-    expect(encodedUrlWithParams).toEqual("https%3A%2F%2Fwww.google.ca%2Fsearch%3Fq%3Dbob%2Bross%26tbm%3Disch");
+    expect(encodedUrlWithParams).toEqual(
+      "https%3A%2F%2Fwww.google.ca%2Fsearch%3Fq%3Dbob%2Bross%26tbm%3Disch"
+    );
     routerDom.useLocation = jest
       .fn()
       .mockReturnValue({ search: `?returnUrl=${encodedUrlWithParams}` });
@@ -105,7 +107,10 @@ describe("PackageReview Component", () => {
 
     fireEvent.click(getByText("Return to Parent App"));
 
-    expect(window.open).toHaveBeenCalledWith(decodeURIComponent(encodedUrlWithParams), "_self");
+    expect(window.open).toHaveBeenCalledWith(
+      decodeURIComponent(encodedUrlWithParams),
+      "_self"
+    );
   });
 
   test("Clicking cancel takes user back to parent app, invalid URL", async () => {

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/PackageReview.test.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/PackageReview.test.js
@@ -9,13 +9,15 @@ import PackageReview from "../PackageReview";
 import { getCourtData } from "../../../../modules/test-data/courtTestData";
 import * as packageReviewTestData from "../../../../modules/test-data/packageReviewTestData";
 import { generateJWTToken } from "../../../../modules/helpers/authentication-helper/authenticationHelper";
-import { getNavigationData } from "../../../../modules/test-data/navigationTestData";
 
 const mockHelper = require("../../../../modules/helpers/mockHelper");
 
 jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),
   useParams: jest.fn().mockReturnValue({ packageId: 1 }),
+  useLocation: jest
+    .fn()
+    .mockReturnValue({ search: "?returnUrl=http://www.google.com" }),
 }));
 
 // hack fix to force GitHub to run tests in BC timezone
@@ -25,7 +27,6 @@ describe("PackageReview Component", () => {
   const packageId = "1";
   const links = { packageHistoryUrl: "http://google.com" };
   const courtData = getCourtData();
-  const navigationUrls = getNavigationData();
   const submittedDate = new Date("2021-01-14T18:57:43.602Z").toISOString();
   const submittedBy = { firstName: "Han", lastName: "Solo" };
   const filingComments =
@@ -77,15 +78,12 @@ describe("PackageReview Component", () => {
   });
 
   test("Clicking cancel takes user back to parent app", async () => {
-    const parentAppUrl = navigationUrls.cancel;
-    sessionStorage.setItem("cancelUrl", parentAppUrl);
-
     const { getByText } = render(<PackageReview />);
     await waitFor(() => {});
 
     fireEvent.click(getByText("Return to Parent App"));
 
-    expect(window.open).toHaveBeenCalledWith(parentAppUrl, "_self");
+    expect(window.open).toHaveBeenCalledWith("http://www.google.com", "_self");
   });
 
   test("Api called successfully when page loads with valid packageId", async () => {

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/__snapshots__/PackageReview.test.js.snap
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/__snapshots__/PackageReview.test.js.snap
@@ -602,6 +602,7 @@ Duis aute irure dolor.
       >
         view all your previously submitted packages.
       </span>
+      <br />
       <section
         class="buttons pt-2"
       >
@@ -1278,6 +1279,7 @@ exports[`PackageReview Component Reload 1`] = `
       >
         view all your previously submitted packages.
       </span>
+      <br />
       <section
         class="buttons pt-2"
       >
@@ -1954,6 +1956,7 @@ exports[`PackageReview Component Withdraw document network error 1`] = `
       >
         view all your previously submitted packages.
       </span>
+      <br />
       <section
         class="buttons pt-2"
       >

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/__snapshots__/PackageReview.test.js.snap
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/__snapshots__/PackageReview.test.js.snap
@@ -606,11 +606,11 @@ Duis aute irure dolor.
         class="buttons pt-2"
       >
         <button
-          class="bcgov-button normal-white btn"
+          class="bcgov-button bcgov-normal-white btn"
           data-test-id=""
           type="button"
         >
-          Cancel and Return to Parent App
+          Return to Parent App
         </button>
       </section>
     </div>
@@ -1282,11 +1282,11 @@ exports[`PackageReview Component Reload 1`] = `
         class="buttons pt-2"
       >
         <button
-          class="bcgov-button normal-white btn"
+          class="bcgov-button bcgov-normal-white btn"
           data-test-id=""
           type="button"
         >
-          Cancel and Return to Parent App
+          Return to Parent App
         </button>
       </section>
     </div>
@@ -1958,11 +1958,11 @@ exports[`PackageReview Component Withdraw document network error 1`] = `
         class="buttons pt-2"
       >
         <button
-          class="bcgov-button normal-white btn"
+          class="bcgov-button bcgov-normal-white btn"
           data-test-id=""
           type="button"
         >
-          Cancel and Return to Parent App
+          Return to Parent App
         </button>
       </section>
     </div>

--- a/src/frontend/efiling-frontend/src/modules/helpers/RoutingUtil.js
+++ b/src/frontend/efiling-frontend/src/modules/helpers/RoutingUtil.js
@@ -1,0 +1,4 @@
+export function redirectToParentApp() {
+  const parentAppUrl = sessionStorage.getItem("cancelUrl");
+  window.open(parentAppUrl, "_self");
+}

--- a/src/frontend/efiling-frontend/src/modules/helpers/RoutingUtil.js
+++ b/src/frontend/efiling-frontend/src/modules/helpers/RoutingUtil.js
@@ -1,4 +1,0 @@
-export function redirectToParentApp() {
-  const parentAppUrl = sessionStorage.getItem("cancelUrl");
-  window.open(parentAppUrl, "_self");
-}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Fixed the **Return to Parent App** button on **Package Review** screen.

The Return to Parent App button shows up if there is a valid returnUrl parameter in the url string, ie. 

http://localhost:3000/efilinghub/packagereview/1?returnUrl=https%3A%2F%2Fwww.google.ca%2Fsearch%3Fq%3Dbob%2Bross%26tbm%3Disch

![image](https://user-images.githubusercontent.com/55215368/110180168-26043400-7dbe-11eb-9e14-92fe5b12f47f.png)

- Updated Package Review to show button conditionally if returnUrl exists and is valid
- Updated ./docs/README.md
- Updated demo app to include returnUrl for testing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

yarn test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
