### PR TITLE
FLA-708 added scrollTo top for Payment screen

### DIFF
--- a/src/frontend/efiling-frontend/src/components/page/rush/Rush.test.js
+++ b/src/frontend/efiling-frontend/src/components/page/rush/Rush.test.js
@@ -32,6 +32,7 @@ describe("Rush Component", () => {
   });
   localStorage.setItem("jwt", token);
   sessionStorage.setItem("csoBaseUrl", "https://dev.justice.gov.bc.ca/cso");
+  window.scrollTo = jest.fn();
 
   test("Matches the snapshot", () => {
     const currentDate = new Date("2019-05-14T11:01:58.135Z");

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__tests__/PackageConfirmation.test.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__tests__/PackageConfirmation.test.js
@@ -39,6 +39,7 @@ describe("PackageConfirmation Component", () => {
   });
   localStorage.setItem("jwt", token);
   sessionStorage.setItem("csoBaseUrl", "https://dev.justice.gov.bc.ca/cso");
+  window.scrollTo = jest.fn();
 
   let mock;
   beforeEach(() => {

--- a/src/frontend/efiling-frontend/src/domain/payment/Payment.js
+++ b/src/frontend/efiling-frontend/src/domain/payment/Payment.js
@@ -129,6 +129,7 @@ export default function Payment({
 
     sessionStorage.setItem("currentPage", "payment");
     window.history.pushState(null, null, window.location.href);
+    window.scrollTo(0, 0);
   }, []);
 
   useEffect(() => {

--- a/src/frontend/efiling-frontend/src/domain/payment/__tests__/Payment.test.js
+++ b/src/frontend/efiling-frontend/src/domain/payment/__tests__/Payment.test.js
@@ -39,6 +39,7 @@ describe("Payment Component", () => {
   });
   localStorage.setItem("jwt", token);
   sessionStorage.setItem("csoBaseUrl", "https://dev.justice.gov.bc.ca/cso");
+  window.scrollTo = jest.fn();
 
   let mock;
   beforeEach(() => {

--- a/src/frontend/efiling-frontend/src/storyshots.test.js
+++ b/src/frontend/efiling-frontend/src/storyshots.test.js
@@ -13,6 +13,7 @@ const runTest = async (story, context) => {
     return;
   }
 
+  window.scrollTo = jest.fn();
   const storyElement = story.render();
 
   const { asFragment } = render(storyElement);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

https://justice.gov.bc.ca/jira/browse/FLA-708

- The way the app works is that it replaces components when rendering -there isn't any navigating to different screens.  So if you scrolled to the bottom of the Package Confirmation screen and hit the Continue to Payment screen, the main body would swap out with the Payment content, but the browser scrollbar would remain unchanged.  The issue is that there is content at the top of the Payment component that is important to see.

This fix is for the Payment screen only, but one could argue that this should be a global fix.  Anytime the route changes, scroll to the top, although per documentation, this may not work for tabs.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

yarn test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
