### PR TITLE
FLA-1321 add regression test for duplicate upload validation

### DIFF
--- a/src/frontend/efiling-frontend/src/components/page/upload/Upload.js
+++ b/src/frontend/efiling-frontend/src/components/page/upload/Upload.js
@@ -401,7 +401,11 @@ export default function Upload({
             ))}
           </>
         )}
-        {errorMessage && <p className="error">{errorMessage}</p>}
+        {errorMessage && (
+          <p className="error" data-testid="err-dup-file">
+            {errorMessage}
+          </p>
+        )}
         <section className="buttons pt-2">
           <Button
             label="Cancel Upload"

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/Keys.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/Keys.java
@@ -13,9 +13,6 @@ public class Keys {
     // Submission Service
     public static final String X_USER_ID = "X-User-Id";
 
-    // Commons
-    public static final String TEST_DOCUMENT_PDF = "test-document.pdf";
-
     // Assertions
     public static final String DESCRIPTION = "DESCRIPTION";
     public static final String RESPONSE_NAVIGATION_URL = "http//somewhere.com";
@@ -27,7 +24,9 @@ public class Keys {
 
     // File path
     public static final String BASE_PATH = System.getProperty("user.dir");
-    public static final String SECOND_PDF_PATH = "/src/test/resources/data/test-document-additional.pdf";
+    public static final String RESOURCES_PATH = "/src/test/resources/data/";
+    public static final String TEST_DOCUMENT_PDF = "test-document.pdf";
+    public static final String SECOND_DOCUMENT_PDF = "test-document-additional.pdf";
 
     // Api endpoint Paths
     public static final String SUBMIT_PATH = "submit";

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/page/DocumentUploadPage.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/page/DocumentUploadPage.java
@@ -1,5 +1,7 @@
 package ca.bc.gov.open.jag.efiling.page;
 
+import java.util.List;
+
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
@@ -8,6 +10,8 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public class DocumentUploadPage extends BasePage {
 
+	public static String DUPLICATE_FILE_ERROR = "You cannot upload multiple files with the same name.";
+	
     @FindBy(xpath = "//*[@data-testid='dropdownzone']/div/input")
     private WebElement selectFile;
 
@@ -25,7 +29,7 @@ public class DocumentUploadPage extends BasePage {
 
     @FindBy(xpath = "//button[@data-testid='remove-icon']")
     private WebElement removeFileIcon;
-
+    
     //Actions:
     public void selectFileToUpload(String file) {
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//*[@data-testid='dropdownzone']/div/input")));
@@ -53,4 +57,13 @@ public class DocumentUploadPage extends BasePage {
         Actions action = new Actions(driver);
         action.moveToElement(removeFileIcon).click();
     }
+    
+    /** Returns the text of a <p /> tag with an error message if it exists. */
+    public String getDuplicateFileError() {
+    	List<WebElement> elements = driver.findElements(By.xpath("//p[@data-testid='err-dup-file']"));
+    	if (elements != null && !elements.isEmpty()) {
+    		return elements.get(0).getText();
+    	}
+    	return null;
+	}
 }

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/UploadDocumentUsingUploadLinkSD.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/UploadDocumentUsingUploadLinkSD.java
@@ -1,52 +1,81 @@
 package ca.bc.gov.open.jag.efiling.stepDefinitions;
 
-import ca.bc.gov.open.jag.efiling.Keys;
-import com.google.common.collect.ImmutableList;
-import io.cucumber.java.en.Then;
-import io.cucumber.java.en.When;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+
+import ca.bc.gov.open.jag.efiling.Keys;
+import ca.bc.gov.open.jag.efiling.page.DocumentUploadPage;
+import ca.bc.gov.open.jag.efiling.page.PackageConfirmationPage;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class UploadDocumentUsingUploadLinkSD {
 
-    private ca.bc.gov.open.jag.efiling.page.PackageConfirmationPage packageConfirmationPage;
-    private ca.bc.gov.open.jag.efiling.page.DocumentUploadPage documentUploadPage;
-    private final List<String> expectedUploadedFilesList = ImmutableList.of("test-document.pdf", "test-document-additional.pdf");
+	private PackageConfirmationPage packageConfirmationPage;
+	private DocumentUploadPage documentUploadPage;
+	private final List<String> expectedUploadedFilesList = ImmutableList.of("test-document.pdf",
+			"test-document-additional.pdf");
 
-    private final Logger logger = LoggerFactory.getLogger(UploadDocumentUsingUploadLinkSD.class);
+	private final Logger logger = LoggerFactory.getLogger(UploadDocumentUsingUploadLinkSD.class);
 
-    public UploadDocumentUsingUploadLinkSD(ca.bc.gov.open.jag.efiling.page.PackageConfirmationPage packageConfirmationPage, ca.bc.gov.open.jag.efiling.page.DocumentUploadPage documentUploadPage) {
-        this.packageConfirmationPage = packageConfirmationPage;
-        this.documentUploadPage = documentUploadPage;
-    }
+	public UploadDocumentUsingUploadLinkSD(PackageConfirmationPage packageConfirmationPage,
+			DocumentUploadPage documentUploadPage) {
+		this.packageConfirmationPage = packageConfirmationPage;
+		this.documentUploadPage = documentUploadPage;
+	}
 
-    @When("user uploads an additional document")
-    public void userUploadsAnAdditionalDocument() {
+	@When("user uploads an additional document")
+	public void userUploadsAnAdditionalDocument() {
 
-        this.packageConfirmationPage.verifyContinuePaymentBtnIsEnabled();
-        this.packageConfirmationPage.clickUploadLink();
+		this.packageConfirmationPage.verifyContinuePaymentBtnIsEnabled();
+		this.packageConfirmationPage.clickUploadLink();
 
-        String filePath = Keys.BASE_PATH + Keys.SECOND_PDF_PATH;
-        this.documentUploadPage.selectFileToUpload(filePath);
+		String filePath = Keys.BASE_PATH + Keys.RESOURCES_PATH + Keys.SECOND_DOCUMENT_PDF;
+		this.documentUploadPage.selectFileToUpload(filePath);
 
-        this.documentUploadPage.clickIsAmendmentRadioBtn();
-        this.documentUploadPage.clickIsSupremeCourtBtn();
-        logger.info("Submitting the additional document upload");
+		this.documentUploadPage.clickIsAmendmentRadioBtn();
+		this.documentUploadPage.clickIsSupremeCourtBtn();
+		logger.info("Submitting the additional document upload");
 
-        this.documentUploadPage.clickContinueBtn();
+		this.documentUploadPage.clickContinueBtn();
+	}
 
-    }
+	@Then("verify the document is uploaded")
+	public void verifyTheDocumentIsUploaded() {
 
-    @Then("verify the document is uploaded")
-    public void verifyTheDocumentIsUploaded() {
+		List<String> uploadedFiles = this.packageConfirmationPage.getUploadedFilesList();
+		assertEquals(expectedUploadedFilesList, uploadedFiles);
 
-        List<String> uploadedFiles = this.packageConfirmationPage.getUploadedFilesList();
-        assertEquals(expectedUploadedFilesList, uploadedFiles);
+		logger.info("Additional document added to the package.");
+	}
 
-        logger.info("Additional document added to the package.");
-    }
+	@When("user uploads the same document")
+	public void userUploadsTheSameDocument() {
+		this.packageConfirmationPage.verifyContinuePaymentBtnIsEnabled();
+		this.packageConfirmationPage.clickUploadLink();
+
+		String filePath = Keys.BASE_PATH + Keys.RESOURCES_PATH + Keys.TEST_DOCUMENT_PDF;
+		this.documentUploadPage.selectFileToUpload(filePath);
+	}
+
+	@Then("verify duplicate uploaded filename error exists")
+	public void verifyDuplicateFileError() {
+		// assert error element exists
+		String errorMsg = documentUploadPage.getDuplicateFileError();
+		assertEquals(DocumentUploadPage.DUPLICATE_FILE_ERROR, errorMsg);
+	}
+
+	@Then("verify duplicate uploaded filename error doesn't exist")
+	public void verifyDuplicateFileErrorNotExist() {
+		// assert error element exists
+		String errorMsg = documentUploadPage.getDuplicateFileError();
+		assertNull(errorMsg);
+	}
 }

--- a/tests/src/test/resources/features/uploadDocumentUsingUploadLink.feature
+++ b/tests/src/test/resources/features/uploadDocumentUsingUploadLink.feature
@@ -1,10 +1,17 @@
 # new feature
 # Tags: optional
 
+@frontend
 Feature: Additional documents can be uploaded from EFiling hub
 
-  @frontend
-  Scenario: Verify documents can be uploaded using the upload link
+  Background:
     Given user is on the eFiling submission page
+  
+  Scenario: Verify documents can be uploaded using the upload link
     When user uploads an additional document
     Then verify the document is uploaded
+    Then verify duplicate uploaded filename error doesn't exist
+
+  Scenario: Verify error on duplicate documents
+    When user uploads the same document
+    Then verify duplicate uploaded filename error exists


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

https://justice.gov.bc.ca/jira/browse/FLA-1321

Created a regression test for the scenario where a user uploads a file with the same name as one that already exists via the parent app.

This test basically verifies the `<p/>` tag with the error message exists: "You cannot upload multiple files with the same name."

![image](https://user-images.githubusercontent.com/55215368/131584529-e3f8e730-220b-4a1e-b012-695c580715de.png)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New test(s)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn verify -f tests/pom.xml

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
