### PR TITLE
FLA-836 fixed multiple calls to backend

### DIFF
--- a/src/frontend/efiling-frontend/src/AxiosConfig.js
+++ b/src/frontend/efiling-frontend/src/AxiosConfig.js
@@ -1,0 +1,14 @@
+import axios from "axios";
+import { REACT_APP_API_BASE_URL } from "./EnvConfig";
+
+const api = axios.create({
+  baseURL: `${REACT_APP_API_BASE_URL}`,
+});
+
+api.interceptors.request.use((request) => {
+  const token = localStorage.getItem("jwt");
+  request.headers.Authorization = `Bearer ${token}`;
+  return request;
+});
+
+export default api;

--- a/src/frontend/efiling-frontend/src/EnvConfig.js
+++ b/src/frontend/efiling-frontend/src/EnvConfig.js
@@ -4,3 +4,7 @@ export const IDP_BCSC = "bcsc";
 export const BAMBORA_REDIRECT_URL = window.env
   ? window.env.REACT_APP_BAMBORA_REDIRECT_URL
   : process.env.REACT_APP_BAMBORA_REDIRECT_URL;
+
+export const REACT_APP_API_BASE_URL = window.env
+  ? window.env.REACT_APP_API_BASE_URL
+  : process.env.REACT_APP_API_BASE_URL;

--- a/src/frontend/efiling-frontend/src/components/page/home/Home.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.js
@@ -13,7 +13,7 @@ import PackageConfirmation from "../../../domain/package/package-confirmation/Pa
 import CSOAccount from "../cso-account/CSOAccount";
 
 import "../page.css";
-import { IDP_BCEID, IDP_BCSC } from "../../../Config";
+import { IDP_BCEID, IDP_BCSC } from "../../../EnvConfig";
 
 const mainButton = {
   label: "Cancel",

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReviewService.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReviewService.js
@@ -1,5 +1,5 @@
-import axios from "axios";
 import FileSaver from "file-saver";
+import api from "../../../AxiosConfig";
 
 /**
  * Retrieves the Filing Package json object from the backend API for the given packageId.
@@ -7,7 +7,7 @@ import FileSaver from "file-saver";
  * @param packageId id associated with the filing package
  */
 export const getFilingPackage = (packageId) =>
-  axios.get(`/filingpackages/${packageId}`);
+  api.get(`/filingpackages/${packageId}`);
 
 /**
  * Retrieves the Submission Sheet from the backend API for the given packageId.
@@ -15,7 +15,7 @@ export const getFilingPackage = (packageId) =>
  * @param packageId id associated with the filing package
  */
 export const downloadSubmissionSheet = async (packageId) => {
-  const response = await axios.get(
+  const response = await api.get(
     `/filingpackages/${packageId}/submissionSheet`,
     {
       responseType: "blob",
@@ -33,7 +33,7 @@ export const downloadSubmissionSheet = async (packageId) => {
  * @param document the document to retrieve. Shape must be {identifier: string, name: string}
  */
 export const downloadSubmittedDocument = async (packageId, document) => {
-  const response = await axios.get(
+  const response = await api.get(
     `/filingpackages/${packageId}/document/${document.identifier}`,
     {
       responseType: "blob",
@@ -51,10 +51,10 @@ export const downloadSubmittedDocument = async (packageId, document) => {
  * @param document the document to retrieve. Shape must be {identifier: string}
  */
 export const withdrawSubmittedDocument = async (packageId, document) =>
-  axios.delete(`/filingpackages/${packageId}/document/${document.identifier}`);
+  api.delete(`/filingpackages/${packageId}/document/${document.identifier}`);
 
 export const downloadRegistryNotice = async (packageId) => {
-  const response = await axios.get(
+  const response = await api.get(
     `/filingpackages/${packageId}/registryNotice`,
     {
       responseType: "blob",

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/PackageReview.test.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/PackageReview.test.js
@@ -1,10 +1,10 @@
 import React from "react";
-import axios from "axios";
 import FileSaver from "file-saver";
 import { render, waitFor, fireEvent } from "@testing-library/react";
 
 import MockAdapter from "axios-mock-adapter";
 import moment from "moment-timezone";
+import api from "../../../../AxiosConfig";
 import PackageReview from "../PackageReview";
 import { getCourtData } from "../../../../modules/test-data/courtTestData";
 import * as packageReviewTestData from "../../../../modules/test-data/packageReviewTestData";
@@ -57,7 +57,7 @@ describe("PackageReview Component", () => {
     });
     localStorage.setItem("jwt", token);
 
-    mock = new MockAdapter(axios);
+    mock = new MockAdapter(api);
     window.open = jest.fn();
   });
 
@@ -146,7 +146,7 @@ describe("PackageReview Component", () => {
       submittedDate,
     });
 
-    const spy = jest.spyOn(axios, "get");
+    const spy = jest.spyOn(api, "get");
 
     render(<PackageReview />);
     await waitFor(() => {});
@@ -161,7 +161,7 @@ describe("PackageReview Component", () => {
       submittedDate: "",
     });
 
-    const spy = jest.spyOn(axios, "get");
+    const spy = jest.spyOn(api, "get");
 
     render(<PackageReview />);
     await waitFor(() => {});
@@ -176,7 +176,7 @@ describe("PackageReview Component", () => {
       submittedDate,
     });
 
-    const spy = jest.spyOn(axios, "get");
+    const spy = jest.spyOn(api, "get");
 
     render(<PackageReview />);
     await waitFor(() => {});
@@ -190,7 +190,7 @@ describe("PackageReview Component", () => {
       submittedDate: "123",
     });
 
-    const spy = jest.spyOn(axios, "get");
+    const spy = jest.spyOn(api, "get");
 
     render(<PackageReview />);
     await waitFor(() => {});
@@ -201,7 +201,7 @@ describe("PackageReview Component", () => {
   test("Api called, missing response data", async () => {
     mock.onGet(apiRequest).reply(200);
 
-    const spy = jest.spyOn(axios, "get");
+    const spy = jest.spyOn(api, "get");
 
     render(<PackageReview />);
     await waitFor(() => {});

--- a/src/frontend/efiling-frontend/src/index.js
+++ b/src/frontend/efiling-frontend/src/index.js
@@ -8,7 +8,7 @@ import "./index.css";
 import "@bcgov/bootstrap-theme/dist/css/bootstrap-theme.min.css";
 import App from "./App";
 import * as serviceWorker from "./serviceWorker";
-import { BAMBORA_REDIRECT_URL } from "./Config";
+import { BAMBORA_REDIRECT_URL } from "./EnvConfig";
 
 axios.defaults.baseURL = window.env
   ? window.env.REACT_APP_API_BASE_URL

--- a/src/frontend/efiling-frontend/src/modules/helpers/translateApplicantInfo.js
+++ b/src/frontend/efiling-frontend/src/modules/helpers/translateApplicantInfo.js
@@ -1,4 +1,4 @@
-import { IDP_BCEID, IDP_BCSC } from "../../Config";
+import { IDP_BCEID, IDP_BCSC } from "../../EnvConfig";
 import { getIdentityProviderAlias } from "./authentication-helper/authenticationHelper";
 
 export function translateApplicantInfo({


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

https://justice.gov.bc.ca/jira/browse/FLA-836

Bug fix: PackageReview screen no longer makes two calls, one 401 and one 200. 
The issue was that the axios instance didn't have the bearer token on the request

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

yarn test
yarn lint

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
