### PR TITLE
Adding Flag to Ignore CSO webHook

### DIFF
--- a/src/backend/efiling-reviewer-api/jag-reviewer-api.yaml
+++ b/src/backend/efiling-reviewer-api/jag-reviewer-api.yaml
@@ -20,6 +20,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/xTransactionId"
         - $ref: "#/components/parameters/xDocumentType"
+        - $ref: "#/components/parameters/xUseWebhook"
       requestBody:
         content:
           multipart/form-data:
@@ -245,6 +246,13 @@ components:
       required: true
       schema:
         type: string
+    xUseWebhook:
+      name: X-Use-Webhook
+      in: header
+      description: A document type
+      schema:
+        type: boolean
+        default: true
   schemas:
     ApiError:
       required:

--- a/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/document/DocumentsApiDelegateImpl.java
+++ b/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/document/DocumentsApiDelegateImpl.java
@@ -88,7 +88,7 @@ public class DocumentsApiDelegateImpl implements DocumentsApiDelegate {
 
         logger.info("document is valid");
 
-        ExtractRequest extractRequest = extractRequestMapper.toExtractRequest(extractRequestMapper.toExtract(xTransactionId, xUseWebhook), xDocumentType, file, receivedTimeMillis);
+        ExtractRequest extractRequest = extractRequestMapper.toExtractRequest(extractRequestMapper.toExtract(xTransactionId, (xUseWebhook == null || xUseWebhook)), xDocumentType, file, receivedTimeMillis);
 
         BigDecimal response = diligenService.postDocument(xDocumentType, file, documentTypeConfiguration.getProjectId());
 

--- a/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/document/DocumentsApiDelegateImpl.java
+++ b/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/document/DocumentsApiDelegateImpl.java
@@ -88,6 +88,7 @@ public class DocumentsApiDelegateImpl implements DocumentsApiDelegate {
 
         logger.info("document is valid");
 
+        //Due to a bug in mapstruct logic has been performed inline
         ExtractRequest extractRequest = extractRequestMapper.toExtractRequest(extractRequestMapper.toExtract(xTransactionId, (xUseWebhook == null || xUseWebhook)), xDocumentType, file, receivedTimeMillis);
 
         BigDecimal response = diligenService.postDocument(xDocumentType, file, documentTypeConfiguration.getProjectId());

--- a/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/extract/mappers/ExtractMapper.java
+++ b/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/extract/mappers/ExtractMapper.java
@@ -7,11 +7,3 @@ import org.mapstruct.Mapping;
 
 import java.util.UUID;
 
-@Mapper(injectionStrategy = InjectionStrategy.CONSTRUCTOR, componentModel = "spring")
-public interface ExtractMapper {
-
-    @Mapping(target = "transactionId", source = "transactionId")
-    @Mapping(target = "id", expression = "java(java.util.UUID.randomUUID())")
-    Extract toExtract(UUID transactionId);
-
-}

--- a/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/extract/mappers/ExtractMapper.java
+++ b/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/extract/mappers/ExtractMapper.java
@@ -1,9 +1,0 @@
-package ca.bc.gov.open.jag.efilingreviewerapi.extract.mappers;
-
-import ca.bc.gov.open.jag.efilingreviewerapi.extract.models.Extract;
-import org.mapstruct.InjectionStrategy;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-
-import java.util.UUID;
-

--- a/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/extract/mappers/ExtractRequestMapper.java
+++ b/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/extract/mappers/ExtractRequestMapper.java
@@ -3,6 +3,7 @@ package ca.bc.gov.open.jag.efilingreviewerapi.extract.mappers;
 import ca.bc.gov.open.jag.efilingreviewerapi.api.model.DocumentExtractResponse;
 import ca.bc.gov.open.jag.efilingreviewerapi.document.mappers.DocumentMapper;
 import ca.bc.gov.open.jag.efilingreviewerapi.document.models.Document;
+import ca.bc.gov.open.jag.efilingreviewerapi.extract.models.Extract;
 import ca.bc.gov.open.jag.efilingreviewerapi.extract.models.ExtractRequest;
 import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
@@ -11,13 +12,13 @@ import org.springframework.web.multipart.MultipartFile;
 import java.math.BigDecimal;
 import java.util.UUID;
 
-@Mapper(injectionStrategy = InjectionStrategy.CONSTRUCTOR, uses = {ExtractMapper.class}, componentModel = "spring")
+@Mapper(injectionStrategy = InjectionStrategy.CONSTRUCTOR, componentModel = "spring")
 public interface ExtractRequestMapper {
 
-    @Mapping(target = "extract", source = "transactionId")
+    @Mapping(target = "extract", source = "extract")
     @Mapping(target = "document", source = "multipartFile", qualifiedByName = "multipartFileToDocument")
     @Mapping(target = "receivedTimeMillis", source = "receivedTimeMillis")
-    ExtractRequest toExtractRequest(UUID transactionId, @Context String documentType, MultipartFile multipartFile, long receivedTimeMillis);
+    ExtractRequest toExtractRequest(Extract extract, @Context String documentType, MultipartFile multipartFile, long receivedTimeMillis);
 
     @Named("multipartFileToDocument")
     static Document multipartFileToDocument(MultipartFile multipartFile, @Context String documentType) {
@@ -33,5 +34,10 @@ public interface ExtractRequestMapper {
     @Mapping(target = "extract.id", source = "extractRequest.extract.id")
     @Mapping(target = "extract.transactionId", source = "extractRequest.extract.transactionId")
     DocumentExtractResponse toDocumentExtractResponse(ExtractRequest extractRequest, BigDecimal documentId);
+
+    @Mapping(target = "transactionId", source = "transactionId")
+    @Mapping(target = "useWebhook", source = "useWebhook")
+    @Mapping(target = "id", expression = "java(java.util.UUID.randomUUID())")
+    Extract toExtract(UUID transactionId, Boolean useWebhook);
 
 }

--- a/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/extract/models/Extract.java
+++ b/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/extract/models/Extract.java
@@ -8,17 +8,21 @@ public class Extract {
 
     private UUID id;
     private UUID transactionId;
+    private Boolean useWebhook;
 
     public Extract(
             @JsonProperty("id") UUID id,
-            @JsonProperty("transactionId") UUID transactionId) {
+            @JsonProperty("transactionId") UUID transactionId,
+            @JsonProperty("useWebhook") Boolean useWebhook) {
         this.id = id;
         this.transactionId = transactionId;
+        this.useWebhook = useWebhook;
     }
 
     public Extract(Builder builder) {
         this.id = builder.id;
         this.transactionId = builder.transactionId;
+        this.useWebhook = builder.useWebhook;
     }
 
     public static Builder builder() {
@@ -41,6 +45,13 @@ public class Extract {
             return this;
         }
 
+        private Boolean useWebhook;
+
+        public Builder useWebhook(Boolean useWebhook) {
+            this.useWebhook = useWebhook;
+            return this;
+        }
+
         public Extract create() {
             return new Extract(this);
         }
@@ -54,4 +65,6 @@ public class Extract {
     public UUID getTransactionId() {
         return transactionId;
     }
+
+    public Boolean getUseWebhook() { return useWebhook; }
 }

--- a/src/backend/efiling-reviewer-api/src/test/java/ca/bc/gov/open/jag/efilingreviewerapi/document/documentsApiDelegateImpl/DocumentEventTest.java
+++ b/src/backend/efiling-reviewer-api/src/test/java/ca/bc/gov/open/jag/efilingreviewerapi/document/documentsApiDelegateImpl/DocumentEventTest.java
@@ -77,9 +77,7 @@ public class DocumentEventTest {
 
         Mockito.when(fieldProcessorMock.getJson(Mockito.any(), Mockito.any())).thenReturn(result);
 
-        Mockito.when(diligenServiceMock.getDocumentDetails(ArgumentMatchers.eq(BigDecimal.ONE))).thenReturn(DiligenDocumentDetails.builder().create());
-        Mockito.when(diligenServiceMock.getDocumentDetails(ArgumentMatchers.eq(BigDecimal.TEN))).thenReturn(DiligenDocumentDetails.builder().create());
-
+        Mockito.when(diligenServiceMock.getDocumentDetails(Mockito.any())).thenReturn(DiligenDocumentDetails.builder().create());
 
         DocumentTypeConfiguration configuration = DocumentTypeConfiguration.builder().create();
         Mockito.when(documentTypeConfigurationRepositoryMock.findByDocumentType(Mockito.eq("TYPE"))).thenReturn(configuration);
@@ -107,6 +105,20 @@ public class DocumentEventTest {
                         .create())
                 .create()));
 
+        Mockito.when(diligenServiceMock.getDocumentDetails(ArgumentMatchers.eq(BigDecimal.ZERO))).thenReturn(DiligenDocumentDetails.builder()
+                .projectFieldsResponse(projectFieldResponse).create());
+
+        Mockito.when(extractStoreMock.get(Mockito.eq(BigDecimal.ZERO))).thenReturn(Optional.of(ExtractRequest.builder()
+                .document(Document.builder()
+                        .type("TYPE")
+                        .create())
+                .extract(Extract.builder()
+                        .id(UUID.randomUUID())
+                        .transactionId(UUID.randomUUID())
+                        .useWebhook(false)
+                        .create())
+                .create()));
+
         Mockito.when(extractStoreMock.get(Mockito.eq(BigDecimal.TEN))).thenReturn(Optional.of(ExtractRequest.builder()
                 .document(Document.builder()
                         .type("NO-CONFIG")
@@ -126,7 +138,19 @@ public class DocumentEventTest {
         DocumentEvent documentEvent = new DocumentEvent();
         documentEvent.setDocumentId(BigDecimal.ONE);
         documentEvent.setStatus("Processed");
-        ResponseEntity<Void> actual = sut.documentEvent(, documentEvent);
+        ResponseEntity<Void> actual = sut.documentEvent(UUID.randomUUID(), documentEvent);
+        Assertions.assertEquals(HttpStatus.NO_CONTENT, actual.getStatusCode());
+
+    }
+
+    @Test()
+    @DisplayName("204: accept any event webHook ignored")
+    public void testAnyEventWebhookIgnored() {
+
+        DocumentEvent documentEvent = new DocumentEvent();
+        documentEvent.setDocumentId(BigDecimal.ONE);
+        documentEvent.setStatus("Processed");
+        ResponseEntity<Void> actual = sut.documentEvent(UUID.randomUUID(), documentEvent);
         Assertions.assertEquals(HttpStatus.NO_CONTENT, actual.getStatusCode());
 
     }

--- a/src/backend/efiling-reviewer-api/src/test/java/ca/bc/gov/open/jag/efilingreviewerapi/document/documentsApiDelegateImpl/DocumentEventTest.java
+++ b/src/backend/efiling-reviewer-api/src/test/java/ca/bc/gov/open/jag/efilingreviewerapi/document/documentsApiDelegateImpl/DocumentEventTest.java
@@ -13,10 +13,9 @@ import ca.bc.gov.open.jag.efilingreviewerapi.document.models.DocumentTypeConfigu
 import ca.bc.gov.open.jag.efilingreviewerapi.document.store.DocumentTypeConfigurationRepository;
 import ca.bc.gov.open.jag.efilingreviewerapi.document.validators.DocumentValidator;
 import ca.bc.gov.open.jag.efilingreviewerapi.error.AiReviewerDocumentConfigException;
-import ca.bc.gov.open.jag.efilingreviewerapi.extract.mappers.ExtractMapper;
-import ca.bc.gov.open.jag.efilingreviewerapi.extract.mappers.ExtractMapperImpl;
 import ca.bc.gov.open.jag.efilingreviewerapi.extract.mappers.ExtractRequestMapper;
 import ca.bc.gov.open.jag.efilingreviewerapi.extract.mappers.ExtractRequestMapperImpl;
+import ca.bc.gov.open.jag.efilingreviewerapi.extract.models.Extract;
 import ca.bc.gov.open.jag.efilingreviewerapi.extract.models.ExtractRequest;
 import ca.bc.gov.open.jag.efilingreviewerapi.extract.store.ExtractStore;
 import ca.bc.gov.open.jag.efilingreviewerapi.webhook.WebHookService;
@@ -69,8 +68,7 @@ public class DocumentEventTest {
 
         MockitoAnnotations.openMocks(this);
 
-        ExtractMapper extractMapper = new ExtractMapperImpl();
-        ExtractRequestMapper extractRequestMapper = new ExtractRequestMapperImpl(extractMapper);
+        ExtractRequestMapper extractRequestMapper = new ExtractRequestMapperImpl();
 
         ObjectMapper objectMapper = new ObjectMapper();
 
@@ -102,6 +100,11 @@ public class DocumentEventTest {
                 .document(Document.builder()
                         .type("TYPE")
                         .create())
+                .extract(Extract.builder()
+                        .id(UUID.randomUUID())
+                        .transactionId(UUID.randomUUID())
+                        .useWebhook(true)
+                        .create())
                 .create()));
 
         Mockito.when(extractStoreMock.get(Mockito.eq(BigDecimal.TEN))).thenReturn(Optional.of(ExtractRequest.builder()
@@ -123,7 +126,7 @@ public class DocumentEventTest {
         DocumentEvent documentEvent = new DocumentEvent();
         documentEvent.setDocumentId(BigDecimal.ONE);
         documentEvent.setStatus("Processed");
-        ResponseEntity<Void> actual = sut.documentEvent(UUID.randomUUID(), documentEvent);
+        ResponseEntity<Void> actual = sut.documentEvent(, documentEvent);
         Assertions.assertEquals(HttpStatus.NO_CONTENT, actual.getStatusCode());
 
     }

--- a/src/backend/efiling-reviewer-api/src/test/java/ca/bc/gov/open/jag/efilingreviewerapi/document/documentsApiDelegateImpl/ExtractDocumentFormDataTest.java
+++ b/src/backend/efiling-reviewer-api/src/test/java/ca/bc/gov/open/jag/efilingreviewerapi/document/documentsApiDelegateImpl/ExtractDocumentFormDataTest.java
@@ -11,7 +11,6 @@ import ca.bc.gov.open.jag.efilingreviewerapi.document.validators.DocumentValidat
 import ca.bc.gov.open.jag.efilingreviewerapi.error.AiReviewerCacheException;
 import ca.bc.gov.open.jag.efilingreviewerapi.error.AiReviewerDocumentException;
 import ca.bc.gov.open.jag.efilingreviewerapi.error.AiReviewerVirusFoundException;
-import ca.bc.gov.open.jag.efilingreviewerapi.extract.mappers.ExtractMapperImpl;
 import ca.bc.gov.open.jag.efilingreviewerapi.extract.mappers.ExtractRequestMapper;
 import ca.bc.gov.open.jag.efilingreviewerapi.extract.mappers.ExtractRequestMapperImpl;
 import ca.bc.gov.open.jag.efilingreviewerapi.extract.mocks.ExtractRequestMockFactory;
@@ -95,7 +94,7 @@ public class ExtractDocumentFormDataTest {
         
         Mockito.doNothing().when(stringRedisTemplateMock).convertAndSend(any(), any());
 
-        ExtractRequestMapper extractRequestMapper = new ExtractRequestMapperImpl(new ExtractMapperImpl());
+        ExtractRequestMapper extractRequestMapper = new ExtractRequestMapperImpl();
         sut = new DocumentsApiDelegateImpl(diligenServiceMock, extractRequestMapper, extractStoreMock, stringRedisTemplateMock, fieldProcessorMock, documentValidatorMock, documentTypeConfigurationRepositoryMock, null, null);
 
     }
@@ -114,7 +113,7 @@ public class ExtractDocumentFormDataTest {
 
         Mockito.doNothing().when(documentValidatorMock).validateDocument(any(), any());
 
-        ResponseEntity<DocumentExtractResponse> actual = sut.extractDocumentFormData(transactionId, DOCUMENT_TYPE, multipartFile);
+        ResponseEntity<DocumentExtractResponse> actual = sut.extractDocumentFormData(transactionId, DOCUMENT_TYPE, true, multipartFile);
 
         Assertions.assertEquals(HttpStatus.OK, actual.getStatusCode());
         Assertions.assertEquals(ExtractRequestMockFactory.EXPECTED_DOCUMENT_CONTENT_TYPE, actual.getBody().getDocument().getContentType());
@@ -140,7 +139,7 @@ public class ExtractDocumentFormDataTest {
                 CASE_1, APPLICATION_PDF, Files.readAllBytes(path));
 
         Assertions.assertThrows(AiReviewerCacheException.class,
-                () -> sut.extractDocumentFormData(transactionId, DOCUMENT_TYPE, multipartFile)
+                () -> sut.extractDocumentFormData(transactionId, DOCUMENT_TYPE,true, multipartFile)
         );
 
     }
@@ -159,7 +158,7 @@ public class ExtractDocumentFormDataTest {
         MultipartFile multipartFile = new MockMultipartFile(CASE_1,
                 CASE_1, APPLICATION_PDF, Files.readAllBytes(path));
 
-        ResponseEntity<DocumentExtractResponse> actual = sut.extractDocumentFormData(transactionId, NOT_FOUND_DOCUMENT_TYPE, multipartFile);
+        ResponseEntity<DocumentExtractResponse> actual = sut.extractDocumentFormData(transactionId, NOT_FOUND_DOCUMENT_TYPE, true, multipartFile);
 
         Assertions.assertEquals(HttpStatus.BAD_REQUEST, actual.getStatusCode());
 
@@ -179,7 +178,7 @@ public class ExtractDocumentFormDataTest {
         MultipartFile multipartFile = new MockMultipartFile(CASE_1,
                 CASE_1, APPLICATION_PDF, Files.readAllBytes(path));
 
-        Assertions.assertThrows(AiReviewerDocumentException.class,() -> sut.extractDocumentFormData(transactionId, DOCUMENT_TYPE, multipartFile));
+        Assertions.assertThrows(AiReviewerDocumentException.class,() -> sut.extractDocumentFormData(transactionId, DOCUMENT_TYPE, true, multipartFile));
 
     }
 
@@ -195,7 +194,7 @@ public class ExtractDocumentFormDataTest {
         MockMultipartFile mockMultipartFileException = Mockito.mock(MockMultipartFile.class);
         Mockito.when(mockMultipartFileException.getBytes()).thenThrow(IOException.class);
 
-        Assertions.assertThrows(AiReviewerDocumentException.class,() -> sut.extractDocumentFormData(transactionId, DOCUMENT_TYPE, mockMultipartFileException));
+        Assertions.assertThrows(AiReviewerDocumentException.class,() -> sut.extractDocumentFormData(transactionId, DOCUMENT_TYPE, true, mockMultipartFileException));
 
     }
 
@@ -212,7 +211,7 @@ public class ExtractDocumentFormDataTest {
         MultipartFile multipartFile = new MockMultipartFile(CASE_1,
                 CASE_1, APPLICATION_PDF, Files.readAllBytes(path));
 
-        Assertions.assertThrows(AiReviewerVirusFoundException.class,() -> sut.extractDocumentFormData(transactionId, DOCUMENT_TYPE, multipartFile));
+        Assertions.assertThrows(AiReviewerVirusFoundException.class,() -> sut.extractDocumentFormData(transactionId, DOCUMENT_TYPE, true, multipartFile));
 
     }
 
@@ -228,7 +227,7 @@ public class ExtractDocumentFormDataTest {
         MultipartFile multipartFile = new MockMultipartFile(CASE_1,
                 CASE_1, APPLICATION_PDF, Files.readAllBytes(path));
 
-        Assertions.assertThrows(AiReviewerDocumentException.class,() -> sut.extractDocumentFormData(transactionId, INVALID_DOCUMENT_TYPE, multipartFile));
+        Assertions.assertThrows(AiReviewerDocumentException.class,() -> sut.extractDocumentFormData(transactionId, INVALID_DOCUMENT_TYPE, true, multipartFile));
 
     }
 

--- a/src/backend/efiling-reviewer-api/src/test/java/ca/bc/gov/open/jag/efilingreviewerapi/document/documentsApiDelegateImpl/ProcessedDocumentTest.java
+++ b/src/backend/efiling-reviewer-api/src/test/java/ca/bc/gov/open/jag/efilingreviewerapi/document/documentsApiDelegateImpl/ProcessedDocumentTest.java
@@ -8,7 +8,6 @@ import ca.bc.gov.open.jag.efilingreviewerapi.document.store.DocumentTypeConfigur
 import ca.bc.gov.open.jag.efilingreviewerapi.document.validators.DocumentValidator;
 import ca.bc.gov.open.jag.efilingreviewerapi.error.AiReviewerCacheException;
 import ca.bc.gov.open.jag.efilingreviewerapi.error.AiReviewerInvalidTransactionIdException;
-import ca.bc.gov.open.jag.efilingreviewerapi.extract.mappers.ExtractMapperImpl;
 import ca.bc.gov.open.jag.efilingreviewerapi.extract.mappers.ExtractRequestMapper;
 import ca.bc.gov.open.jag.efilingreviewerapi.extract.mappers.ExtractRequestMapperImpl;
 import ca.bc.gov.open.jag.efilingreviewerapi.extract.mappers.ProcessedDocumentMapperImpl;
@@ -69,7 +68,7 @@ public class ProcessedDocumentTest {
                 .when(extractStoreMock.getResponse(Mockito.eq(BigDecimal.TEN)))
                 .thenReturn(Optional.empty());
 
-        ExtractRequestMapper extractRequestMapper = new ExtractRequestMapperImpl(new ExtractMapperImpl());
+        ExtractRequestMapper extractRequestMapper = new ExtractRequestMapperImpl();
         sut = new DocumentsApiDelegateImpl(diligenServiceMock, extractRequestMapper, extractStoreMock, stringRedisTemplateMock, fieldProcessorMock, documentValidatorMock, documentTypeConfigurationRepositoryMock, new ProcessedDocumentMapperImpl(), null);
 
     }

--- a/src/backend/efiling-reviewer-api/src/test/java/ca/bc/gov/open/jag/efilingreviewerapi/extract/mocks/ExtractRequestMockFactory.java
+++ b/src/backend/efiling-reviewer-api/src/test/java/ca/bc/gov/open/jag/efilingreviewerapi/extract/mocks/ExtractRequestMockFactory.java
@@ -19,7 +19,7 @@ public class ExtractRequestMockFactory {
     public static ExtractRequest mock() {
 
         return new ExtractRequest(
-                new Extract(EXPECTED_EXTRACT_ID, EXPECTED_EXTRACT_TRANSACTION_ID),
+                new Extract(EXPECTED_EXTRACT_ID, EXPECTED_EXTRACT_TRANSACTION_ID, true),
                 new Document(EXPECTED_DOCUMENT_TYPE, EXPECTED_DOCUMENT_FILE_NAME, EXPECTED_DOCUMENT_SIZE, EXPECTED_DOCUMENT_CONTENT_TYPE),
                 10l,
                 15l);

--- a/src/backend/efiling-reviewer-api/src/test/java/ca/bc/gov/open/jag/efilingreviewerapi/extract/mocks/ExtractResponseMockFactory.java
+++ b/src/backend/efiling-reviewer-api/src/test/java/ca/bc/gov/open/jag/efilingreviewerapi/extract/mocks/ExtractResponseMockFactory.java
@@ -28,7 +28,7 @@ public class ExtractResponseMockFactory {
     public static ExtractResponse mock() {
 
         return new ExtractResponse(
-                new Extract(EXPECTED_EXTRACT_ID, EXPECTED_EXTRACT_TRANSACTION_ID),
+                new Extract(EXPECTED_EXTRACT_ID, EXPECTED_EXTRACT_TRANSACTION_ID, true),
                 new Document(EXPECTED_DOCUMENT_TYPE, EXPECTED_DOCUMENT_FILE_NAME, EXPECTED_DOCUMENT_SIZE, EXPECTED_DOCUMENT_CONTENT_TYPE),
                 new DocumentValidation(Collections.singletonList(new DocumentValidationResult(ValidationTypes.DOCUMENT_TYPE, EXPECTED, ACTUAL))),
                 null);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

This gives the functionality to ignore the use of CSO webHook

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
