### PR TITLE
FLA-1098 implement auditing

### DIFF
--- a/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/document/models/AuditAction.java
+++ b/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/document/models/AuditAction.java
@@ -1,0 +1,7 @@
+package ca.bc.gov.open.jag.efilingreviewerapi.document.models;
+
+public enum AuditAction {
+
+	INSERT, UPDATE, DELETE
+
+}

--- a/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/document/models/Auditable.java
+++ b/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/document/models/Auditable.java
@@ -7,9 +7,8 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.annotation.Version;
 
 /**
- * An abstract Auditable class that auto-populates <code>createDate</code>,
- * <code>modifiedDate</code>, and <code>version</code> fields. Class need only
- * to extend this class to add auditing fields to a model object.
+ * An abstract Auditable class that auto-populates <code>createdDate</code>, <code>modifiedDate</code>, and
+ * <code>version</code> fields. Class need only to extend this class to add auditing fields to a model object.
  */
 public abstract class Auditable {
 

--- a/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/document/models/Auditable.java
+++ b/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/document/models/Auditable.java
@@ -1,0 +1,49 @@
+package ca.bc.gov.open.jag.efilingreviewerapi.document.models;
+
+import java.util.Date;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.annotation.Version;
+
+/**
+ * An abstract Auditable class that auto-populates <code>createDate</code>,
+ * <code>modifiedDate</code>, and <code>version</code> fields. Class need only
+ * to extend this class to add auditing fields to a model object.
+ */
+public abstract class Auditable {
+
+	@CreatedDate
+	protected Date createdDate;
+
+	@LastModifiedDate
+	protected Date modifiedDate;
+
+	@Version
+	private Integer version;
+
+	public Date getCreatedDate() {
+		return createdDate == null ? new Date() : createdDate;
+	}
+
+	public void setCreatedDate(Date createdDate) {
+		this.createdDate = createdDate;
+	}
+
+	public Date getModifiedDate() {
+		return modifiedDate;
+	}
+
+	public void setModifiedDate(Date modifiedDate) {
+		this.modifiedDate = modifiedDate;
+	}
+
+	public Integer getVersion() {
+		return version;
+	}
+
+	public void setVersion(Integer version) {
+		this.version = version;
+	}
+
+}

--- a/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/document/models/DocumentTypeConfiguration.java
+++ b/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/document/models/DocumentTypeConfiguration.java
@@ -1,16 +1,18 @@
 package ca.bc.gov.open.jag.efilingreviewerapi.document.models;
 
-import ca.bc.gov.open.efilingdiligenclient.diligen.model.DocumentConfig;
-import ca.bc.gov.open.efilingdiligenclient.diligen.model.PropertyConfig;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.data.annotation.Id;
-
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
 
-public class DocumentTypeConfiguration {
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.data.annotation.Id;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import ca.bc.gov.open.efilingdiligenclient.diligen.model.DocumentConfig;
+import ca.bc.gov.open.efilingdiligenclient.diligen.model.PropertyConfig;
+
+public class DocumentTypeConfiguration extends Auditable {
 
     @Id
     private UUID id;
@@ -52,13 +54,25 @@ public class DocumentTypeConfiguration {
         return documentType;
     }
 
+	public void setDocumentType(String documentType) {
+		this.documentType = documentType;
+	}
+
     public String getDocumentTypeDescription() { return documentTypeDescription;  }
+    
+    public void setDocumentTypeDescription(String documentTypeDescription) {
+		this.documentTypeDescription = documentTypeDescription;
+	}
 
     public Integer getProjectId() { return projectId; }
 
     public DocumentConfig getDocumentConfig() {
         return documentConfig;
     }
+    
+    public void setDocumentConfig(DocumentConfig documentConfig) {
+		this.documentConfig = documentConfig;
+	}
 
     public DocumentTypeConfiguration(Builder builder) {
         this();

--- a/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/document/models/DocumentTypeConfigurationAudit.java
+++ b/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/document/models/DocumentTypeConfigurationAudit.java
@@ -1,0 +1,52 @@
+package ca.bc.gov.open.jag.efilingreviewerapi.document.models;
+
+import java.util.Date;
+import java.util.UUID;
+
+import org.springframework.data.annotation.Id;
+
+public class DocumentTypeConfigurationAudit {
+
+	@Id
+	private UUID id;
+	private DocumentTypeConfiguration DocumentTypeConfiguration;
+	private AuditAction auditAction;
+	private Date auditDate;
+
+	public DocumentTypeConfigurationAudit() {
+		id = UUID.randomUUID();
+	}
+
+	public void setId(UUID id) {
+		this.id = id;
+	}
+
+	public UUID getId() {
+		return id;
+	}
+	
+	public DocumentTypeConfiguration getDocumentTypeConfiguration() {
+		return DocumentTypeConfiguration;
+	}
+	
+	public void setDocumentTypeConfiguration(DocumentTypeConfiguration documentTypeConfiguration) {
+		DocumentTypeConfiguration = documentTypeConfiguration;
+	}
+
+	public AuditAction getAuditAction() {
+		return auditAction;
+	}
+
+	public void setAuditAction(AuditAction auditAction) {
+		this.auditAction = auditAction;
+	}
+
+	public Date getAuditDate() {
+		return auditDate;
+	}
+
+	public void setAuditDate(Date auditDate) {
+		this.auditDate = auditDate;
+	}
+
+}

--- a/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/document/models/DocumentTypeConfigurationAudit.java
+++ b/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/document/models/DocumentTypeConfigurationAudit.java
@@ -5,6 +5,10 @@ import java.util.UUID;
 
 import org.springframework.data.annotation.Id;
 
+/**
+ * A model object to store a history of transactions against {@link DocumentTypeConfiguration}. Besides the object
+ * itself, includes an action (INSERT, UPDATE, or DELETE) and a timestamp.
+ */
 public class DocumentTypeConfigurationAudit {
 
 	@Id
@@ -24,11 +28,11 @@ public class DocumentTypeConfigurationAudit {
 	public UUID getId() {
 		return id;
 	}
-	
+
 	public DocumentTypeConfiguration getDocumentTypeConfiguration() {
 		return DocumentTypeConfiguration;
 	}
-	
+
 	public void setDocumentTypeConfiguration(DocumentTypeConfiguration documentTypeConfiguration) {
 		DocumentTypeConfiguration = documentTypeConfiguration;
 	}

--- a/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/document/store/DocumentConfigurationAuditRepository.java
+++ b/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/document/store/DocumentConfigurationAuditRepository.java
@@ -1,0 +1,11 @@
+package ca.bc.gov.open.jag.efilingreviewerapi.document.store;
+
+import java.util.UUID;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import ca.bc.gov.open.jag.efilingreviewerapi.document.models.DocumentTypeConfigurationAudit;
+
+public interface DocumentConfigurationAuditRepository extends MongoRepository<DocumentTypeConfigurationAudit, UUID> {
+
+}

--- a/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/documentconfiguration/audit/AuditConfig.java
+++ b/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/documentconfiguration/audit/AuditConfig.java
@@ -1,0 +1,15 @@
+package ca.bc.gov.open.jag.efilingreviewerapi.documentconfiguration.audit;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+
+/**
+ * A simple configuration that enables auditing in Mongo (auto-population of
+ * <code>@CreatedDate</code>, <code>@LastModifiedDate</code>, and
+ * <code>@Version</code> fields.
+ */
+@Configuration
+@EnableMongoAuditing
+public class AuditConfig {
+
+}

--- a/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/documentconfiguration/audit/DocumentConfigurationsEventListener.java
+++ b/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/documentconfiguration/audit/DocumentConfigurationsEventListener.java
@@ -1,0 +1,58 @@
+package ca.bc.gov.open.jag.efilingreviewerapi.documentconfiguration.audit;
+
+import java.util.Date;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
+import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
+import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
+import org.springframework.stereotype.Component;
+
+import ca.bc.gov.open.jag.efilingreviewerapi.document.models.AuditAction;
+import ca.bc.gov.open.jag.efilingreviewerapi.document.models.DocumentTypeConfiguration;
+import ca.bc.gov.open.jag.efilingreviewerapi.document.models.DocumentTypeConfigurationAudit;
+import ca.bc.gov.open.jag.efilingreviewerapi.document.store.DocumentConfigurationAuditRepository;
+import ca.bc.gov.open.jag.efilingreviewerapi.document.store.DocumentTypeConfigurationRepository;
+
+@Component
+public class DocumentConfigurationsEventListener extends AbstractMongoEventListener<DocumentTypeConfiguration> {
+	
+	@Autowired
+	private DocumentTypeConfigurationRepository documentTypeConfigurationRepository;
+	
+	@Autowired
+	private DocumentConfigurationAuditRepository documentConfigurationAuditRepository;
+
+	@Override
+	public void onAfterSave(AfterSaveEvent<DocumentTypeConfiguration> event) {
+		super.onAfterSave(event);
+
+		DocumentTypeConfigurationAudit documentTypeConfigurationAudit = new DocumentTypeConfigurationAudit();
+		documentTypeConfigurationAudit.setAuditDate(new Date(event.getTimestamp()));
+		documentTypeConfigurationAudit.setDocumentTypeConfiguration(event.getSource());
+		if (event.getSource().getVersion().intValue() == 0) {
+			documentTypeConfigurationAudit.setAuditAction(AuditAction.INSERT);			
+		}
+		else {
+			documentTypeConfigurationAudit.setAuditAction(AuditAction.UPDATE);
+		}
+
+		documentConfigurationAuditRepository.save(documentTypeConfigurationAudit);
+	}
+	
+	@Override
+	public void onBeforeDelete(BeforeDeleteEvent<DocumentTypeConfiguration> event) {
+		super.onBeforeDelete(event);
+		// retrieve document we are about to delete so we can log it's deletion (event doesn't include this object, only the UUID)
+		DocumentTypeConfiguration documentTypeConfiguration = documentTypeConfigurationRepository.findById((UUID)event.getDocument().get("_id")).get();
+
+		DocumentTypeConfigurationAudit documentTypeConfigurationAudit = new DocumentTypeConfigurationAudit();
+		documentTypeConfigurationAudit.setAuditAction(AuditAction.DELETE);
+		documentTypeConfigurationAudit.setAuditDate(new Date(event.getTimestamp()));
+		documentTypeConfigurationAudit.setDocumentTypeConfiguration(documentTypeConfiguration);
+
+		documentConfigurationAuditRepository.save(documentTypeConfigurationAudit);
+	}
+
+}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

https://justice.gov.bc.ca/jira/browse/FLA-1098

- Added a new mongoDB table (DocumentTypeConfigurationAudit) to log document type transactions
- Added an Auditable abstract class to auto-populate createdDate and modifiedDate
- Added an event listener to populate DocumentTypeConfigurationAudit onSave, onDelete
- Changed DocumentTypeConfiguration `update`  repository method to include optimistic concurrency support (update not overwrite the previous document)

_There was an issue with our version of spring-boot: the `@CreatedDate` would not auto-populate unless `@Version` was also added to the Auditable class.  However, this also means that the DocumentTypeConfiguration update method now necessarily has optimistic concurrency support (the update will fail if the "version" of the checked-out document record doesn't match the database- ie. someone else already modified the same record). This is a good thing since now updates won't silently overwrite someone else's changes._

Does not yet include mock tests for the event listener.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
