### PR TITLE
Add the ability to navigate to a tab directly via URL & small CSS tweak

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -176,7 +176,7 @@ The `organizationParties` array represents a list of organization parties for th
 
 The efiling Package Review screen shows the details of a submitted package.
 
-https://dev.justice.gov.bc.ca/efilinghub/packagereview/:packageId?returnUrl=&returnAppName=
+https://dev.justice.gov.bc.ca/efilinghub/packagereview/:packageId?returnUrl=&returnAppName=&defaultTab=
 
 The returnUrl parameter is optional, but if an encoded URL is supplied, the
 page will render with a button that will return the user to the given URL
@@ -184,6 +184,9 @@ page will render with a button that will return the user to the given URL
 
 The returnAppName parameter is optional, but if an encoded name of the Parent Application
 is specified, the "Return to Parent App" button will be named accordingly.
+
+The defaultTab parameter is optional, but if an encoded defaultTab
+is specified, the Package Review will display that tab by default.
 
 ### Api Documentation
 

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.js
@@ -31,8 +31,9 @@ export default function PackageReview() {
 
   const location = useLocation();
   const queryParams = queryString.parse(location.search);
-  const { returnUrl, returnAppName } = queryParams;
+  const { returnUrl, returnAppName, defaultTab } = queryParams;
   const returnButtonName = `Return to ${returnAppName || "Parent App"}`;
+  const defaultTabKey = defaultTab || "documents";
 
   const [error, setError] = useState(false);
   const [packageDetails, setPackageDetails] = useState([
@@ -237,7 +238,7 @@ export default function PackageReview() {
             />
           )}
           <br />
-          <Tabs defaultActiveKey="documents" id="uncontrolled-tab">
+          <Tabs defaultActiveKey={defaultTabKey} id="uncontrolled-tab">
             <Tab eventKey="documents" title="Documents">
               <br />
               <DocumentList

--- a/src/frontend/efiling-frontend/src/domain/payment/Payment.scss
+++ b/src/frontend/efiling-frontend/src/domain/payment/Payment.scss
@@ -16,6 +16,13 @@
     margin-left: 1rem;
   }
 
+  label[for="agreeCallout"] {
+    -webkit-user-select: none; /* Safari */        
+    -moz-user-select: none; /* Firefox */
+    -ms-user-select: none; /* IE10+/Edge */
+    user-select: none; /* Standard */
+  }
+
   @media (max-width: 576px) {
     .button-container {
       justify-content: space-between;


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Provide the ability to navigate to a tab directly via URL.
- Small CSS fix to make agree button text not selectable (triggerable, when moving mouse fast).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

I short circuited the pages locally to get to the required screens.

## Does the change impact or break the Docker build?

- [ ] Yes
- [X] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [X] No

## Checklist:

- [X] My code follows the style guidelines of this project - **I hope so?**
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
