### PR TITLE
Set submission auto processing flag if package contains specific document types

### DIFF
--- a/src/backend/libs/efiling-cso-client/src/main/java/ca/bc/gov/open/jag/efilingcsoclient/CsoReviewServiceImpl.java
+++ b/src/backend/libs/efiling-cso-client/src/main/java/ca/bc/gov/open/jag/efilingcsoclient/CsoReviewServiceImpl.java
@@ -69,7 +69,7 @@ public class CsoReviewServiceImpl implements EfilingReviewService {
             logger.info("Calling soap findStatusBySearchCriteria by client id and package service ");
 
             FilingStatus filingStatus = filingStatusFacadeBean
-                    .findStatusBySearchCriteria(null, null, null, null, null, null, filingPackageRequest.getPackageNo(), filingPackageRequest.getClientId(), null, null, null, null, BigDecimal.ONE, null);
+                    .findStatusBySearchCriteria(null, null, null, null, null, null, filingPackageRequest.getPackageNo(), filingPackageRequest.getClientId(), null, null, null, null, BigDecimal.ONE, null, null);
 
             if (filingStatus.getFilePackages() == null || filingStatus.getFilePackages().isEmpty()) return Optional.empty();
 
@@ -103,7 +103,7 @@ public class CsoReviewServiceImpl implements EfilingReviewService {
             DateTime startDate = endDate.minusYears(1);
 
             FilingStatus filingStatus = filingStatusFacadeBean
-                    .findStatusBySearchCriteria(null, null, null, DateUtils.getXmlDate(startDate), DateUtils.getXmlDate(endDate), null , null, filingPackageRequest.getClientId(), null, null, null, null, BigDecimal.valueOf(100), null);
+                    .findStatusBySearchCriteria(null, null, null, DateUtils.getXmlDate(startDate), DateUtils.getXmlDate(endDate), null , null, filingPackageRequest.getClientId(), null, null, null, null, BigDecimal.valueOf(100), null, null);
 
             if (filingStatus.getFilePackages().isEmpty()) return new ArrayList<>();
 

--- a/src/backend/libs/efiling-cso-client/src/main/java/ca/bc/gov/open/jag/efilingcsoclient/CsoSubmissionServiceImpl.java
+++ b/src/backend/libs/efiling-cso-client/src/main/java/ca/bc/gov/open/jag/efilingcsoclient/CsoSubmissionServiceImpl.java
@@ -112,12 +112,10 @@ public class CsoSubmissionServiceImpl implements EfilingSubmissionService {
 
             String documentTypeCd = document.getDocumentTypeCd();
             for(DocumentTypeDetails documentTypeDetail : documentTypeDetailsList) {
-                if(documentTypeDetail.getType().equals(documentTypeCd)) {
-                    if(documentTypeDetail.isAutoProcessing()) {
-                        csoFilingPackage.setAutomatedProcessYn(true);
-                        autoProcess = true;
-                        break;
-                    }
+                if(documentTypeDetail.getType().equals(documentTypeCd) && documentTypeDetail.isAutoProcessing()) {
+                    csoFilingPackage.setAutomatedProcessYn(true);
+                    autoProcess = true;
+                    break;
                 }
             }
         }

--- a/src/backend/libs/efiling-cso-client/src/main/java/ca/bc/gov/open/jag/efilingcsoclient/CsoSubmissionServiceImpl.java
+++ b/src/backend/libs/efiling-cso-client/src/main/java/ca/bc/gov/open/jag/efilingcsoclient/CsoSubmissionServiceImpl.java
@@ -99,26 +99,7 @@ public class CsoSubmissionServiceImpl implements EfilingSubmissionService {
             csoFilingPackage.setProcRequest(buildRushedOrderRequest(accountDetails));
         }
 
-        String courtClass = efilingPackage.getCourt().getCourtClass();
-        String courtLevel = efilingPackage.getCourt().getLevel();
-        List<DocumentTypeDetails> documentTypeDetailsList = efilingDocumentService.getDocumentTypes(courtLevel, courtClass);
-
-        List<CivilDocument> documents = csoFilingPackage.getDocuments();
-        boolean autoProcess = false;
-        for(CivilDocument document : documents) {
-            if(autoProcess) {
-                break;
-            }
-
-            String documentTypeCd = document.getDocumentTypeCd();
-            for(DocumentTypeDetails documentTypeDetail : documentTypeDetailsList) {
-                if(documentTypeDetail.getType().equals(documentTypeCd) && documentTypeDetail.isAutoProcessing()) {
-                    csoFilingPackage.setAutomatedProcessYn(true);
-                    autoProcess = true;
-                    break;
-                }
-            }
-        }
+        determineAutoProcessingFlagFromDocuments(efilingPackage, csoFilingPackage);
 
         BigDecimal filingResult = filePackage(csoFilingPackage);
 
@@ -334,6 +315,30 @@ public class CsoSubmissionServiceImpl implements EfilingSubmissionService {
         }
 
     }
+
+    private void determineAutoProcessingFlagFromDocuments(FilingPackage efilingPackage, ca.bc.gov.ag.csows.filing.FilingPackage csoFilingPackage) {
+        String courtClass = efilingPackage.getCourt().getCourtClass();
+        String courtLevel = efilingPackage.getCourt().getLevel();
+        List<DocumentTypeDetails> documentTypeDetailsList = efilingDocumentService.getDocumentTypes(courtLevel, courtClass);
+
+        List<CivilDocument> documents = csoFilingPackage.getDocuments();
+        boolean autoProcess = false;
+        for(CivilDocument document : documents) {
+            if(autoProcess) {
+                break;
+            }
+
+            String documentTypeCd = document.getDocumentTypeCd();
+            for(DocumentTypeDetails documentTypeDetail : documentTypeDetailsList) {
+                if(documentTypeDetail.getType().equals(documentTypeCd) && documentTypeDetail.isAutoProcessing()) {
+                    csoFilingPackage.setAutomatedProcessYn(true);
+                    autoProcess = true;
+                    break;
+                }
+            }
+        }
+    }
+
     //This function will be used when cso has the valid flag available
     private Boolean validateJson(Object json) {
 

--- a/src/backend/libs/efiling-cso-client/src/main/java/ca/bc/gov/open/jag/efilingcsoclient/CsoSubmissionServiceImpl.java
+++ b/src/backend/libs/efiling-cso-client/src/main/java/ca/bc/gov/open/jag/efilingcsoclient/CsoSubmissionServiceImpl.java
@@ -322,18 +322,12 @@ public class CsoSubmissionServiceImpl implements EfilingSubmissionService {
         List<DocumentTypeDetails> documentTypeDetailsList = efilingDocumentService.getDocumentTypes(courtLevel, courtClass);
 
         List<CivilDocument> documents = csoFilingPackage.getDocuments();
-        boolean autoProcess = false;
         for(CivilDocument document : documents) {
-            if(autoProcess) {
-                break;
-            }
-
             String documentTypeCd = document.getDocumentTypeCd();
             for(DocumentTypeDetails documentTypeDetail : documentTypeDetailsList) {
                 if(documentTypeDetail.getType().equals(documentTypeCd) && documentTypeDetail.isAutoProcessing()) {
                     csoFilingPackage.setAutomatedProcessYn(true);
-                    autoProcess = true;
-                    break;
+                    return;
                 }
             }
         }

--- a/src/backend/libs/efiling-cso-client/src/main/resources/wsdl/FilingStatusFacade.wsdl
+++ b/src/backend/libs/efiling-cso-client/src/main/resources/wsdl/FilingStatusFacade.wsdl
@@ -128,6 +128,7 @@
             </xs:complexType>
             <xs:complexType name="documentType">
                 <xs:sequence>
+                    <xs:element minOccurs="0" name="autoProcessYn" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="defaultStatutoryFee" type="xs:decimal"/>
                     <xs:element minOccurs="0" name="documentTypeCd" type="xs:string"/>
                     <xs:element minOccurs="0" name="documentTypeDesc" type="xs:string"/>
@@ -249,6 +250,8 @@
             </xs:complexType>
             <xs:complexType name="filePackage">
                 <xs:sequence>
+                    <xs:element minOccurs="0" name="applicationCd" type="xs:string"/>
+                    <xs:element minOccurs="0" name="applicationDsc" type="xs:string"/>
                     <xs:element minOccurs="0" name="clientFileNo" type="xs:string"/>
                     <xs:element minOccurs="0" name="courtClassCd" type="xs:string"/>
                     <xs:element minOccurs="0" name="courtFileNo" type="xs:string"/>
@@ -485,6 +488,7 @@
                     <xs:element minOccurs="0" name="arg11" type="xs:decimal"/>
                     <xs:element minOccurs="0" name="arg12" type="xs:decimal"/>
                     <xs:element minOccurs="0" name="arg13" type="xs:dateTime"/>
+                    <xs:element minOccurs="0" name="arg14" type="xs:string"/>
                 </xs:sequence>
             </xs:complexType>
             <xs:complexType name="findStatusBySearchCriteriaResponse">

--- a/src/backend/libs/efiling-cso-client/src/test/java/ca/bc/gov/open/jag/efilingcsoclient/csoReviewServiceImpl/FindPackageByIdTest.java
+++ b/src/backend/libs/efiling-cso-client/src/test/java/ca/bc/gov/open/jag/efilingcsoclient/csoReviewServiceImpl/FindPackageByIdTest.java
@@ -65,11 +65,11 @@ public class FindPackageByIdTest {
         FilingStatus filingStatus =  createFilingStatus();
         filingStatus.getFilePackages().add(createFilePackage());
 
-        Mockito.when(filingStatusFacadeBean.findStatusBySearchCriteria(any(), any(), any(), any(), any(), any(), ArgumentMatchers.eq(SUCCESS_PACKAGE), ArgumentMatchers.eq(SUCCESS_CLIENT), any(), any(), any(), any(), any(), any())).thenReturn(filingStatus);
+        Mockito.when(filingStatusFacadeBean.findStatusBySearchCriteria(any(), any(), any(), any(), any(), any(), ArgumentMatchers.eq(SUCCESS_PACKAGE), ArgumentMatchers.eq(SUCCESS_CLIENT), any(), any(), any(), any(), any(), any(), any())).thenReturn(filingStatus);
 
-        Mockito.when(filingStatusFacadeBean.findStatusBySearchCriteria(any(), any(), any(), any(), any(), any(), ArgumentMatchers.eq(NOTFOUND_PACKAGE), ArgumentMatchers.eq(NOTFOUND_CLIENT), any(), any(), any(), any(), any(), any())).thenReturn(createFilingStatus());
+        Mockito.when(filingStatusFacadeBean.findStatusBySearchCriteria(any(), any(), any(), any(), any(), any(), ArgumentMatchers.eq(NOTFOUND_PACKAGE), ArgumentMatchers.eq(NOTFOUND_CLIENT), any(), any(), any(), any(), any(), any(), any())).thenReturn(createFilingStatus());
 
-        Mockito.when(filingStatusFacadeBean.findStatusBySearchCriteria(any(), any(), any(), any(), any(), any(), ArgumentMatchers.eq(EXCEPTION_PACKAGE), ArgumentMatchers.eq(EXCEPTION_CLIENT), any(), any(), any(), any(), any(), any())).thenThrow(new NestedEjbException_Exception());
+        Mockito.when(filingStatusFacadeBean.findStatusBySearchCriteria(any(), any(), any(), any(), any(), any(), ArgumentMatchers.eq(EXCEPTION_PACKAGE), ArgumentMatchers.eq(EXCEPTION_CLIENT), any(), any(), any(), any(), any(), any(), any())).thenThrow(new NestedEjbException_Exception());
 
         CsoProperties csoProperties = new CsoProperties();
         csoProperties.setCsoBasePath("http://locahost:8080");

--- a/src/backend/libs/efiling-cso-client/src/test/java/ca/bc/gov/open/jag/efilingcsoclient/csoReviewServiceImpl/FindPackagesByClientIdTest.java
+++ b/src/backend/libs/efiling-cso-client/src/test/java/ca/bc/gov/open/jag/efilingcsoclient/csoReviewServiceImpl/FindPackagesByClientIdTest.java
@@ -62,11 +62,11 @@ public class FindPackagesByClientIdTest {
         FilingStatus filingStatus =  createFilingStatus();
         filingStatus.getFilePackages().add(createFilePackage());
 
-        Mockito.when(filingStatusFacadeBean.findStatusBySearchCriteria(any(), any(), any(), any(), any(), any(), any(), ArgumentMatchers.eq(SUCCESS_CLIENT), any(), any(), any(), any(), any(), any())).thenReturn(filingStatus);
+        Mockito.when(filingStatusFacadeBean.findStatusBySearchCriteria(any(), any(), any(), any(), any(), any(), any(), ArgumentMatchers.eq(SUCCESS_CLIENT), any(), any(), any(), any(), any(), any(), any())).thenReturn(filingStatus);
 
-        Mockito.when(filingStatusFacadeBean.findStatusBySearchCriteria(any(), any(), any(), any(), any(), any(), any(), ArgumentMatchers.eq(NOTFOUND_CLIENT), any(), any(), any(), any(), any(), any())).thenReturn(createFilingStatus());
+        Mockito.when(filingStatusFacadeBean.findStatusBySearchCriteria(any(), any(), any(), any(), any(), any(), any(), ArgumentMatchers.eq(NOTFOUND_CLIENT), any(), any(), any(), any(), any(), any(), any())).thenReturn(createFilingStatus());
 
-        Mockito.when(filingStatusFacadeBean.findStatusBySearchCriteria(any(), any(), any(), any(), any(), any(), any(), ArgumentMatchers.eq(EXCEPTION_CLIENT), any(), any(), any(), any(), any(), any())).thenThrow(new NestedEjbException_Exception());
+        Mockito.when(filingStatusFacadeBean.findStatusBySearchCriteria(any(), any(), any(), any(), any(), any(), any(), ArgumentMatchers.eq(EXCEPTION_CLIENT), any(), any(), any(), any(), any(), any(), any())).thenThrow(new NestedEjbException_Exception());
 
         CsoProperties csoProperties = new CsoProperties();
         csoProperties.setCsoBasePath("http://locahost:8080");

--- a/src/backend/libs/efiling-cso-client/src/test/java/ca/bc/gov/open/jag/efilingcsoclient/csoSubmissionServiceImpl/SubmitFilingPackageTest.java
+++ b/src/backend/libs/efiling-cso-client/src/test/java/ca/bc/gov/open/jag/efilingcsoclient/csoSubmissionServiceImpl/SubmitFilingPackageTest.java
@@ -110,8 +110,8 @@ public class SubmitFilingPackageTest {
                 .calculateSubmittedDate(any(), Mockito.eq(BAD_LOCATION));
 
 
-        DocumentTypeDetails documentTypeDetailsNoRush = new DocumentTypeDetails("description", "type1", new BigDecimal(1.0), false, false, false);
-        DocumentTypeDetails documentTypeDetailsRush = new DocumentTypeDetails("description", "type2", new BigDecimal(1.0), false, false, true);
+        DocumentTypeDetails documentTypeDetailsNoRush = new DocumentTypeDetails("description", "type1", new BigDecimal("1"), false, false, false);
+        DocumentTypeDetails documentTypeDetailsRush = new DocumentTypeDetails("description", "type2", new BigDecimal("1"), false, false, true);
         List<DocumentTypeDetails> documentTypeDetailsList = Arrays.asList(documentTypeDetailsNoRush, documentTypeDetailsRush);
         Mockito.when(efilingDocumentServiceMock.getDocumentTypes(Mockito.anyString(), Mockito.anyString())).thenReturn(documentTypeDetailsList);
 

--- a/src/backend/libs/efiling-cso-client/src/test/java/ca/bc/gov/open/jag/efilingcsoclient/csoSubmissionServiceImpl/SubmitFilingPackageTest.java
+++ b/src/backend/libs/efiling-cso-client/src/test/java/ca/bc/gov/open/jag/efilingcsoclient/csoSubmissionServiceImpl/SubmitFilingPackageTest.java
@@ -110,8 +110,8 @@ public class SubmitFilingPackageTest {
                 .calculateSubmittedDate(any(), Mockito.eq(BAD_LOCATION));
 
 
-        DocumentTypeDetails documentTypeDetailsNoRush = new DocumentTypeDetails("description", "type1", new BigDecimal("1"), false, false, false);
-        DocumentTypeDetails documentTypeDetailsRush = new DocumentTypeDetails("description", "type2", new BigDecimal("1"), false, false, true);
+        DocumentTypeDetails documentTypeDetailsNoRush = new DocumentTypeDetails("description", "type1", BigDecimal.ONE, false, false, false);
+        DocumentTypeDetails documentTypeDetailsRush = new DocumentTypeDetails("description", "type2", BigDecimal.ONE, false, false, true);
         List<DocumentTypeDetails> documentTypeDetailsList = Arrays.asList(documentTypeDetailsNoRush, documentTypeDetailsRush);
         Mockito.when(efilingDocumentServiceMock.getDocumentTypes(Mockito.anyString(), Mockito.anyString())).thenReturn(documentTypeDetailsList);
 

--- a/src/backend/libs/efiling-cso-starter/src/main/java/ca/bc/gov/open/jag/efilingcsostarter/config/AutoConfiguration.java
+++ b/src/backend/libs/efiling-cso-starter/src/main/java/ca/bc/gov/open/jag/efilingcsostarter/config/AutoConfiguration.java
@@ -240,7 +240,8 @@ public class AutoConfiguration {
                                                              FinancialTransactionMapper financialTransactionMapper,
                                                              DocumentMapper documentMapper,
                                                              CsoPartyMapper csoPartyMapper,
-                                                             PackageAuthorityMapper packageAuthorityMapper) {
+                                                             PackageAuthorityMapper packageAuthorityMapper,
+                                                             EfilingDocumentService efilingDocumentService) {
 
         return new CsoSubmissionServiceImpl(
                 filingFacadeBean,
@@ -251,7 +252,8 @@ public class AutoConfiguration {
                 csoProperties,
                 documentMapper,
                 csoPartyMapper,
-                packageAuthorityMapper); }
+                packageAuthorityMapper,
+                efilingDocumentService); }
 
 
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

FLA-1099
- When submitting a package to CSO, the auto processing flag is now set if the package contains document types that should be auto processed
- The FilingStatusFacade WSDL has been updated

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Unit tests.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
