### PR TITLE
LFA-1034 improved Home when no submissionId in session

### DIFF
--- a/src/frontend/efiling-frontend/src/components/page/home/Home.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.js
@@ -80,6 +80,10 @@ const checkCSOAccountStatus = (
   setClientApplicationName,
   setError
 ) => {
+  if (!submissionId) {
+    setShowLoader(false);
+    return;
+  }
   axios
     .get(`/submission/${submissionId}/config`)
     .then(({ data: { navigationUrls, clientAppName, csoBaseUrl } }) => {
@@ -217,6 +221,18 @@ export default function Home() {
   return (
     <>
       {showLoader && <Loader page />}
+      {!submissionId && (
+        <div className="page">
+          <div className="content col-md-8">
+            <Alert
+              icon={<MdCancel size={32} />}
+              type="error"
+              styling="bcgov-error-background"
+              element="No submission ID in session."
+            />
+          </div>
+        </div>
+      )}
       {!showLoader && error && (
         <div className="page">
           <div className="content col-md-8">

--- a/src/frontend/efiling-frontend/src/components/page/home/__snapshots__/Home.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/components/page/home/__snapshots__/Home.stories.storyshot
@@ -35,7 +35,7 @@ exports[`Storyshots Home Account Exists 1`] = `
         <div
           class="bcgov-display-right-element"
         >
-          Authorized users only.
+          No submission ID in session.
         </div>
       </div>
     </div>
@@ -78,7 +78,7 @@ exports[`Storyshots Home Account Exists Mobile 1`] = `
         <div
           class="bcgov-display-right-element"
         >
-          Authorized users only.
+          No submission ID in session.
         </div>
       </div>
     </div>
@@ -121,7 +121,7 @@ exports[`Storyshots Home Error 1`] = `
         <div
           class="bcgov-display-right-element"
         >
-          Authorized users only.
+          No submission ID in session.
         </div>
       </div>
     </div>
@@ -164,7 +164,7 @@ exports[`Storyshots Home Error Mobile 1`] = `
         <div
           class="bcgov-display-right-element"
         >
-          Authorized users only.
+          No submission ID in session.
         </div>
       </div>
     </div>
@@ -207,7 +207,7 @@ exports[`Storyshots Home No Account Exists 1`] = `
         <div
           class="bcgov-display-right-element"
         >
-          Authorized users only.
+          No submission ID in session.
         </div>
       </div>
     </div>
@@ -250,7 +250,7 @@ exports[`Storyshots Home No Account Exists Mobile 1`] = `
         <div
           class="bcgov-display-right-element"
         >
-          Authorized users only.
+          No submission ID in session.
         </div>
       </div>
     </div>

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/PackageReview.test.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/PackageReview.test.js
@@ -383,6 +383,28 @@ describe("PackageReview Component", () => {
     );
   });
 
+  test("View Submission Sheet (on keyDown) - tab", async () => {
+    sessionStorage.setItem("errorUrl", "error.com");
+
+    mock
+      .onGet(apiRequest)
+      .reply(200, { court: courtData, submittedBy, submittedDate });
+    mock
+      .onGet(`/filingpackages/${packageId}/submissionSheet`)
+      .reply(400, { message: "There was an error." });
+
+    const { getByText } = render(<PackageReview />);
+    await waitFor(() => {});
+
+    fireEvent.keyDown(getByText("Print Submission Sheet"), {
+      key: "Tab",
+      keyCode: "9",
+    });
+    await waitFor(() => {});
+
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
   test("Reload", async () => {
     mock.onGet(apiRequest).reply(200, {
       packageNumber: packageId,


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

https://justice.gov.bc.ca/jira/browse/FLA-1034

- suppressed call to backend if there is no submissionID in session, show error instead.
- improved unit tests - fixed untested line number 
- 
![image](https://user-images.githubusercontent.com/55215368/114215216-30b06c80-991a-11eb-8772-099f84a39e91.png)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
