### PR TITLE
FLA-1380 added banner when rejected docs exists

### DIFF
--- a/src/frontend/efiling-frontend/src/components/page/home/__snapshots__/Home.test.js.snap
+++ b/src/frontend/efiling-frontend/src/components/page/home/__snapshots__/Home.test.js.snap
@@ -1149,6 +1149,31 @@ exports[`Home Component matches the snapshot when user cso account exists 1`] = 
         </ul>
       </div>
       <br />
+      <div
+        class="alert alert-danger show rejectedMsg"
+        role="alert"
+      >
+        <div>
+          <svg
+            fill="currentColor"
+            height="32"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 24 24"
+            width="32"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+            />
+          </svg>
+        </div>
+        <div>
+          <span>
+            Please ensure you have uploaded all required rejected documents. If you still need to add documents use the upload link below.
+          </span>
+        </div>
+      </div>
       <h4>
         Do you have additional documents to upload? 
         <span

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/PackageConfirmation.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/PackageConfirmation.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
-import { MdCheckBox } from "react-icons/md";
+import { MdCheckBox, MdError } from "react-icons/md";
 import ConfirmationPopup, {
   Alert,
   Button,
@@ -57,6 +57,18 @@ const getFilingPackageData = (
     });
 };
 
+const checkRejectedFiles = (files, setShowRejectedMsg) => {
+  let hasRejectedDoc = false;
+  if (files && files.length > 0) {
+    files.forEach((file) => {
+      if (file.actionDocument && file.actionDocument.status === "REJ") {
+        hasRejectedDoc = true;
+      }
+    });
+  }
+  setShowRejectedMsg(hasRejectedDoc);
+};
+
 const checkDuplicateFileNames = (files, setShowToast, setToastMessage) => {
   if (files && files.length > 0) {
     const filenames = [];
@@ -108,6 +120,7 @@ export default function PackageConfirmation({
   const aboutCsoSidecard = getSidecardData().aboutCso;
   const csoAccountDetailsSidecard = getSidecardData().csoAccountDetails;
   const rushSubmissionSidecard = getSidecardData().rushSubmission;
+  const [showRejectedMsg, setShowRejectedMsg] = useState(false);
 
   const resetState = () => {
     setShowUpload(false);
@@ -139,6 +152,7 @@ export default function PackageConfirmation({
     );
 
     checkDuplicateFileNames(files, setShowToast, setToastMessage);
+    checkRejectedFiles(files, setShowRejectedMsg);
   }, [files, submissionId, showUpload, refreshFiles]);
 
   function handleUploadFile(e) {
@@ -223,6 +237,22 @@ export default function PackageConfirmation({
         <br />
         {<FileList submissionId={submissionId} files={files} />}
         <br />
+        {showRejectedMsg && (
+          <>
+            <div className="alert alert-danger show rejectedMsg" role="alert">
+              <div>
+                <MdError size={32} />
+              </div>
+              <div>
+                <span>
+                  Please ensure you have uploaded all required rejected
+                  documents. If you still need to add documents use the upload
+                  link below.
+                </span>
+              </div>
+            </div>
+          </>
+        )}
         <h4>
           Do you have additional documents to upload?&nbsp;
           <span

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/PackageConfirmation.scss
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/PackageConfirmation.scss
@@ -15,6 +15,18 @@
     visibility: hidden !important;
   }
 
+  .rejectedMsg {
+    margin-bottom: 20px;
+    svg {
+      color: #A84441;
+    }
+    div {
+      display: table-cell;
+      vertical-align: middle;
+      padding: 10px 10px 10px 0px;
+    }
+  }
+
   @media (min-width: 1200px) {
     .near-half-width {
       width: 60% !important;

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__snapshots__/PackageConfirmation.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__snapshots__/PackageConfirmation.stories.storyshot
@@ -136,6 +136,31 @@ exports[`Storyshots PackageConfirmation Existing Account 1`] = `
         </ul>
       </div>
       <br />
+      <div
+        class="alert alert-danger show rejectedMsg"
+        role="alert"
+      >
+        <div>
+          <svg
+            fill="currentColor"
+            height="32"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 24 24"
+            width="32"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+            />
+          </svg>
+        </div>
+        <div>
+          <span>
+            Please ensure you have uploaded all required rejected documents. If you still need to add documents use the upload link below.
+          </span>
+        </div>
+      </div>
       <h4>
         Do you have additional documents to upload? 
         <span
@@ -585,6 +610,31 @@ exports[`Storyshots PackageConfirmation Mobile 1`] = `
         </ul>
       </div>
       <br />
+      <div
+        class="alert alert-danger show rejectedMsg"
+        role="alert"
+      >
+        <div>
+          <svg
+            fill="currentColor"
+            height="32"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 24 24"
+            width="32"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+            />
+          </svg>
+        </div>
+        <div>
+          <span>
+            Please ensure you have uploaded all required rejected documents. If you still need to add documents use the upload link below.
+          </span>
+        </div>
+      </div>
       <h4>
         Do you have additional documents to upload? 
         <span
@@ -1065,6 +1115,31 @@ exports[`Storyshots PackageConfirmation New Account 1`] = `
         </ul>
       </div>
       <br />
+      <div
+        class="alert alert-danger show rejectedMsg"
+        role="alert"
+      >
+        <div>
+          <svg
+            fill="currentColor"
+            height="32"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 24 24"
+            width="32"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+            />
+          </svg>
+        </div>
+        <div>
+          <span>
+            Please ensure you have uploaded all required rejected documents. If you still need to add documents use the upload link below.
+          </span>
+        </div>
+      </div>
       <h4>
         Do you have additional documents to upload? 
         <span

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__tests__/__snapshots__/PackageConfirmation.test.js.snap
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__tests__/__snapshots__/PackageConfirmation.test.js.snap
@@ -136,6 +136,31 @@ exports[`PackageConfirmation Component Matches the existing account snapshot 1`]
         </ul>
       </div>
       <br />
+      <div
+        class="alert alert-danger show rejectedMsg"
+        role="alert"
+      >
+        <div>
+          <svg
+            fill="currentColor"
+            height="32"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 24 24"
+            width="32"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+            />
+          </svg>
+        </div>
+        <div>
+          <span>
+            Please ensure you have uploaded all required rejected documents. If you still need to add documents use the upload link below.
+          </span>
+        </div>
+      </div>
       <h4>
         Do you have additional documents to upload? 
         <span
@@ -616,6 +641,31 @@ exports[`PackageConfirmation Component Matches the new account snapshot 1`] = `
         </ul>
       </div>
       <br />
+      <div
+        class="alert alert-danger show rejectedMsg"
+        role="alert"
+      >
+        <div>
+          <svg
+            fill="currentColor"
+            height="32"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 24 24"
+            width="32"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+            />
+          </svg>
+        </div>
+        <div>
+          <span>
+            Please ensure you have uploaded all required rejected documents. If you still need to add documents use the upload link below.
+          </span>
+        </div>
+      </div>
       <h4>
         Do you have additional documents to upload? 
         <span
@@ -1783,6 +1833,31 @@ exports[`PackageConfirmation Component On keydown of Upload them now text, it re
         </ul>
       </div>
       <br />
+      <div
+        class="alert alert-danger show rejectedMsg"
+        role="alert"
+      >
+        <div>
+          <svg
+            fill="currentColor"
+            height="32"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 24 24"
+            width="32"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+            />
+          </svg>
+        </div>
+        <div>
+          <span>
+            Please ensure you have uploaded all required rejected documents. If you still need to add documents use the upload link below.
+          </span>
+        </div>
+      </div>
       <h4>
         Do you have additional documents to upload? 
         <span

--- a/src/frontend/efiling-frontend/src/domain/payment/__tests__/__snapshots__/Payment.test.js.snap
+++ b/src/frontend/efiling-frontend/src/domain/payment/__tests__/__snapshots__/Payment.test.js.snap
@@ -1165,6 +1165,31 @@ exports[`Payment Component On back click, it redirects back to the package confi
         </ul>
       </div>
       <br />
+      <div
+        class="alert alert-danger show rejectedMsg"
+        role="alert"
+      >
+        <div>
+          <svg
+            fill="currentColor"
+            height="32"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 24 24"
+            width="32"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+            />
+          </svg>
+        </div>
+        <div>
+          <span>
+            Please ensure you have uploaded all required rejected documents. If you still need to add documents use the upload link below.
+          </span>
+        </div>
+      </div>
       <h4>
         Do you have additional documents to upload? 
         <span

--- a/src/frontend/efiling-frontend/src/modules/test-data/documentTestData.js
+++ b/src/frontend/efiling-frontend/src/modules/test-data/documentTestData.js
@@ -10,6 +10,9 @@ const documents = [
     isSupremeCourtScheduling: null,
     mimeType: "application/pdf",
     statutoryFeeAmount: 40,
+    actionDocument: {
+      status: "SUB",
+    },
   },
   {
     description: "file description 2",
@@ -22,6 +25,9 @@ const documents = [
     isSupremeCourtScheduling: true,
     mimeType: "application/pdf",
     statutoryFeeAmount: 0,
+    actionDocument: {
+      status: "REJ",
+    },
   },
 ];
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

https://justice.gov.bc.ca/jira/browse/FLA-1380

Added a banner on the Package Confirmation screen when a document in the list has a status of "REJ".

![image](https://user-images.githubusercontent.com/55215368/131915189-2f1059a5-3430-4ac7-b296-86ec62b5a927.png)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

yarn lint
yarn test -u

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
