### PR TITLE
Added package review rush details tab

### DIFF
--- a/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.js
@@ -55,6 +55,14 @@ const determineDefaultTabKey = (queryParamTab, isRush, isProtectionOrder) => {
   return defaultTabKey;
 };
 
+const determineIfProtectionOrder = (documents) => {
+  for (let i = 0; i < documents.length; i += 1) {
+    if (documents[i].documentProperties.type === "POR") return true;
+  }
+
+  return false;
+};
+
 export default function PackageReview() {
   const params = useParams();
   const packageId = Number(params.packageId);
@@ -176,8 +184,14 @@ export default function PackageReview() {
           setSubmissionHistoryLink(response.data.links.packageHistoryUrl);
           setHasRegistryNotice(response.data.hasRegistryNotice);
 
-          // TODO: Proper protection order logic
-          setIsProtectionOrder(false);
+          let protectionOrderFlag = isProtectionOrder;
+          if (response.data.documents) {
+            protectionOrderFlag = determineIfProtectionOrder(
+              response.data.documents
+            );
+            setIsProtectionOrder(protectionOrderFlag);
+          }
+
           if (response.data.rush) {
             setIsRush(true);
             const rushResponse = response.data.rush;
@@ -219,8 +233,7 @@ export default function PackageReview() {
 
             if (tabKey === "") {
               setTabKey(
-                // TODO: confirm it still makes sense to hard code true and false here
-                determineDefaultTabKey(defaultTab, true, false)
+                determineDefaultTabKey(defaultTab, true, protectionOrderFlag)
               );
             }
           } else {
@@ -228,8 +241,7 @@ export default function PackageReview() {
 
             if (tabKey === "") {
               setTabKey(
-                // TODO: confirm isProtectionOrder is fine here (value shouldn't matter if rush is false)
-                determineDefaultTabKey(defaultTab, false, isProtectionOrder)
+                determineDefaultTabKey(defaultTab, false, protectionOrderFlag)
               );
             }
           }

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.js
@@ -118,7 +118,6 @@ export default function PackageReview() {
     getFilingPackage(packageId)
       .then((response) => {
         try {
-          console.log(response);
           const packageNo = response.data.packageNumber || "";
           let submittedBy = "";
           if (response.data.submittedBy.firstName) {

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/SupportingDocumentList.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/SupportingDocumentList.js
@@ -13,9 +13,7 @@ export default function SupportingDocumentList({ packageId, files }) {
 
   const handleDownloadFileEvent = (e, document) => {
     if (isClick(e) || isEnter(e)) {
-      downloadSubmittedDocument(packageId, document).catch((err) => {
-        // TODO: Remove all added console.log statements
-        console.log(err);
+      downloadSubmittedDocument(packageId, document).catch(() => {
         setShowToast(true);
       });
     }
@@ -36,7 +34,7 @@ export default function SupportingDocumentList({ packageId, files }) {
       )}
       <ul>
         {files.map((file) => (
-          // TODO: Fix the classname to be based on the document status
+          // TODO: Fix the classname to be based on the document status when supporting document statuses are added
           <li key={hash(file)} className="SUB">
             <span className="label col-md-5 d-lg-none">File Name:</span>
             <span className="col-md-5 col-lg-4 file-cell">

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/SupportingDocumentList.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/SupportingDocumentList.js
@@ -1,0 +1,71 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import { MdDescription } from "react-icons/md";
+import { propTypes } from "../../../types/propTypes";
+import { Toast } from "../../../components/toast/Toast";
+import { isClick, isEnter } from "../../../modules/helpers/eventUtil";
+import { downloadSubmittedDocument } from "./PackageReviewService";
+
+const hash = require("object-hash");
+
+export default function SupportingDocumentList({ packageId, files }) {
+  const [showToast, setShowToast] = useState(false);
+
+  const handleDownloadFileEvent = (e, document) => {
+    if (isClick(e) || isEnter(e)) {
+      downloadSubmittedDocument(packageId, document).catch((err) => {
+        // TODO: Remove all added console.log statements
+        console.log(err);
+        setShowToast(true);
+      });
+    }
+  };
+
+  return (
+    <div className="ct-document-list">
+      <div className="header">
+        <span className="d-none d-lg-inline col-lg-4">File Name</span>
+        <span className="d-none d-lg-inline col-lg-4">Status</span>
+        <span className="d-none d-lg-inline col-lg-4">Registry Notice</span>
+      </div>
+      {showToast && (
+        <Toast
+          content="Something went wrong while trying to download your file."
+          setShow={setShowToast}
+        />
+      )}
+      <ul>
+        {files.map((file) => (
+          // TODO: Fix the classname to be based on the document status
+          <li key={hash(file)} className="SUB">
+            <span className="label col-md-5 d-lg-none">File Name:</span>
+            <span className="col-md-5 col-lg-4 file-cell">
+              <MdDescription size={30} color="#FCBA19" />
+              <span
+                className="file-href"
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => handleDownloadFileEvent(e, file)}
+                onClick={(e) => handleDownloadFileEvent(e, file)}
+                data-test-id="uploaded-file"
+              >
+                {file.fileName}
+              </span>
+            </span>
+            <span className="label col-md-5 d-lg-none">Status:</span>
+            <span className="col-md-5 col-lg-4">
+              {file.status ? file.status : "file.status not a propety"}
+            </span>
+            <span className="label col-md-5 d-lg-none">Registry Notice:</span>
+            <span className="col-md-5 col-lg-4">Yes/No</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+SupportingDocumentList.propTypes = {
+  packageId: PropTypes.number.isRequired,
+  files: PropTypes.arrayOf(propTypes.file.isRequired).isRequired,
+};

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/SupportingDocumentList.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/SupportingDocumentList.js
@@ -45,7 +45,7 @@ export default function SupportingDocumentList({ packageId, files }) {
                 tabIndex={0}
                 onKeyDown={(e) => handleDownloadFileEvent(e, file)}
                 onClick={(e) => handleDownloadFileEvent(e, file)}
-                data-test-id="uploaded-file"
+                data-testid="uploaded-file"
               >
                 {file.fileName}
               </span>

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/SupportingDocumentList.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/SupportingDocumentList.js
@@ -51,11 +51,9 @@ export default function SupportingDocumentList({ packageId, files }) {
               </span>
             </span>
             <span className="label col-md-5 d-lg-none">Status:</span>
-            <span className="col-md-5 col-lg-4">
-              {file.status ? file.status : "file.status not a propety"}
-            </span>
+            <span className="col-md-5 col-lg-4">Submitted</span>
             <span className="label col-md-5 d-lg-none">Registry Notice:</span>
-            <span className="col-md-5 col-lg-4">Yes/No</span>
+            <span className="col-md-5 col-lg-4">Registry notice goes here</span>
           </li>
         ))}
       </ul>

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__snapshots__/PackageReview.stories.storyshot
@@ -196,45 +196,58 @@ exports[`Storyshots PackageReview Default 1`] = `
         role="tablist"
       >
         <a
-          aria-controls="uncontrolled-tab-tabpane-documents"
-          aria-selected="true"
-          class="nav-item nav-link active"
+          aria-controls="controlled-tab-tabpane-documents"
+          aria-selected="false"
+          class="nav-item nav-link"
           data-rb-event-key="documents"
           href="#"
-          id="uncontrolled-tab-tab-documents"
+          id="controlled-tab-tab-documents"
           role="tab"
         >
           Documents
         </a>
         <a
-          aria-controls="uncontrolled-tab-tabpane-parties"
+          aria-controls="controlled-tab-tabpane-parties"
           aria-selected="false"
           class="nav-item nav-link"
           data-rb-event-key="parties"
           href="#"
-          id="uncontrolled-tab-tab-parties"
+          id="controlled-tab-tab-parties"
           role="tab"
         >
           Parties
         </a>
         <a
-          aria-controls="uncontrolled-tab-tabpane-payment"
+          aria-controls="controlled-tab-tabpane-payment"
           aria-selected="false"
           class="nav-item nav-link"
           data-rb-event-key="payment"
           href="#"
-          id="uncontrolled-tab-tab-payment"
+          id="controlled-tab-tab-payment"
           role="tab"
         >
           Payment Status
         </a>
         <a
-          aria-controls="uncontrolled-tab-tabpane-comments"
+          aria-controls="controlled-tab-tabpane-rush"
+          aria-disabled="true"
+          aria-selected="false"
+          class="nav-item nav-link disabled"
+          data-rb-event-key="rush"
+          href="#"
+          id="controlled-tab-tab-rush"
+          role="tab"
+          tabindex="-1"
+        >
+          Rush Details
+        </a>
+        <a
+          aria-controls="controlled-tab-tabpane-comments"
           aria-selected="false"
           class="nav-item nav-link"
           data-rb-event-key="comments"
           href="#"
-          id="uncontrolled-tab-tab-comments"
+          id="controlled-tab-tab-comments"
           role="tab"
         >
           Filing Comments
@@ -244,10 +257,10 @@ exports[`Storyshots PackageReview Default 1`] = `
         class="tab-content"
       >
         <div
-          aria-hidden="false"
-          aria-labelledby="uncontrolled-tab-tab-documents"
-          class="fade tab-pane active show"
-          id="uncontrolled-tab-tabpane-documents"
+          aria-hidden="true"
+          aria-labelledby="controlled-tab-tab-documents"
+          class="fade tab-pane"
+          id="controlled-tab-tabpane-documents"
           role="tabpanel"
         >
           <br />
@@ -283,9 +296,9 @@ exports[`Storyshots PackageReview Default 1`] = `
         </div>
         <div
           aria-hidden="true"
-          aria-labelledby="uncontrolled-tab-tab-parties"
+          aria-labelledby="controlled-tab-tab-parties"
           class="fade tab-pane"
-          id="uncontrolled-tab-tabpane-parties"
+          id="controlled-tab-tabpane-parties"
           role="tabpanel"
         >
           <br />
@@ -316,9 +329,9 @@ exports[`Storyshots PackageReview Default 1`] = `
         </div>
         <div
           aria-hidden="true"
-          aria-labelledby="uncontrolled-tab-tab-payment"
+          aria-labelledby="controlled-tab-tab-payment"
           class="fade tab-pane"
-          id="uncontrolled-tab-tabpane-payment"
+          id="controlled-tab-tabpane-payment"
           role="tabpanel"
         >
           <br />
@@ -438,9 +451,51 @@ exports[`Storyshots PackageReview Default 1`] = `
         </div>
         <div
           aria-hidden="true"
-          aria-labelledby="uncontrolled-tab-tab-comments"
+          aria-labelledby="controlled-tab-tab-rush"
           class="fade tab-pane"
-          id="uncontrolled-tab-tabpane-comments"
+          id="controlled-tab-tabpane-rush"
+          role="tabpanel"
+        >
+          <br />
+          <div
+            class="bcgov-table "
+          >
+            <b />
+            <div
+              class="bcgov-table-body"
+            />
+          </div>
+          <br />
+          <div
+            class="ct-document-list"
+          >
+            <div
+              class="header"
+            >
+              <span
+                class="d-none d-lg-inline col-lg-4"
+              >
+                File Name
+              </span>
+              <span
+                class="d-none d-lg-inline col-lg-4"
+              >
+                Status
+              </span>
+              <span
+                class="d-none d-lg-inline col-lg-4"
+              >
+                Registry Notice
+              </span>
+            </div>
+            <ul />
+          </div>
+        </div>
+        <div
+          aria-hidden="true"
+          aria-labelledby="controlled-tab-tab-comments"
+          class="fade tab-pane"
+          id="controlled-tab-tabpane-comments"
           role="tabpanel"
         >
           <br />
@@ -836,45 +891,58 @@ exports[`Storyshots PackageReview Mobile 1`] = `
         role="tablist"
       >
         <a
-          aria-controls="uncontrolled-tab-tabpane-documents"
-          aria-selected="true"
-          class="nav-item nav-link active"
+          aria-controls="controlled-tab-tabpane-documents"
+          aria-selected="false"
+          class="nav-item nav-link"
           data-rb-event-key="documents"
           href="#"
-          id="uncontrolled-tab-tab-documents"
+          id="controlled-tab-tab-documents"
           role="tab"
         >
           Documents
         </a>
         <a
-          aria-controls="uncontrolled-tab-tabpane-parties"
+          aria-controls="controlled-tab-tabpane-parties"
           aria-selected="false"
           class="nav-item nav-link"
           data-rb-event-key="parties"
           href="#"
-          id="uncontrolled-tab-tab-parties"
+          id="controlled-tab-tab-parties"
           role="tab"
         >
           Parties
         </a>
         <a
-          aria-controls="uncontrolled-tab-tabpane-payment"
+          aria-controls="controlled-tab-tabpane-payment"
           aria-selected="false"
           class="nav-item nav-link"
           data-rb-event-key="payment"
           href="#"
-          id="uncontrolled-tab-tab-payment"
+          id="controlled-tab-tab-payment"
           role="tab"
         >
           Payment Status
         </a>
         <a
-          aria-controls="uncontrolled-tab-tabpane-comments"
+          aria-controls="controlled-tab-tabpane-rush"
+          aria-disabled="true"
+          aria-selected="false"
+          class="nav-item nav-link disabled"
+          data-rb-event-key="rush"
+          href="#"
+          id="controlled-tab-tab-rush"
+          role="tab"
+          tabindex="-1"
+        >
+          Rush Details
+        </a>
+        <a
+          aria-controls="controlled-tab-tabpane-comments"
           aria-selected="false"
           class="nav-item nav-link"
           data-rb-event-key="comments"
           href="#"
-          id="uncontrolled-tab-tab-comments"
+          id="controlled-tab-tab-comments"
           role="tab"
         >
           Filing Comments
@@ -884,10 +952,10 @@ exports[`Storyshots PackageReview Mobile 1`] = `
         class="tab-content"
       >
         <div
-          aria-hidden="false"
-          aria-labelledby="uncontrolled-tab-tab-documents"
-          class="fade tab-pane active show"
-          id="uncontrolled-tab-tabpane-documents"
+          aria-hidden="true"
+          aria-labelledby="controlled-tab-tab-documents"
+          class="fade tab-pane"
+          id="controlled-tab-tabpane-documents"
           role="tabpanel"
         >
           <br />
@@ -923,9 +991,9 @@ exports[`Storyshots PackageReview Mobile 1`] = `
         </div>
         <div
           aria-hidden="true"
-          aria-labelledby="uncontrolled-tab-tab-parties"
+          aria-labelledby="controlled-tab-tab-parties"
           class="fade tab-pane"
-          id="uncontrolled-tab-tabpane-parties"
+          id="controlled-tab-tabpane-parties"
           role="tabpanel"
         >
           <br />
@@ -956,9 +1024,9 @@ exports[`Storyshots PackageReview Mobile 1`] = `
         </div>
         <div
           aria-hidden="true"
-          aria-labelledby="uncontrolled-tab-tab-payment"
+          aria-labelledby="controlled-tab-tab-payment"
           class="fade tab-pane"
-          id="uncontrolled-tab-tabpane-payment"
+          id="controlled-tab-tabpane-payment"
           role="tabpanel"
         >
           <br />
@@ -1078,9 +1146,51 @@ exports[`Storyshots PackageReview Mobile 1`] = `
         </div>
         <div
           aria-hidden="true"
-          aria-labelledby="uncontrolled-tab-tab-comments"
+          aria-labelledby="controlled-tab-tab-rush"
           class="fade tab-pane"
-          id="uncontrolled-tab-tabpane-comments"
+          id="controlled-tab-tabpane-rush"
+          role="tabpanel"
+        >
+          <br />
+          <div
+            class="bcgov-table "
+          >
+            <b />
+            <div
+              class="bcgov-table-body"
+            />
+          </div>
+          <br />
+          <div
+            class="ct-document-list"
+          >
+            <div
+              class="header"
+            >
+              <span
+                class="d-none d-lg-inline col-lg-4"
+              >
+                File Name
+              </span>
+              <span
+                class="d-none d-lg-inline col-lg-4"
+              >
+                Status
+              </span>
+              <span
+                class="d-none d-lg-inline col-lg-4"
+              >
+                Registry Notice
+              </span>
+            </div>
+            <ul />
+          </div>
+        </div>
+        <div
+          aria-hidden="true"
+          aria-labelledby="controlled-tab-tab-comments"
+          class="fade tab-pane"
+          id="controlled-tab-tabpane-comments"
           role="tabpanel"
         >
           <br />

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/PackageReview.test.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/PackageReview.test.js
@@ -671,4 +671,35 @@ describe("PackageReview Component", () => {
       getByText("Something went wrong while trying to download your file.")
     ).toBeInTheDocument();
   });
+
+  test("An error is shown when rush tab supporting documents fail to download - keydown", async () => {
+    const promise = Promise.resolve();
+    mock.onGet(apiRequest).reply(200, csoRedirectResponseWithRush);
+    mock
+      .onGet(
+        `/filingpackages/${packageId}/document/${supportingDocuments[0].identifier}`
+      )
+      .reply(400, {});
+
+    const { getByText, getAllByTestId } = render(<PackageReview />);
+
+    const rushTab = getByText("Rush Details");
+    expect(rushTab).not.toHaveAttribute("aria-disabled", "false");
+    fireEvent.click(rushTab);
+
+    await act(() => promise);
+
+    expect(
+      getByText("Reason for requesting urgent (rush) filing:")
+    ).toBeInTheDocument();
+
+    const downloadButton = getAllByTestId("uploaded-file")[0];
+    fireEvent.keyDown(downloadButton, { key: "Enter", keyCode: "13" });
+
+    await act(() => promise);
+
+    expect(
+      getByText("Something went wrong while trying to download your file.")
+    ).toBeInTheDocument();
+  });
 });

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/PackageReview.test.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/PackageReview.test.js
@@ -640,4 +640,35 @@ describe("PackageReview Component", () => {
     const rushTab = getByText("Rush Details");
     expect(rushTab).toHaveAttribute("aria-disabled", "true");
   });
+
+  test("An error is shown when rush tab supporting documents fail to download - click", async () => {
+    const promise = Promise.resolve();
+    mock.onGet(apiRequest).reply(200, csoRedirectResponseWithRush);
+    mock
+      .onGet(
+        `/filingpackages/${packageId}/document/${supportingDocuments[0].identifier}`
+      )
+      .reply(400, {});
+
+    const { getByText, getAllByTestId } = render(<PackageReview />);
+
+    const rushTab = getByText("Rush Details");
+    expect(rushTab).not.toHaveAttribute("aria-disabled", "false");
+    fireEvent.click(rushTab);
+
+    await act(() => promise);
+
+    expect(
+      getByText("Reason for requesting urgent (rush) filing:")
+    ).toBeInTheDocument();
+
+    const downloadButton = getAllByTestId("uploaded-file")[0];
+    fireEvent.click(downloadButton);
+
+    await act(() => promise);
+
+    expect(
+      getByText("Something went wrong while trying to download your file.")
+    ).toBeInTheDocument();
+  });
 });

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/__snapshots__/PackageReview.test.js.snap
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/__snapshots__/PackageReview.test.js.snap
@@ -195,6 +195,22 @@ exports[`PackageReview Component Matches the snapshot 1`] = `
                   </b>
                 </div>
               </div>
+              <div
+                class="bcgov-row "
+              >
+                <div
+                  class="bcgov-fill-width"
+                >
+                  Rush Processing:
+                </div>
+                <div
+                  class="bcgov-table-value "
+                >
+                  <b>
+                    No
+                  </b>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -206,45 +222,58 @@ exports[`PackageReview Component Matches the snapshot 1`] = `
         role="tablist"
       >
         <a
-          aria-controls="uncontrolled-tab-tabpane-documents"
-          aria-selected="true"
-          class="nav-item nav-link active"
+          aria-controls="controlled-tab-tabpane-documents"
+          aria-selected="false"
+          class="nav-item nav-link"
           data-rb-event-key="documents"
           href="#"
-          id="uncontrolled-tab-tab-documents"
+          id="controlled-tab-tab-documents"
           role="tab"
         >
           Documents
         </a>
         <a
-          aria-controls="uncontrolled-tab-tabpane-parties"
+          aria-controls="controlled-tab-tabpane-parties"
           aria-selected="false"
           class="nav-item nav-link"
           data-rb-event-key="parties"
           href="#"
-          id="uncontrolled-tab-tab-parties"
+          id="controlled-tab-tab-parties"
           role="tab"
         >
           Parties
         </a>
         <a
-          aria-controls="uncontrolled-tab-tabpane-payment"
+          aria-controls="controlled-tab-tabpane-payment"
           aria-selected="false"
           class="nav-item nav-link"
           data-rb-event-key="payment"
           href="#"
-          id="uncontrolled-tab-tab-payment"
+          id="controlled-tab-tab-payment"
           role="tab"
         >
           Payment Status
         </a>
         <a
-          aria-controls="uncontrolled-tab-tabpane-comments"
+          aria-controls="controlled-tab-tabpane-rush"
+          aria-disabled="true"
+          aria-selected="false"
+          class="nav-item nav-link disabled"
+          data-rb-event-key="rush"
+          href="#"
+          id="controlled-tab-tab-rush"
+          role="tab"
+          tabindex="-1"
+        >
+          Rush Details
+        </a>
+        <a
+          aria-controls="controlled-tab-tabpane-comments"
           aria-selected="false"
           class="nav-item nav-link"
           data-rb-event-key="comments"
           href="#"
-          id="uncontrolled-tab-tab-comments"
+          id="controlled-tab-tab-comments"
           role="tab"
         >
           Filing Comments
@@ -254,10 +283,10 @@ exports[`PackageReview Component Matches the snapshot 1`] = `
         class="tab-content"
       >
         <div
-          aria-hidden="false"
-          aria-labelledby="uncontrolled-tab-tab-documents"
-          class="fade tab-pane active show"
-          id="uncontrolled-tab-tabpane-documents"
+          aria-hidden="true"
+          aria-labelledby="controlled-tab-tab-documents"
+          class="fade tab-pane"
+          id="controlled-tab-tabpane-documents"
           role="tabpanel"
         >
           <br />
@@ -383,9 +412,9 @@ exports[`PackageReview Component Matches the snapshot 1`] = `
         </div>
         <div
           aria-hidden="true"
-          aria-labelledby="uncontrolled-tab-tab-parties"
+          aria-labelledby="controlled-tab-tab-parties"
           class="fade tab-pane"
-          id="uncontrolled-tab-tabpane-parties"
+          id="controlled-tab-tabpane-parties"
           role="tabpanel"
         >
           <br />
@@ -459,9 +488,9 @@ exports[`PackageReview Component Matches the snapshot 1`] = `
         </div>
         <div
           aria-hidden="true"
-          aria-labelledby="uncontrolled-tab-tab-payment"
+          aria-labelledby="controlled-tab-tab-payment"
           class="fade tab-pane"
-          id="uncontrolled-tab-tabpane-payment"
+          id="controlled-tab-tabpane-payment"
           role="tabpanel"
         >
           <br />
@@ -581,9 +610,51 @@ exports[`PackageReview Component Matches the snapshot 1`] = `
         </div>
         <div
           aria-hidden="true"
-          aria-labelledby="uncontrolled-tab-tab-comments"
+          aria-labelledby="controlled-tab-tab-rush"
           class="fade tab-pane"
-          id="uncontrolled-tab-tabpane-comments"
+          id="controlled-tab-tabpane-rush"
+          role="tabpanel"
+        >
+          <br />
+          <div
+            class="bcgov-table "
+          >
+            <b />
+            <div
+              class="bcgov-table-body"
+            />
+          </div>
+          <br />
+          <div
+            class="ct-document-list"
+          >
+            <div
+              class="header"
+            >
+              <span
+                class="d-none d-lg-inline col-lg-4"
+              >
+                File Name
+              </span>
+              <span
+                class="d-none d-lg-inline col-lg-4"
+              >
+                Status
+              </span>
+              <span
+                class="d-none d-lg-inline col-lg-4"
+              >
+                Registry Notice
+              </span>
+            </div>
+            <ul />
+          </div>
+        </div>
+        <div
+          aria-hidden="true"
+          aria-labelledby="controlled-tab-tab-comments"
+          class="fade tab-pane"
+          id="controlled-tab-tabpane-comments"
           role="tabpanel"
         >
           <br />
@@ -980,6 +1051,22 @@ exports[`PackageReview Component Reload 1`] = `
                   </b>
                 </div>
               </div>
+              <div
+                class="bcgov-row "
+              >
+                <div
+                  class="bcgov-fill-width"
+                >
+                  Rush Processing:
+                </div>
+                <div
+                  class="bcgov-table-value "
+                >
+                  <b>
+                    No
+                  </b>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -991,45 +1078,58 @@ exports[`PackageReview Component Reload 1`] = `
         role="tablist"
       >
         <a
-          aria-controls="uncontrolled-tab-tabpane-documents"
-          aria-selected="true"
-          class="nav-item nav-link active"
+          aria-controls="controlled-tab-tabpane-documents"
+          aria-selected="false"
+          class="nav-item nav-link"
           data-rb-event-key="documents"
           href="#"
-          id="uncontrolled-tab-tab-documents"
+          id="controlled-tab-tab-documents"
           role="tab"
         >
           Documents
         </a>
         <a
-          aria-controls="uncontrolled-tab-tabpane-parties"
+          aria-controls="controlled-tab-tabpane-parties"
           aria-selected="false"
           class="nav-item nav-link"
           data-rb-event-key="parties"
           href="#"
-          id="uncontrolled-tab-tab-parties"
+          id="controlled-tab-tab-parties"
           role="tab"
         >
           Parties
         </a>
         <a
-          aria-controls="uncontrolled-tab-tabpane-payment"
+          aria-controls="controlled-tab-tabpane-payment"
           aria-selected="false"
           class="nav-item nav-link"
           data-rb-event-key="payment"
           href="#"
-          id="uncontrolled-tab-tab-payment"
+          id="controlled-tab-tab-payment"
           role="tab"
         >
           Payment Status
         </a>
         <a
-          aria-controls="uncontrolled-tab-tabpane-comments"
+          aria-controls="controlled-tab-tabpane-rush"
+          aria-disabled="true"
+          aria-selected="false"
+          class="nav-item nav-link disabled"
+          data-rb-event-key="rush"
+          href="#"
+          id="controlled-tab-tab-rush"
+          role="tab"
+          tabindex="-1"
+        >
+          Rush Details
+        </a>
+        <a
+          aria-controls="controlled-tab-tabpane-comments"
           aria-selected="false"
           class="nav-item nav-link"
           data-rb-event-key="comments"
           href="#"
-          id="uncontrolled-tab-tab-comments"
+          id="controlled-tab-tab-comments"
           role="tab"
         >
           Filing Comments
@@ -1039,10 +1139,10 @@ exports[`PackageReview Component Reload 1`] = `
         class="tab-content"
       >
         <div
-          aria-hidden="false"
-          aria-labelledby="uncontrolled-tab-tab-documents"
-          class="fade tab-pane active show"
-          id="uncontrolled-tab-tabpane-documents"
+          aria-hidden="true"
+          aria-labelledby="controlled-tab-tab-documents"
+          class="fade tab-pane"
+          id="controlled-tab-tabpane-documents"
           role="tabpanel"
         >
           <br />
@@ -1168,9 +1268,9 @@ exports[`PackageReview Component Reload 1`] = `
         </div>
         <div
           aria-hidden="true"
-          aria-labelledby="uncontrolled-tab-tab-parties"
+          aria-labelledby="controlled-tab-tab-parties"
           class="fade tab-pane"
-          id="uncontrolled-tab-tabpane-parties"
+          id="controlled-tab-tabpane-parties"
           role="tabpanel"
         >
           <br />
@@ -1201,9 +1301,9 @@ exports[`PackageReview Component Reload 1`] = `
         </div>
         <div
           aria-hidden="true"
-          aria-labelledby="uncontrolled-tab-tab-payment"
+          aria-labelledby="controlled-tab-tab-payment"
           class="fade tab-pane"
-          id="uncontrolled-tab-tabpane-payment"
+          id="controlled-tab-tabpane-payment"
           role="tabpanel"
         >
           <br />
@@ -1268,9 +1368,51 @@ exports[`PackageReview Component Reload 1`] = `
         </div>
         <div
           aria-hidden="true"
-          aria-labelledby="uncontrolled-tab-tab-comments"
+          aria-labelledby="controlled-tab-tab-rush"
           class="fade tab-pane"
-          id="uncontrolled-tab-tabpane-comments"
+          id="controlled-tab-tabpane-rush"
+          role="tabpanel"
+        >
+          <br />
+          <div
+            class="bcgov-table "
+          >
+            <b />
+            <div
+              class="bcgov-table-body"
+            />
+          </div>
+          <br />
+          <div
+            class="ct-document-list"
+          >
+            <div
+              class="header"
+            >
+              <span
+                class="d-none d-lg-inline col-lg-4"
+              >
+                File Name
+              </span>
+              <span
+                class="d-none d-lg-inline col-lg-4"
+              >
+                Status
+              </span>
+              <span
+                class="d-none d-lg-inline col-lg-4"
+              >
+                Registry Notice
+              </span>
+            </div>
+            <ul />
+          </div>
+        </div>
+        <div
+          aria-hidden="true"
+          aria-labelledby="controlled-tab-tab-comments"
+          class="fade tab-pane"
+          id="controlled-tab-tabpane-comments"
           role="tabpanel"
         >
           <br />
@@ -1663,6 +1805,22 @@ exports[`PackageReview Component Withdraw document network error 1`] = `
                   </b>
                 </div>
               </div>
+              <div
+                class="bcgov-row "
+              >
+                <div
+                  class="bcgov-fill-width"
+                >
+                  Rush Processing:
+                </div>
+                <div
+                  class="bcgov-table-value "
+                >
+                  <b>
+                    No
+                  </b>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -1674,45 +1832,58 @@ exports[`PackageReview Component Withdraw document network error 1`] = `
         role="tablist"
       >
         <a
-          aria-controls="uncontrolled-tab-tabpane-documents"
-          aria-selected="true"
-          class="nav-item nav-link active"
+          aria-controls="controlled-tab-tabpane-documents"
+          aria-selected="false"
+          class="nav-item nav-link"
           data-rb-event-key="documents"
           href="#"
-          id="uncontrolled-tab-tab-documents"
+          id="controlled-tab-tab-documents"
           role="tab"
         >
           Documents
         </a>
         <a
-          aria-controls="uncontrolled-tab-tabpane-parties"
+          aria-controls="controlled-tab-tabpane-parties"
           aria-selected="false"
           class="nav-item nav-link"
           data-rb-event-key="parties"
           href="#"
-          id="uncontrolled-tab-tab-parties"
+          id="controlled-tab-tab-parties"
           role="tab"
         >
           Parties
         </a>
         <a
-          aria-controls="uncontrolled-tab-tabpane-payment"
+          aria-controls="controlled-tab-tabpane-payment"
           aria-selected="false"
           class="nav-item nav-link"
           data-rb-event-key="payment"
           href="#"
-          id="uncontrolled-tab-tab-payment"
+          id="controlled-tab-tab-payment"
           role="tab"
         >
           Payment Status
         </a>
         <a
-          aria-controls="uncontrolled-tab-tabpane-comments"
+          aria-controls="controlled-tab-tabpane-rush"
+          aria-disabled="true"
+          aria-selected="false"
+          class="nav-item nav-link disabled"
+          data-rb-event-key="rush"
+          href="#"
+          id="controlled-tab-tab-rush"
+          role="tab"
+          tabindex="-1"
+        >
+          Rush Details
+        </a>
+        <a
+          aria-controls="controlled-tab-tabpane-comments"
           aria-selected="false"
           class="nav-item nav-link"
           data-rb-event-key="comments"
           href="#"
-          id="uncontrolled-tab-tab-comments"
+          id="controlled-tab-tab-comments"
           role="tab"
         >
           Filing Comments
@@ -1722,10 +1893,10 @@ exports[`PackageReview Component Withdraw document network error 1`] = `
         class="tab-content"
       >
         <div
-          aria-hidden="false"
-          aria-labelledby="uncontrolled-tab-tab-documents"
-          class="fade tab-pane active show"
-          id="uncontrolled-tab-tabpane-documents"
+          aria-hidden="true"
+          aria-labelledby="controlled-tab-tab-documents"
+          class="fade tab-pane"
+          id="controlled-tab-tabpane-documents"
           role="tabpanel"
         >
           <br />
@@ -1851,9 +2022,9 @@ exports[`PackageReview Component Withdraw document network error 1`] = `
         </div>
         <div
           aria-hidden="true"
-          aria-labelledby="uncontrolled-tab-tab-parties"
+          aria-labelledby="controlled-tab-tab-parties"
           class="fade tab-pane"
-          id="uncontrolled-tab-tabpane-parties"
+          id="controlled-tab-tabpane-parties"
           role="tabpanel"
         >
           <br />
@@ -1884,9 +2055,9 @@ exports[`PackageReview Component Withdraw document network error 1`] = `
         </div>
         <div
           aria-hidden="true"
-          aria-labelledby="uncontrolled-tab-tab-payment"
+          aria-labelledby="controlled-tab-tab-payment"
           class="fade tab-pane"
-          id="uncontrolled-tab-tabpane-payment"
+          id="controlled-tab-tabpane-payment"
           role="tabpanel"
         >
           <br />
@@ -1951,9 +2122,51 @@ exports[`PackageReview Component Withdraw document network error 1`] = `
         </div>
         <div
           aria-hidden="true"
-          aria-labelledby="uncontrolled-tab-tab-comments"
+          aria-labelledby="controlled-tab-tab-rush"
           class="fade tab-pane"
-          id="uncontrolled-tab-tabpane-comments"
+          id="controlled-tab-tabpane-rush"
+          role="tabpanel"
+        >
+          <br />
+          <div
+            class="bcgov-table "
+          >
+            <b />
+            <div
+              class="bcgov-table-body"
+            />
+          </div>
+          <br />
+          <div
+            class="ct-document-list"
+          >
+            <div
+              class="header"
+            >
+              <span
+                class="d-none d-lg-inline col-lg-4"
+              >
+                File Name
+              </span>
+              <span
+                class="d-none d-lg-inline col-lg-4"
+              >
+                Status
+              </span>
+              <span
+                class="d-none d-lg-inline col-lg-4"
+              >
+                Registry Notice
+              </span>
+            </div>
+            <ul />
+          </div>
+        </div>
+        <div
+          aria-hidden="true"
+          aria-labelledby="controlled-tab-tab-comments"
+          class="fade tab-pane"
+          id="controlled-tab-tabpane-comments"
           role="tabpanel"
         >
           <br />

--- a/src/frontend/efiling-frontend/src/modules/test-data/packageReviewTestData.js
+++ b/src/frontend/efiling-frontend/src/modules/test-data/packageReviewTestData.js
@@ -13,6 +13,21 @@ export const documents = [
   },
 ];
 
+export const protectionOrderDocuments = [
+  {
+    identifier: "1",
+    documentProperties: {
+      type: "POR",
+      name: "test-POR-document.pdf",
+    },
+    status: {
+      description: "Submitted",
+      code: "SUB",
+    },
+    filingDate: "2020-05-05T00:00:00.000Z",
+  },
+];
+
 export const parties = [
   {
     partyType: "IND",

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/page/PackageReviewPage.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/page/PackageReviewPage.java
@@ -37,31 +37,31 @@ public class PackageReviewPage extends BasePage {
     @FindBy(xpath = "//*[contains(@class,'bcgov-table-value')]/b")
     private List<WebElement> packageValueDetails;
 
-    @FindBy(id = "uncontrolled-tab-tab-documents")
+    @FindBy(id = "controlled-tab-tab-documents")
     private WebElement documentsTab;
 
     @FindBy(xpath = "//*[@data-testid='btn-download-document']")
     private WebElement downloadButton;
 
-    @FindBy(id = "uncontrolled-tab-tab-parties")
+    @FindBy(id = "controlled-tab-tab-parties")
     private WebElement partiesTab;
 
-    @FindBy(id = "uncontrolled-tab-tab-comments")
+    @FindBy(id = "controlled-tab-tab-comments")
     private WebElement filingCommentsTab;
 
-    @FindBy(id = "uncontrolled-tab-tab-payment")
+    @FindBy(id = "controlled-tab-tab-payment")
     private WebElement paymentStatusTab;
 
-    @FindBy(id = "uncontrolled-tab-tabpane-documents")
+    @FindBy(id = "controlled-tab-tabpane-documents")
     private WebElement documentPane;
 
-    @FindBy(id = "uncontrolled-tab-tabpane-payment")
+    @FindBy(id = "controlled-tab-tabpane-payment")
     private WebElement paymentPane;
 
     @FindBy(xpath = "//*[@data-testid='btn-view-receipt']")
     private WebElement viewReceiptButton;
 
-    @FindBy(id = "uncontrolled-tab-tabpane-parties")
+    @FindBy(id = "controlled-tab-tabpane-parties")
     private WebElement partiesTable;
 
     @FindBy(id = "filingComments")
@@ -96,7 +96,7 @@ public class PackageReviewPage extends BasePage {
         packageValueDetails.forEach(webElement -> {
             if (!webElement.isDisplayed()) {
                 logger.info("WebElement is still not visible. Waiting for all rows to be present: {}", webElement.isDisplayed());
-                wait.until(ExpectedConditions.visibilityOfAllElementsLocatedBy(By.xpath("//*[contains(@class,'bcgov-table-value')]/b")));
+                wait.until(ExpectedConditions.visibilityOfAllElementsLocatedBy(By.xpath("//div[@data-test-id='detailsTable'] //*[contains(@class,'bcgov-table-value')]/b")));
             }
             logger.info("Is it visible: {}", webElement.isDisplayed());
             logger.info("Is it enabled: {}", webElement.isEnabled());

--- a/tests/src/test/resources/features/addRushProcessing.feature
+++ b/tests/src/test/resources/features/addRushProcessing.feature
@@ -1,6 +1,6 @@
 # new feature
 # Tags: optional
-
+@demo
 Feature: Rush processing data point can be added to the package
 
   Scenario: Validate the rush processing data point can be added to the package

--- a/tests/src/test/resources/features/getCountries.feature
+++ b/tests/src/test/resources/features/getCountries.feature
@@ -1,6 +1,6 @@
 # new feature
 # Tags: optional
-
+@demo
 Feature: List of countries can be looked up
 
   Scenario: Validate that list of countries can be retrieved

--- a/tests/src/test/resources/features/getFilingPackages.feature
+++ b/tests/src/test/resources/features/getFilingPackages.feature
@@ -1,6 +1,6 @@
 # new feature
 # Tags: optional
-
+@demo
 Feature: Filing packages history can be retrieved from CSO
 
   Scenario: Validate that filing packages history is retrieved


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

FLA-1314, FLA-1315
- Added rush processing details tab on package review page
- Added logic that disables the rush processing details tab for protection orders or non-rush submissions
- Added logic for linking directly to rush processing details tab (prevents direct linking in case where tab is disabled)

The following changes are currently waiting on API updates:
- Downloading supporting documents from the rush tab
- Displaying document statuses for supporting documents
- Displaying registry comments

![image](https://user-images.githubusercontent.com/55457785/128759442-86344562-0e01-4249-82ef-1b6c8abfb755.png)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Unit tests, manual testing.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
