### PR TITLE
rush modal with tests

### DIFF
--- a/src/frontend/efiling-frontend/src/components/safety-check/SafetyCheckHelp.js
+++ b/src/frontend/efiling-frontend/src/components/safety-check/SafetyCheckHelp.js
@@ -9,16 +9,12 @@ import "./SafetyCheckHelp.scss";
 /** Opens up a modal popup with help content */
 export default function SafetyCheckHelp({ showModal, onHide }) {
   return (
-    <Modal
-      show={showModal}
-      onHide={onHide}
-      className="safety-check-modal modal-xl"
-    >
+    <Modal show={showModal} onHide={onHide} className="safety-check-modal">
       <Modal.Header closeButton>
         <Modal.Title>
-          <h2 className="text-primary" data-testid="help-title">
+          <h3 className="text-primary" data-testid="help-title">
             Get Help Opening and Saving PDF forms
-          </h2>
+          </h3>
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/PackageConfirmation.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/PackageConfirmation.js
@@ -9,6 +9,7 @@ import ConfirmationPopup, {
 } from "shared-components";
 import axios from "axios";
 import Rush from "../../../components/page/rush/Rush";
+import RushConfirmation from "./RushConfirmation";
 import { getSidecardData } from "../../../modules/helpers/sidecardData";
 import { propTypes } from "../../../types/propTypes";
 import { onBackButtonEvent } from "../../../modules/helpers/handleBackEvent";
@@ -72,11 +73,18 @@ const checkDuplicateFileNames = (files, setShowToast, setToastMessage) => {
   }
 };
 
-const handleContinue = (isRush, setShowRush, setShowPayment) => {
+const handleContinue = (
+  isRush,
+  setShowRush,
+  setShowPayment,
+  showModal,
+  setShowModal
+) => {
   if (isRush) {
     setShowPayment(false);
-    setShowRush(true);
+    setShowModal(true);
   } else {
+    setShowModal(false);
     setShowRush(false);
     setShowPayment(true);
   }
@@ -95,6 +103,7 @@ export default function PackageConfirmation({
   const [toastMessage, setToastMessage] = useState(null);
   const [refreshFiles, setRefreshFiles] = useState(true);
   const [showRush, setShowRush] = useState(false);
+  const [showModal, setShowModal] = useState(false);
   const [isRush, setIsRush] = useState(false);
   const aboutCsoSidecard = getSidecardData().aboutCso;
   const csoAccountDetailsSidecard = getSidecardData().csoAccountDetails;
@@ -180,6 +189,13 @@ export default function PackageConfirmation({
 
   return (
     <div className="ct-package-confirmation page">
+      {showModal && (
+        <RushConfirmation
+          show={showModal}
+          setShow={setShowModal}
+          setShowRush={setShowRush}
+        />
+      )}
       <div className="content col-md-8">
         {isNew && (
           <>
@@ -260,7 +276,15 @@ export default function PackageConfirmation({
           />
           <Button
             label="Continue"
-            onClick={() => handleContinue(isRush, setShowRush, setShowPayment)}
+            onClick={() =>
+              handleContinue(
+                isRush,
+                setShowRush,
+                setShowPayment,
+                showModal,
+                setShowModal
+              )
+            }
             styling="bcgov-normal-blue btn"
             testId="continue-btn"
             disabled={toastMessage !== null}

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/PackageConfirmation.scss
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/PackageConfirmation.scss
@@ -11,6 +11,10 @@
     margin-left: 10px;
   }
 
+  .hidden {
+    visibility: hidden !important;
+  }
+
   @media (min-width: 1200px) {
     .near-half-width {
       width: 60% !important;

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/RushConfirmation.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/RushConfirmation.js
@@ -1,40 +1,92 @@
 /* eslint-disable no-unused-vars */
 import React from "react";
 import PropTypes from "prop-types";
-import ConfirmationPopup from "shared-components";
+import Modal from "react-bootstrap/Modal";
 
-export default function RushConfirmation({ show, setShow }) {
-  const modal = {
-    show,
-    title: "placeholder",
-    body: () => <></>,
+import "./RushConfirmation.scss";
+// import "../../../components/safety-check/SafetyCheck.scss";
+
+export default function RushConfirmation({ show, setShow, setShowRush }) {
+  const handleOnHide = () => {
+    setShow(false);
+    setShowRush(true);
   };
-  const mainButton = <></>;
-  const confirmButton = <></>;
-  const cancelButton = <></>;
-
-  const handleClose = () => setShow(false);
-  const handleShow = () => setShow(true);
-  const handleConfirm = () => {};
-
-  const confirmationPopup = {
-    modal,
-    mainButton: { ...mainButton, onClick: handleShow },
-    confirmButton: { ...confirmButton, onClick: handleConfirm },
-    cancelButton: { ...cancelButton, onClick: handleClose },
-  };
-
   return (
-    <ConfirmationPopup
-      modal={modal}
-      mainButton={mainButton}
-      confirmButton={confirmButton}
-      cancelButton={cancelButton}
-    />
+    <Modal
+      show={show}
+      onHide={handleOnHide}
+      className="safety-check-modal rush-modal"
+      size="lg"
+    >
+      <Modal.Header closeButton className="border-0 modal-header">
+        <Modal.Title>
+          <h2>Rush Documents</h2>
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body className="modal-body">
+        <p>
+          An application made under Rule 8-5(1) of the Supreme Court Rules for
+          short notice will be processed on an urgent(rush) basis. Prior to
+          e-filing an application for short notice, review Practice Direction
+          20, Short Notice Applications - Civil.{" "}
+        </p>
+        <br />
+
+        <p>
+          When directed by the court, an order will be processed on an
+          urgent(rush) basis. The registry will consider the following reasons
+          for processing an order on an urgent(rush) basis:{" "}
+        </p>
+        <ul>
+          <li>the order must be served immediately, </li>
+          <li>the order is necessary for immediate enforcement purposes, </li>
+          <li>the order is a protection order or restraining order, or </li>
+          <li>for any reason considered by the registry to be sufficient. </li>
+        </ul>
+        <br />
+
+        <p>
+          <b>
+            Only request processing on an urgent(rush) basis in exceptional
+            circumstances.{" "}
+          </b>
+        </p>
+        <br />
+        <p>
+          For your information, the following types of orders are generally
+          entered on an urgent(rush) basis:{" "}
+        </p>
+        <ul>
+          <li>Restraining Orders</li>
+          <li>Injunctions</li>
+          <li>Transfer of Lands when completion date is imminent</li>
+          <li>Custodial</li>
+        </ul>
+        <br />
+
+        <p>
+          The following types of orders are not generally entered on an
+          urgent(rush) basis:{" "}
+        </p>
+        <ul>
+          <li>Trial Orders</li>
+          <li>Reserved Judgements</li>
+          <li>Desk Orders that require the Courts&apos; Approval </li>
+        </ul>
+        <br />
+
+        <p>
+          The registry will determine whether to process a submission on an
+          urgent(rush) basis after reviewing the reasons provided by you. The
+          registry may contact you for further information.{" "}
+        </p>
+      </Modal.Body>
+    </Modal>
   );
 }
 
 RushConfirmation.propTypes = {
   show: PropTypes.bool.isRequired,
   setShow: PropTypes.func.isRequired,
+  setShowRush: PropTypes.func.isRequired,
 };

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/RushConfirmation.scss
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/RushConfirmation.scss
@@ -1,0 +1,15 @@
+.rush-modal {
+  border-radius: 30px;
+
+  .modal-header{
+    margin: 20px 20px 0 20px; 
+  }
+
+  .modal-body {
+    margin: 0 20px 20px 20px;
+  }
+  
+  p, li {
+    font-size: 18px;
+  }
+}

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__snapshots__/RushConfirmation.test.js.snap
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__snapshots__/RushConfirmation.test.js.snap
@@ -1,11 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RushConfirmation Component Matches the snapshot 1`] = `
-<DocumentFragment>
-  <button
-    class="bcgov-button undefined"
-    data-testid="main-cancel-btn"
-    type="button"
-  />
-</DocumentFragment>
-`;
+exports[`RushConfirmation Component Matches the snapshot 1`] = `<DocumentFragment />`;

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__tests__/PackageConfirmation.test.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__tests__/PackageConfirmation.test.js
@@ -92,7 +92,7 @@ describe("PackageConfirmation Component", () => {
       .onGet(apiRequest)
       .reply(200, { documents, court, submissionFeeAmount });
 
-    const { getByLabelText, getByText, queryByText } = render(
+    const { getByLabelText, getByText, queryByText, getByRole } = render(
       <PackageConfirmation
         packageConfirmation={packageConfirmation}
         csoAccountStatus={csoAccountStatus}
@@ -112,6 +112,7 @@ describe("PackageConfirmation Component", () => {
     );
 
     fireEvent.click(continueBtn);
+    fireEvent.click(getByRole("dialog"));
     await waitFor(() =>
       expect(queryByText("Rush Details")).toBeInTheDocument()
     );


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- FLA-1353
- Package Confirmation page now displays a popup modal before continuing to Rush

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?
```bash
yarn lint
yarn test -u
```

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
