### PR TITLE
Updated csoBaseUrl to use front end environment variable instead of calling config API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - REACT_APP_KEYCLOAK_URL=${KEYCLOAK_URL:-http://localhost:8081/auth}
       - REACT_APP_API_BASE_URL=http://localhost:8080
       - REACT_APP_BAMBORA_REDIRECT_URL=http://localhost:3000/efilinghub
+      - REACT_APP_CSO_BASE_URL=http://localhost/cso
 
   #############################################################################################
   ###                                 EFILING DEMO                                          ###

--- a/src/frontend/efiling-frontend/.env.template
+++ b/src/frontend/efiling-frontend/.env.template
@@ -5,3 +5,4 @@ REACT_APP_KEYCLOAK_URL=http://localhost:8081/auth
 REACT_APP_API_BASE_URL=http://localhost:8080
 REACT_APP_BAMBORA_REDIRECT_URL=http://localhost:3000/efilinghub
 REACT_APP_BCSC_USERINFO_URL=http://localhost
+REACT_APP_CSO_BASE_URL=http://localhost/cso

--- a/src/frontend/efiling-frontend/src/components/page/cso-account/CSOAccount.stories.js
+++ b/src/frontend/efiling-frontend/src/components/page/cso-account/CSOAccount.stories.js
@@ -19,7 +19,6 @@ const setCsoAccountStatus = action("setCso");
 
 const mock = new MockAdapter(axios);
 const API_REQUEST = "/csoAccount";
-sessionStorage.setItem("csoBaseUrl", "https://dev.justice.gov.bc.ca/cso");
 
 const CreateAccount = (props) => {
   mock.onPost(API_REQUEST).reply(201, {

--- a/src/frontend/efiling-frontend/src/components/page/cso-account/__snapshots__/CSOAccount.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/components/page/cso-account/__snapshots__/CSOAccount.stories.storyshot
@@ -895,7 +895,7 @@ exports[`Storyshots CSOAccount Default 1`] = `
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1808,7 +1808,7 @@ exports[`Storyshots CSOAccount Mobile 1`] = `
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >

--- a/src/frontend/efiling-frontend/src/components/page/cso-account/__tests__/CSOAccount.test.js
+++ b/src/frontend/efiling-frontend/src/components/page/cso-account/__tests__/CSOAccount.test.js
@@ -32,7 +32,6 @@ describe("CSOAccount Component", () => {
   });
 
   localStorage.setItem("jwt", token);
-  sessionStorage.setItem("csoBaseUrl", "https://dev.justice.gov.bc.ca/cso");
 
   test("Matches the snapshot", () => {
     const { asFragment } = render(

--- a/src/frontend/efiling-frontend/src/components/page/cso-account/__tests__/__snapshots__/CSOAccount.test.js.snap
+++ b/src/frontend/efiling-frontend/src/components/page/cso-account/__tests__/__snapshots__/CSOAccount.test.js.snap
@@ -895,7 +895,7 @@ exports[`CSOAccount Component Matches the snapshot 1`] = `
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >

--- a/src/frontend/efiling-frontend/src/components/page/home/Home.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.js
@@ -40,14 +40,10 @@ const setRequestHeaders = (transactionId) => {
   });
 };
 
-export const saveUrlsToSessionStorage = (
-  { cancel, success, error },
-  csoBaseUrl
-) => {
+export const saveUrlsToSessionStorage = ({ cancel, success, error }) => {
   sessionStorage.setItem("cancelUrl", cancel);
   sessionStorage.setItem("successUrl", success);
   sessionStorage.setItem("errorUrl", error);
-  localStorage.setItem("csoBaseUrl", csoBaseUrl);
 };
 
 const addUserInfo = (firstName, middleName, lastName) => {
@@ -86,9 +82,9 @@ const checkCSOAccountStatus = (
   }
   axios
     .get(`/submission/${submissionId}/config`)
-    .then(({ data: { navigationUrls, clientAppName, csoBaseUrl } }) => {
+    .then(({ data: { navigationUrls, clientAppName } }) => {
       setClientApplicationName(clientAppName);
-      saveUrlsToSessionStorage(navigationUrls, csoBaseUrl);
+      saveUrlsToSessionStorage(navigationUrls);
 
       axios
         .get("/csoAccount")

--- a/src/frontend/efiling-frontend/src/components/page/home/Home.test.js
+++ b/src/frontend/efiling-frontend/src/components/page/home/Home.test.js
@@ -114,33 +114,27 @@ describe("Home", () => {
     expect(sessionStorage.getItem("cancelUrl")).toBeFalsy();
     expect(sessionStorage.getItem("successUrl")).toBeFalsy();
     expect(sessionStorage.getItem("errorUrl")).toBeFalsy();
-    expect(sessionStorage.getItem("csoBaseUrl")).toBeFalsy();
 
-    saveUrlsToSessionStorage(navigationUrls, csoBaseUrl);
+    saveUrlsToSessionStorage(navigationUrls);
 
     expect(sessionStorage.getItem("cancelUrl")).toEqual(navigationUrls.cancel);
     expect(sessionStorage.getItem("successUrl")).toEqual(
       navigationUrls.success
     );
     expect(sessionStorage.getItem("errorUrl")).toBeFalsy();
-    expect(localStorage.getItem("csoBaseUrl")).toEqual(csoBaseUrl);
 
     sessionStorage.clear();
 
-    saveUrlsToSessionStorage(
-      {
-        ...navigationUrls,
-        cancel: "",
-        success: "",
-        error: "error.com",
-      },
-      csoBaseUrl
-    );
+    saveUrlsToSessionStorage({
+      ...navigationUrls,
+      cancel: "",
+      success: "",
+      error: "error.com",
+    });
 
     expect(sessionStorage.getItem("cancelUrl")).toBeFalsy();
     expect(sessionStorage.getItem("successUrl")).toBeFalsy();
     expect(sessionStorage.getItem("errorUrl")).toEqual("error.com");
-    expect(localStorage.getItem("csoBaseUrl")).toEqual(csoBaseUrl);
   });
 
   test("Redirects to error page when lookup to bceid call fails", async () => {

--- a/src/frontend/efiling-frontend/src/components/page/home/__snapshots__/Home.test.js.snap
+++ b/src/frontend/efiling-frontend/src/components/page/home/__snapshots__/Home.test.js.snap
@@ -995,7 +995,7 @@ exports[`Home Component matches the snapshot when user cso account does not exis
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="https://dev.justice.gov.bc.ca/cso/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1314,7 +1314,7 @@ exports[`Home Component matches the snapshot when user cso account exists 1`] = 
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="https://dev.justice.gov.bc.ca/cso/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1384,7 +1384,7 @@ exports[`Home Component matches the snapshot when user cso account exists 1`] = 
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="https://dev.justice.gov.bc.ca/cso/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -2311,7 +2311,7 @@ exports[`Home When user has authenticated with BCSC with no CSO account, retriev
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="https://dev.justice.gov.bc.ca/cso/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >

--- a/src/frontend/efiling-frontend/src/components/page/rush/Rush.test.js
+++ b/src/frontend/efiling-frontend/src/components/page/rush/Rush.test.js
@@ -31,7 +31,6 @@ describe("Rush Component", () => {
     },
   });
   localStorage.setItem("jwt", token);
-  sessionStorage.setItem("csoBaseUrl", "https://dev.justice.gov.bc.ca/cso");
   window.scrollTo = jest.fn();
 
   test("Matches the snapshot", () => {

--- a/src/frontend/efiling-frontend/src/components/page/rush/__snapshots__/Rush.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/components/page/rush/__snapshots__/Rush.stories.storyshot
@@ -446,7 +446,7 @@ you feel are necessary.
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -516,7 +516,7 @@ you feel are necessary.
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -980,7 +980,7 @@ you feel are necessary.
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1050,7 +1050,7 @@ you feel are necessary.
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >

--- a/src/frontend/efiling-frontend/src/components/page/rush/__snapshots__/Rush.test.js.snap
+++ b/src/frontend/efiling-frontend/src/components/page/rush/__snapshots__/Rush.test.js.snap
@@ -404,7 +404,7 @@ package and am prepared to submit them for filing. I agree that all fees for thi
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -474,7 +474,7 @@ package and am prepared to submit them for filing. I agree that all fees for thi
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -936,7 +936,7 @@ you feel are necessary.
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1006,7 +1006,7 @@ you feel are necessary.
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >

--- a/src/frontend/efiling-frontend/src/components/page/upload/Upload.test.js
+++ b/src/frontend/efiling-frontend/src/components/page/upload/Upload.test.js
@@ -65,7 +65,6 @@ describe("Upload Component", () => {
 
   const token = generateJWTToken({ preferred_username: "username@bceid" });
   localStorage.setItem("jwt", token);
-  sessionStorage.setItem("csoBaseUrl", "https://dev.justice.gov.bc.ca/cso");
 
   const apiRequest = `/submission/${submissionId}/filing-package`;
   let mock;

--- a/src/frontend/efiling-frontend/src/components/page/upload/__snapshots__/Upload.test.js.snap
+++ b/src/frontend/efiling-frontend/src/components/page/upload/__snapshots__/Upload.test.js.snap
@@ -501,7 +501,7 @@ exports[`Upload Component On cancel upload button click, it redirects to the pac
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -571,7 +571,7 @@ exports[`Upload Component On cancel upload button click, it redirects to the pac
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -978,7 +978,7 @@ exports[`Upload Component Radio buttons working as expected 1`] = `
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1048,7 +1048,7 @@ exports[`Upload Component Radio buttons working as expected 1`] = `
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1900,7 +1900,7 @@ exports[`Upload Component successful document upload works as expected 1`] = `
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1970,7 +1970,7 @@ exports[`Upload Component successful document upload works as expected 1`] = `
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__snapshots__/PackageConfirmation.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__snapshots__/PackageConfirmation.stories.storyshot
@@ -301,7 +301,7 @@ exports[`Storyshots PackageConfirmation Existing Account 1`] = `
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -371,7 +371,7 @@ exports[`Storyshots PackageConfirmation Existing Account 1`] = `
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -690,7 +690,7 @@ exports[`Storyshots PackageConfirmation Mobile 1`] = `
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -760,7 +760,7 @@ exports[`Storyshots PackageConfirmation Mobile 1`] = `
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1110,7 +1110,7 @@ exports[`Storyshots PackageConfirmation New Account 1`] = `
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1180,7 +1180,7 @@ exports[`Storyshots PackageConfirmation New Account 1`] = `
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__tests__/PackageConfirmation.test.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__tests__/PackageConfirmation.test.js
@@ -38,7 +38,6 @@ describe("PackageConfirmation Component", () => {
     },
   });
   localStorage.setItem("jwt", token);
-  sessionStorage.setItem("csoBaseUrl", "https://dev.justice.gov.bc.ca/cso");
   window.scrollTo = jest.fn();
 
   let mock;

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__tests__/__snapshots__/PackageConfirmation.test.js.snap
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__tests__/__snapshots__/PackageConfirmation.test.js.snap
@@ -301,7 +301,7 @@ exports[`PackageConfirmation Component Matches the existing account snapshot 1`]
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -371,7 +371,7 @@ exports[`PackageConfirmation Component Matches the existing account snapshot 1`]
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -721,7 +721,7 @@ exports[`PackageConfirmation Component Matches the new account snapshot 1`] = `
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -791,7 +791,7 @@ exports[`PackageConfirmation Component Matches the new account snapshot 1`] = `
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1215,7 +1215,7 @@ package and am prepared to submit them for filing. I agree that all fees for thi
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1285,7 +1285,7 @@ package and am prepared to submit them for filing. I agree that all fees for thi
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1806,7 +1806,7 @@ exports[`PackageConfirmation Component On keydown of Upload them now text, it re
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1876,7 +1876,7 @@ exports[`PackageConfirmation Component On keydown of Upload them now text, it re
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -2300,7 +2300,7 @@ package and am prepared to submit them for filing. I agree that all fees for thi
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -2370,7 +2370,7 @@ package and am prepared to submit them for filing. I agree that all fees for thi
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.stories.storyshot
@@ -552,7 +552,7 @@ exports[`Storyshots PackageReview Default 1`] = `
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -622,7 +622,7 @@ exports[`Storyshots PackageReview Default 1`] = `
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1192,7 +1192,7 @@ exports[`Storyshots PackageReview Mobile 1`] = `
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1262,7 +1262,7 @@ exports[`Storyshots PackageReview Mobile 1`] = `
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/__snapshots__/PackageReview.test.js.snap
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/__snapshots__/PackageReview.test.js.snap
@@ -697,7 +697,7 @@ Duis aute irure dolor.
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -767,7 +767,7 @@ Duis aute irure dolor.
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1380,7 +1380,7 @@ exports[`PackageReview Component Reload 1`] = `
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1450,7 +1450,7 @@ exports[`PackageReview Component Reload 1`] = `
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -2063,7 +2063,7 @@ exports[`PackageReview Component Withdraw document network error 1`] = `
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -2133,7 +2133,7 @@ exports[`PackageReview Component Withdraw document network error 1`] = `
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >

--- a/src/frontend/efiling-frontend/src/domain/payment/__snapshots__/Payment.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/domain/payment/__snapshots__/Payment.stories.storyshot
@@ -406,7 +406,7 @@ package and am prepared to submit them for filing. I agree that all fees for thi
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -476,7 +476,7 @@ package and am prepared to submit them for filing. I agree that all fees for thi
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -900,7 +900,7 @@ package and am prepared to submit them for filing. I agree that all fees for thi
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -970,7 +970,7 @@ package and am prepared to submit them for filing. I agree that all fees for thi
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1261,7 +1261,7 @@ package and am prepared to submit them for filing.
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1331,7 +1331,7 @@ package and am prepared to submit them for filing.
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >

--- a/src/frontend/efiling-frontend/src/domain/payment/__tests__/Payment.test.js
+++ b/src/frontend/efiling-frontend/src/domain/payment/__tests__/Payment.test.js
@@ -43,7 +43,6 @@ describe("Payment Component", () => {
     },
   });
   localStorage.setItem("jwt", token);
-  sessionStorage.setItem("csoBaseUrl", "https://dev.justice.gov.bc.ca/cso");
   window.scrollTo = jest.fn();
 
   let mock;

--- a/src/frontend/efiling-frontend/src/domain/payment/__tests__/__snapshots__/Payment.test.js.snap
+++ b/src/frontend/efiling-frontend/src/domain/payment/__tests__/__snapshots__/Payment.test.js.snap
@@ -444,7 +444,7 @@ you feel are necessary.
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -514,7 +514,7 @@ you feel are necessary.
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -936,7 +936,7 @@ package and am prepared to submit them for filing. I agree that all fees for thi
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1006,7 +1006,7 @@ package and am prepared to submit them for filing. I agree that all fees for thi
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1429,7 +1429,7 @@ package and am prepared to submit them for filing. I agree that all fees for thi
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1499,7 +1499,7 @@ package and am prepared to submit them for filing. I agree that all fees for thi
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1816,7 +1816,7 @@ exports[`Payment Component On back click, it redirects back to the package confi
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -1886,7 +1886,7 @@ exports[`Payment Component On back click, it redirects back to the package confi
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >

--- a/src/frontend/efiling-frontend/src/domain/submission/submission-history/__snapshots__/SubmissionHistory.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/domain/submission/submission-history/__snapshots__/SubmissionHistory.stories.storyshot
@@ -173,7 +173,7 @@ exports[`Storyshots SubmissionHistory Default 1`] = `
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -243,7 +243,7 @@ exports[`Storyshots SubmissionHistory Default 1`] = `
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >

--- a/src/frontend/efiling-frontend/src/domain/submission/submission-history/__tests__/__snapshots__/SubmissionHistory.test.js.snap
+++ b/src/frontend/efiling-frontend/src/domain/submission/submission-history/__tests__/__snapshots__/SubmissionHistory.test.js.snap
@@ -205,7 +205,7 @@ exports[`Submission History Component Matches the snapshot 1`] = `
                   </strong>
                    and will be used to file documents. 
                   <a
-                    href="null/accounts/editProfile.do"
+                    href="undefined/accounts/editProfile.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -275,7 +275,7 @@ exports[`Submission History Component Matches the snapshot 1`] = `
                 <p>
                   E-File Submission is a service to help you securely and electronically file documents with the Courts of British Columbia via Court Services Online. 
                   <a
-                    href="null/about/index.do"
+                    href="undefined/about/index.do"
                     rel="noopener noreferrer"
                     target="_blank"
                   >

--- a/src/frontend/efiling-frontend/src/modules/helpers/sidecardData.js
+++ b/src/frontend/efiling-frontend/src/modules/helpers/sidecardData.js
@@ -11,7 +11,7 @@ const aboutCso = () => ({
       file documents with the Courts of British Columbia via Court Services
       Online.&nbsp;
       <a
-        href={`${localStorage.getItem("csoBaseUrl")}/about/index.do`}
+        href={`${process.env.REACT_APP_CSO_BASE_URL}/about/index.do`}
         target="_blank"
         rel="noopener noreferrer"
       >
@@ -39,7 +39,7 @@ const csoAccountDetails = () => {
         <strong>{username}</strong>
         &nbsp;and will be used to file documents.&nbsp;
         <a
-          href={`${localStorage.getItem("csoBaseUrl")}/accounts/editProfile.do`}
+          href={`${process.env.REACT_APP_CSO_BASE_URL}/accounts/editProfile.do`}
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

FLA-1337
- Fixes the side card links when accessing the package screen directly. This is done by replacing the API call to get the csoBaseUrl (which requires a submission ID) with an environment variable.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Unit tests, manual testing.

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
