### PR TITLE
Added endpoint for receiving webhook call from Diligen

### DIFF
--- a/src/backend/efiling-reviewer-api/jag-reviewer-api.yaml
+++ b/src/backend/efiling-reviewer-api/jag-reviewer-api.yaml
@@ -58,7 +58,23 @@ paths:
               $ref: "#/components/schemas/DocumentEvent"
       responses:
         "204":
-          description: Document Event acknoledged
+          description: Document Event acknowledged
+  "/documents/webhookEvent":
+    post:
+      summary: to receive status updates on submitted documents via Diligen webhook
+      operationId: DocumentWebhookEvent
+      tags:
+        - document
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DocumentWebhookEvent"
+      responses:
+        "200":
+          description: Status update received successfully
+        "400":
+          description: Incorrectly formatted request body
   "/documents/processed/{documentId}":
     get:
       summary: to inform api on a document event
@@ -306,6 +322,21 @@ components:
         documentId:
           type: number
           format: integer
+    DocumentWebhookEvent:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: number
+                format: integer
+              status:
+                type: string
+        event:
+          type: string        
     DocumentTypeConfigurationRequest:
       type: object
       properties:

--- a/src/backend/efiling-reviewer-api/src/test/jag-reviewer-api.postman_collection.json
+++ b/src/backend/efiling-reviewer-api/src/test/jag-reviewer-api.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "83cd3971-ad87-480d-9996-5098ea33e01d",
+		"_postman_id": "45a8c23a-4549-4d89-9119-996ec7331777",
 		"name": "jag-reviewer-api Copy",
 		"description": "Efiling AI Reviewer api",
-		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
@@ -41,7 +41,15 @@
 								}
 							}
 						},
-						"url": "{{baseUrl}}/documentTypeConfigurations"
+						"url": {
+							"raw": "{{baseUrl}}/documentTypeConfigurations",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"documentTypeConfigurations"
+							]
+						}
 					},
 					"response": [
 						{
@@ -70,7 +78,16 @@
 										}
 									]
 								},
-								"url": "{{baseUrl}}/documents/extract"
+								"url": {
+									"raw": "{{baseUrl}}/documents/extract",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"documents",
+										"extract"
+									]
+								}
 							},
 							"status": "OK",
 							"code": 200,
@@ -110,7 +127,16 @@
 										}
 									]
 								},
-								"url": "{{baseUrl}}/documents/extract"
+								"url": {
+									"raw": "{{baseUrl}}/documents/extract",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"documents",
+										"extract"
+									]
+								}
 							},
 							"status": "Bad Request",
 							"code": 400,
@@ -192,7 +218,16 @@
 										}
 									]
 								},
-								"url": "{{baseUrl}}/documents/extract"
+								"url": {
+									"raw": "{{baseUrl}}/documents/extract",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"documents",
+										"extract"
+									]
+								}
 							},
 							"status": "OK",
 							"code": 200,
@@ -232,7 +267,16 @@
 										}
 									]
 								},
-								"url": "{{baseUrl}}/documents/extract"
+								"url": {
+									"raw": "{{baseUrl}}/documents/extract",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"documents",
+										"extract"
+									]
+								}
 							},
 							"status": "Bad Request",
 							"code": 400,
@@ -262,7 +306,15 @@
 								}
 							}
 						},
-						"url": "{{baseUrl}}/documentTypeConfigurations"
+						"url": {
+							"raw": "{{baseUrl}}/documentTypeConfigurations",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"documentTypeConfigurations"
+							]
+						}
 					},
 					"response": []
 				},
@@ -277,7 +329,16 @@
 								"type": "text"
 							}
 						],
-						"url": "{{baseUrl}}/documentTypeConfigurations/{{id}}"
+						"url": {
+							"raw": "{{baseUrl}}/documentTypeConfigurations/{{id}}",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"documentTypeConfigurations",
+								"{{id}}"
+							]
+						}
 					},
 					"response": []
 				}
@@ -316,7 +377,16 @@
 								}
 							]
 						},
-						"url": "{{baseUrl}}/documents/extract"
+						"url": {
+							"raw": "{{baseUrl}}/documents/extract",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"documents",
+								"extract"
+							]
+						}
 					},
 					"response": [
 						{
@@ -345,7 +415,16 @@
 										}
 									]
 								},
-								"url": "{{baseUrl}}/documents/extract"
+								"url": {
+									"raw": "{{baseUrl}}/documents/extract",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"documents",
+										"extract"
+									]
+								}
 							},
 							"status": "Bad Request",
 							"code": 400,
@@ -385,7 +464,16 @@
 										}
 									]
 								},
-								"url": "{{baseUrl}}/documents/extract"
+								"url": {
+									"raw": "{{baseUrl}}/documents/extract",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"documents",
+										"extract"
+									]
+								}
 							},
 							"status": "OK",
 							"code": 200,
@@ -411,7 +499,15 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"url": "{{baseUrl}}/restrictedDocumentTypes"
+						"url": {
+							"raw": "{{baseUrl}}/restrictedDocumentTypes",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"restrictedDocumentTypes"
+							]
+						}
 					},
 					"response": []
 				},
@@ -420,7 +516,16 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"url": "{{baseUrl}}/restrictedDocumentTypes/810edbd7-6fc1-483e-a2ff-c86ed677c6f2"
+						"url": {
+							"raw": "{{baseUrl}}/restrictedDocumentTypes/810edbd7-6fc1-483e-a2ff-c86ed677c6f2",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"restrictedDocumentTypes",
+								"810edbd7-6fc1-483e-a2ff-c86ed677c6f2"
+							]
+						}
 					},
 					"response": []
 				},
@@ -438,7 +543,15 @@
 								}
 							}
 						},
-						"url": "{{baseUrl}}/restrictedDocumentTypes"
+						"url": {
+							"raw": "{{baseUrl}}/restrictedDocumentTypes",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"restrictedDocumentTypes"
+							]
+						}
 					},
 					"response": []
 				},
@@ -456,7 +569,15 @@
 								}
 							}
 						},
-						"url": "{{baseUrl}}/restrictedDocumentTypes"
+						"url": {
+							"raw": "{{baseUrl}}/restrictedDocumentTypes",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"restrictedDocumentTypes"
+							]
+						}
 					},
 					"response": []
 				},
@@ -465,7 +586,16 @@
 					"request": {
 						"method": "DELETE",
 						"header": [],
-						"url": "{{baseUrl}}/restrictedDocumentTypes/{{id}}"
+						"url": {
+							"raw": "{{baseUrl}}/restrictedDocumentTypes/{{id}}",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"restrictedDocumentTypes",
+								"{{id}}"
+							]
+						}
 					},
 					"response": []
 				}
@@ -485,19 +615,79 @@
 								"type": "text"
 							}
 						],
-						"url": "{{baseUrl}}/documents/processed/1234"
+						"url": {
+							"raw": "{{baseUrl}}/documents/processed/1234",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"documents",
+								"processed",
+								"1234"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Document Webhook Events",
+			"item": [
+				{
+					"name": "Document Status Update",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"data\": [\r\n    {\r\n      \"id\": 2390,\r\n      \"status\": \"PROCESSED\"\r\n    }\r\n  ],\r\n  \"event\": \"FILE_PROCESSED\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/documents/webhookEvent",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"documents",
+								"webhookEvent"
+							]
+						}
 					},
 					"response": []
 				}
 			]
 		}
 	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
 	"variable": [
 		{
-			"id": "42189589-4c99-4d9a-8870-aec8ce810e78",
 			"key": "baseUrl",
-			"value": "http://localhost:8080",
-			"type": "string"
+			"value": "http://localhost:8080"
 		}
 	]
 }

--- a/src/backend/efiling-reviewer-api/src/test/java/ca/bc/gov/open/jag/efilingreviewerapi/document/documentsApiDelegateImpl/DocumentWebhookEventTest.java
+++ b/src/backend/efiling-reviewer-api/src/test/java/ca/bc/gov/open/jag/efilingreviewerapi/document/documentsApiDelegateImpl/DocumentWebhookEventTest.java
@@ -1,0 +1,167 @@
+package ca.bc.gov.open.jag.efilingreviewerapi.document.documentsApiDelegateImpl;
+
+import ca.bc.gov.open.efilingdiligenclient.diligen.DiligenService;
+import ca.bc.gov.open.efilingdiligenclient.diligen.model.DiligenDocumentDetails;
+import ca.bc.gov.open.efilingdiligenclient.diligen.processor.FieldProcessor;
+import ca.bc.gov.open.jag.efilingdiligenclient.api.model.Field;
+import ca.bc.gov.open.jag.efilingdiligenclient.api.model.ProjectFieldsResponse;
+import ca.bc.gov.open.jag.efilingdiligenclient.api.model.ProjectFieldsResponseData;
+import ca.bc.gov.open.jag.efilingreviewerapi.api.model.DocumentWebhookEvent;
+import ca.bc.gov.open.jag.efilingreviewerapi.api.model.DocumentWebhookEventData;
+import ca.bc.gov.open.jag.efilingreviewerapi.document.DocumentsApiDelegateImpl;
+import ca.bc.gov.open.jag.efilingreviewerapi.document.models.Document;
+import ca.bc.gov.open.jag.efilingreviewerapi.document.models.DocumentTypeConfiguration;
+import ca.bc.gov.open.jag.efilingreviewerapi.document.store.DocumentTypeConfigurationRepository;
+import ca.bc.gov.open.jag.efilingreviewerapi.document.validators.DocumentValidator;
+import ca.bc.gov.open.jag.efilingreviewerapi.error.AiReviewerDocumentException;
+import ca.bc.gov.open.jag.efilingreviewerapi.extract.mappers.ExtractRequestMapper;
+import ca.bc.gov.open.jag.efilingreviewerapi.extract.mappers.ExtractRequestMapperImpl;
+import ca.bc.gov.open.jag.efilingreviewerapi.extract.models.Extract;
+import ca.bc.gov.open.jag.efilingreviewerapi.extract.models.ExtractRequest;
+import ca.bc.gov.open.jag.efilingreviewerapi.extract.store.ExtractStore;
+import ca.bc.gov.open.jag.efilingreviewerapi.webhook.WebHookService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.*;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class DocumentWebhookEventTest {
+
+
+    private DocumentsApiDelegateImpl sut;
+
+    @Mock
+    private DiligenService diligenServiceMock;
+
+    @Mock
+    private ExtractStore extractStoreMock;
+
+    @Mock
+    private DocumentValidator documentValidatorMock;
+
+    @Mock
+    private FieldProcessor fieldProcessorMock;
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplateMock;
+
+    @Mock
+    private DocumentTypeConfigurationRepository documentTypeConfigurationRepositoryMock;
+
+    @Mock
+    private WebHookService webHookServiceMock;
+
+    @BeforeAll
+    public void beforeAll() {
+
+        MockitoAnnotations.openMocks(this);
+
+        ExtractRequestMapper extractRequestMapper = new ExtractRequestMapperImpl();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        ObjectNode result = objectMapper.createObjectNode();
+        result.put("test", "test");
+
+        Mockito.when(fieldProcessorMock.getJson(Mockito.any(), Mockito.any())).thenReturn(result);
+
+        Mockito.when(diligenServiceMock.getDocumentDetails(Mockito.any())).thenReturn(DiligenDocumentDetails.builder().create());
+
+        DocumentTypeConfiguration configuration = DocumentTypeConfiguration.builder().create();
+        Mockito.when(documentTypeConfigurationRepositoryMock.findByDocumentType(Mockito.eq("TYPE"))).thenReturn(configuration);
+
+        ProjectFieldsResponse projectFieldResponse = new ProjectFieldsResponse();
+        ProjectFieldsResponseData data = new ProjectFieldsResponseData();
+        List<Field> fields = new ArrayList<>();
+        Field field = new Field();
+        List<String> values = new ArrayList<>();
+        values.add("test");
+        field.setValues(values);
+        fields.add(field);
+        data.setFields(fields);
+        projectFieldResponse.setData(data);
+        Mockito.when(diligenServiceMock.getDocumentDetails(ArgumentMatchers.eq(BigDecimal.ONE))).thenReturn(DiligenDocumentDetails.builder()
+                .projectFieldsResponse(projectFieldResponse).create());
+        Mockito.when(extractStoreMock.get(Mockito.eq(BigDecimal.ONE))).thenReturn(Optional.of(ExtractRequest.builder()
+                .document(Document.builder()
+                        .type("TYPE")
+                        .create())
+                .extract(Extract.builder()
+                        .id(UUID.randomUUID())
+                        .transactionId(UUID.randomUUID())
+                        .useWebhook(true)
+                        .create())
+                .create()));
+
+        Mockito.when(diligenServiceMock.getDocumentDetails(ArgumentMatchers.eq(BigDecimal.ZERO))).thenReturn(DiligenDocumentDetails.builder()
+                .projectFieldsResponse(projectFieldResponse).create());
+
+        Mockito.when(extractStoreMock.get(Mockito.eq(BigDecimal.ZERO))).thenReturn(Optional.of(ExtractRequest.builder()
+                .document(Document.builder()
+                        .type("TYPE")
+                        .create())
+                .extract(Extract.builder()
+                        .id(UUID.randomUUID())
+                        .transactionId(UUID.randomUUID())
+                        .useWebhook(false)
+                        .create())
+                .create()));
+
+        Mockito.when(extractStoreMock.get(Mockito.eq(BigDecimal.TEN))).thenReturn(Optional.of(ExtractRequest.builder()
+                .document(Document.builder()
+                        .type("NO-CONFIG")
+                        .create())
+                .create()));
+
+        Mockito.doNothing().when(webHookServiceMock).sendDocumentReady(Mockito.any(), Mockito.any());
+
+        sut = new DocumentsApiDelegateImpl(diligenServiceMock, extractRequestMapper, extractStoreMock, stringRedisTemplateMock, fieldProcessorMock, documentValidatorMock, documentTypeConfigurationRepositoryMock, null, webHookServiceMock);
+
+    }
+
+    @Test
+    @DisplayName("200: succeeds with correctly formatted request body")
+    public void testSuccessEvent() {
+        ArrayList<DocumentWebhookEventData> documentWebhookEventDataList = new ArrayList<DocumentWebhookEventData>();
+        DocumentWebhookEvent documentWebhookEvent = new DocumentWebhookEvent();
+        DocumentWebhookEventData documentWebhookEventData = new DocumentWebhookEventData();
+        documentWebhookEventData.setId(BigDecimal.ONE);
+        documentWebhookEventData.setStatus("Processed");
+        documentWebhookEventDataList.add(documentWebhookEventData);
+        documentWebhookEvent.setData(documentWebhookEventDataList);
+        documentWebhookEvent.setEvent("FILE_PROCESSED");
+        ResponseEntity<Void> actual = sut.documentWebhookEvent(documentWebhookEvent);
+        Assertions.assertEquals(HttpStatus.OK, actual.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("400: error when data object is not present in request body")
+    public void testErrorEventNullData() {
+        DocumentWebhookEvent documentWebhookEvent = new DocumentWebhookEvent();
+        documentWebhookEvent.setData(null);
+        documentWebhookEvent.setEvent("FILE_PROCESSED");
+        Assertions.assertThrows(AiReviewerDocumentException.class, () -> sut.documentWebhookEvent(documentWebhookEvent));
+    }
+
+    @Test
+    @DisplayName("400: error when data object is empty in request body")
+    public void testErrorEventEmptyData() {
+        DocumentWebhookEvent documentWebhookEvent = new DocumentWebhookEvent();
+        documentWebhookEvent.setData(new ArrayList<>());
+        documentWebhookEvent.setEvent("FILE_PROCESSED");
+        Assertions.assertThrows(AiReviewerDocumentException.class, () -> sut.documentWebhookEvent(documentWebhookEvent));
+    }
+}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

FLA-1085
- Added an endpoint that receives a call from Diligen via webhook and processes document events

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Manual testing, postman testing, unit tests.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
