### PR TITLE
FLA-1381 added Rejected Documents sidecard

### DIFF
--- a/src/frontend/efiling-frontend/src/components/page/home/__snapshots__/Home.test.js.snap
+++ b/src/frontend/efiling-frontend/src/components/page/home/__snapshots__/Home.test.js.snap
@@ -1345,6 +1345,80 @@ exports[`Home Component matches the snapshot when user cso account exists 1`] = 
           <p />
           <section
             class="bcgov-bluegrey-container"
+            id="rejectedDocumentsCard"
+          >
+            <div
+              class="bcgov-container-background bcgov-bluegrey-heading"
+            >
+              <h2
+                class="bcgov-heading-style"
+              >
+                <div
+                  class="bcgov-side-card-row"
+                >
+                  <div
+                    class="bcgov-round-icon-wrapper"
+                  >
+                    <svg
+                      class="bcgov-side-card-icon"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="bcgov-side-card-title"
+                  >
+                    Rejected Documents
+                  </div>
+                </div>
+              </h2>
+            </div>
+            <div
+              class="bcgov-bluegrey-content"
+            >
+              <span
+                class="bcgov-content-style"
+              >
+                <p>
+                  When directed by the court, an order will be processed on an urgent(rush) basis. The registry will consider specific reasons for processing an order on an urgent(rush) basis.
+                </p>
+                <p>
+                  <b>
+                    Only request processing on an urgent(rush) basis in exceptional circumstances.
+                  </b>
+                </p>
+                <p>
+                  <span
+                    class="file-href"
+                  >
+                    Learn more about rejected documents.
+                  </span>
+                </p>
+              </span>
+            </div>
+          </section>
+        </div>
+      </div>
+      <div
+        class="bcgov-wide-dashboard-spacing"
+        style="position: relative;"
+      >
+        <div
+          class="col-12 pt-2"
+          style="position: relative;"
+        >
+          <p />
+          <section
+            class="bcgov-bluegrey-container"
             id="csoAccountDetailsCard"
           >
             <div

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/PackageConfirmation.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/PackageConfirmation.js
@@ -57,7 +57,7 @@ const getFilingPackageData = (
     });
 };
 
-const checkRejectedFiles = (files, setShowRejectedMsg) => {
+const checkRejectedFiles = (files, setHasRejectedDocuments) => {
   let hasRejectedDoc = false;
   if (files && files.length > 0) {
     files.forEach((file) => {
@@ -66,7 +66,7 @@ const checkRejectedFiles = (files, setShowRejectedMsg) => {
       }
     });
   }
-  setShowRejectedMsg(hasRejectedDoc);
+  setHasRejectedDocuments(hasRejectedDoc);
 };
 
 const checkDuplicateFileNames = (files, setShowToast, setToastMessage) => {
@@ -120,7 +120,8 @@ export default function PackageConfirmation({
   const aboutCsoSidecard = getSidecardData().aboutCso;
   const csoAccountDetailsSidecard = getSidecardData().csoAccountDetails;
   const rushSubmissionSidecard = getSidecardData().rushSubmission;
-  const [showRejectedMsg, setShowRejectedMsg] = useState(false);
+  const rejectedDocumentsSideCard = getSidecardData().rejectedDocuments;
+  const [hasRejectedDocuments, setHasRejectedDocuments] = useState(false);
 
   const resetState = () => {
     setShowUpload(false);
@@ -152,7 +153,7 @@ export default function PackageConfirmation({
     );
 
     checkDuplicateFileNames(files, setShowToast, setToastMessage);
-    checkRejectedFiles(files, setShowRejectedMsg);
+    checkRejectedFiles(files, setHasRejectedDocuments);
   }, [files, submissionId, showUpload, refreshFiles]);
 
   function handleUploadFile(e) {
@@ -237,7 +238,7 @@ export default function PackageConfirmation({
         <br />
         {<FileList submissionId={submissionId} files={files} />}
         <br />
-        {showRejectedMsg && (
+        {hasRejectedDocuments && (
           <>
             <div className="alert alert-danger show rejectedMsg" role="alert">
               <div>
@@ -322,6 +323,9 @@ export default function PackageConfirmation({
         </section>
       </div>
       <div className="sidecard">
+        {hasRejectedDocuments && (
+          <Sidecard sideCard={rejectedDocumentsSideCard} />
+        )}
         {isRush && <Sidecard sideCard={rushSubmissionSidecard} />}
         <Sidecard sideCard={csoAccountDetailsSidecard} />
         <Sidecard sideCard={aboutCsoSidecard} />

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__snapshots__/PackageConfirmation.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__snapshots__/PackageConfirmation.stories.storyshot
@@ -332,6 +332,80 @@ exports[`Storyshots PackageConfirmation Existing Account 1`] = `
           <p />
           <section
             class="bcgov-bluegrey-container"
+            id="rejectedDocumentsCard"
+          >
+            <div
+              class="bcgov-container-background bcgov-bluegrey-heading"
+            >
+              <h2
+                class="bcgov-heading-style"
+              >
+                <div
+                  class="bcgov-side-card-row"
+                >
+                  <div
+                    class="bcgov-round-icon-wrapper"
+                  >
+                    <svg
+                      class="bcgov-side-card-icon"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="bcgov-side-card-title"
+                  >
+                    Rejected Documents
+                  </div>
+                </div>
+              </h2>
+            </div>
+            <div
+              class="bcgov-bluegrey-content"
+            >
+              <span
+                class="bcgov-content-style"
+              >
+                <p>
+                  When directed by the court, an order will be processed on an urgent(rush) basis. The registry will consider specific reasons for processing an order on an urgent(rush) basis.
+                </p>
+                <p>
+                  <b>
+                    Only request processing on an urgent(rush) basis in exceptional circumstances.
+                  </b>
+                </p>
+                <p>
+                  <span
+                    class="file-href"
+                  >
+                    Learn more about rejected documents.
+                  </span>
+                </p>
+              </span>
+            </div>
+          </section>
+        </div>
+      </div>
+      <div
+        class="bcgov-wide-dashboard-spacing"
+        style="position: relative;"
+      >
+        <div
+          class="col-12 pt-2"
+          style="position: relative;"
+        >
+          <p />
+          <section
+            class="bcgov-bluegrey-container"
             id="csoAccountDetailsCard"
           >
             <div
@@ -795,6 +869,80 @@ exports[`Storyshots PackageConfirmation Mobile 1`] = `
     <div
       class="sidecard"
     >
+      <div
+        class="bcgov-wide-dashboard-spacing"
+        style="position: relative;"
+      >
+        <div
+          class="col-12 pt-2"
+          style="position: relative;"
+        >
+          <p />
+          <section
+            class="bcgov-bluegrey-container"
+            id="rejectedDocumentsCard"
+          >
+            <div
+              class="bcgov-container-background bcgov-bluegrey-heading"
+            >
+              <h2
+                class="bcgov-heading-style"
+              >
+                <div
+                  class="bcgov-side-card-row"
+                >
+                  <div
+                    class="bcgov-round-icon-wrapper"
+                  >
+                    <svg
+                      class="bcgov-side-card-icon"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="bcgov-side-card-title"
+                  >
+                    Rejected Documents
+                  </div>
+                </div>
+              </h2>
+            </div>
+            <div
+              class="bcgov-bluegrey-content"
+            >
+              <span
+                class="bcgov-content-style"
+              >
+                <p>
+                  When directed by the court, an order will be processed on an urgent(rush) basis. The registry will consider specific reasons for processing an order on an urgent(rush) basis.
+                </p>
+                <p>
+                  <b>
+                    Only request processing on an urgent(rush) basis in exceptional circumstances.
+                  </b>
+                </p>
+                <p>
+                  <span
+                    class="file-href"
+                  >
+                    Learn more about rejected documents.
+                  </span>
+                </p>
+              </span>
+            </div>
+          </section>
+        </div>
+      </div>
       <div
         class="bcgov-wide-dashboard-spacing"
         style="position: relative;"
@@ -1300,6 +1448,80 @@ exports[`Storyshots PackageConfirmation New Account 1`] = `
     <div
       class="sidecard"
     >
+      <div
+        class="bcgov-wide-dashboard-spacing"
+        style="position: relative;"
+      >
+        <div
+          class="col-12 pt-2"
+          style="position: relative;"
+        >
+          <p />
+          <section
+            class="bcgov-bluegrey-container"
+            id="rejectedDocumentsCard"
+          >
+            <div
+              class="bcgov-container-background bcgov-bluegrey-heading"
+            >
+              <h2
+                class="bcgov-heading-style"
+              >
+                <div
+                  class="bcgov-side-card-row"
+                >
+                  <div
+                    class="bcgov-round-icon-wrapper"
+                  >
+                    <svg
+                      class="bcgov-side-card-icon"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="bcgov-side-card-title"
+                  >
+                    Rejected Documents
+                  </div>
+                </div>
+              </h2>
+            </div>
+            <div
+              class="bcgov-bluegrey-content"
+            >
+              <span
+                class="bcgov-content-style"
+              >
+                <p>
+                  When directed by the court, an order will be processed on an urgent(rush) basis. The registry will consider specific reasons for processing an order on an urgent(rush) basis.
+                </p>
+                <p>
+                  <b>
+                    Only request processing on an urgent(rush) basis in exceptional circumstances.
+                  </b>
+                </p>
+                <p>
+                  <span
+                    class="file-href"
+                  >
+                    Learn more about rejected documents.
+                  </span>
+                </p>
+              </span>
+            </div>
+          </section>
+        </div>
+      </div>
       <div
         class="bcgov-wide-dashboard-spacing"
         style="position: relative;"

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__tests__/__snapshots__/PackageConfirmation.test.js.snap
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__tests__/__snapshots__/PackageConfirmation.test.js.snap
@@ -332,6 +332,80 @@ exports[`PackageConfirmation Component Matches the existing account snapshot 1`]
           <p />
           <section
             class="bcgov-bluegrey-container"
+            id="rejectedDocumentsCard"
+          >
+            <div
+              class="bcgov-container-background bcgov-bluegrey-heading"
+            >
+              <h2
+                class="bcgov-heading-style"
+              >
+                <div
+                  class="bcgov-side-card-row"
+                >
+                  <div
+                    class="bcgov-round-icon-wrapper"
+                  >
+                    <svg
+                      class="bcgov-side-card-icon"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="bcgov-side-card-title"
+                  >
+                    Rejected Documents
+                  </div>
+                </div>
+              </h2>
+            </div>
+            <div
+              class="bcgov-bluegrey-content"
+            >
+              <span
+                class="bcgov-content-style"
+              >
+                <p>
+                  When directed by the court, an order will be processed on an urgent(rush) basis. The registry will consider specific reasons for processing an order on an urgent(rush) basis.
+                </p>
+                <p>
+                  <b>
+                    Only request processing on an urgent(rush) basis in exceptional circumstances.
+                  </b>
+                </p>
+                <p>
+                  <span
+                    class="file-href"
+                  >
+                    Learn more about rejected documents.
+                  </span>
+                </p>
+              </span>
+            </div>
+          </section>
+        </div>
+      </div>
+      <div
+        class="bcgov-wide-dashboard-spacing"
+        style="position: relative;"
+      >
+        <div
+          class="col-12 pt-2"
+          style="position: relative;"
+        >
+          <p />
+          <section
+            class="bcgov-bluegrey-container"
             id="csoAccountDetailsCard"
           >
             <div
@@ -826,6 +900,80 @@ exports[`PackageConfirmation Component Matches the new account snapshot 1`] = `
     <div
       class="sidecard"
     >
+      <div
+        class="bcgov-wide-dashboard-spacing"
+        style="position: relative;"
+      >
+        <div
+          class="col-12 pt-2"
+          style="position: relative;"
+        >
+          <p />
+          <section
+            class="bcgov-bluegrey-container"
+            id="rejectedDocumentsCard"
+          >
+            <div
+              class="bcgov-container-background bcgov-bluegrey-heading"
+            >
+              <h2
+                class="bcgov-heading-style"
+              >
+                <div
+                  class="bcgov-side-card-row"
+                >
+                  <div
+                    class="bcgov-round-icon-wrapper"
+                  >
+                    <svg
+                      class="bcgov-side-card-icon"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="bcgov-side-card-title"
+                  >
+                    Rejected Documents
+                  </div>
+                </div>
+              </h2>
+            </div>
+            <div
+              class="bcgov-bluegrey-content"
+            >
+              <span
+                class="bcgov-content-style"
+              >
+                <p>
+                  When directed by the court, an order will be processed on an urgent(rush) basis. The registry will consider specific reasons for processing an order on an urgent(rush) basis.
+                </p>
+                <p>
+                  <b>
+                    Only request processing on an urgent(rush) basis in exceptional circumstances.
+                  </b>
+                </p>
+                <p>
+                  <span
+                    class="file-href"
+                  >
+                    Learn more about rejected documents.
+                  </span>
+                </p>
+              </span>
+            </div>
+          </section>
+        </div>
+      </div>
       <div
         class="bcgov-wide-dashboard-spacing"
         style="position: relative;"
@@ -2018,6 +2166,80 @@ exports[`PackageConfirmation Component On keydown of Upload them now text, it re
     <div
       class="sidecard"
     >
+      <div
+        class="bcgov-wide-dashboard-spacing"
+        style="position: relative;"
+      >
+        <div
+          class="col-12 pt-2"
+          style="position: relative;"
+        >
+          <p />
+          <section
+            class="bcgov-bluegrey-container"
+            id="rejectedDocumentsCard"
+          >
+            <div
+              class="bcgov-container-background bcgov-bluegrey-heading"
+            >
+              <h2
+                class="bcgov-heading-style"
+              >
+                <div
+                  class="bcgov-side-card-row"
+                >
+                  <div
+                    class="bcgov-round-icon-wrapper"
+                  >
+                    <svg
+                      class="bcgov-side-card-icon"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="bcgov-side-card-title"
+                  >
+                    Rejected Documents
+                  </div>
+                </div>
+              </h2>
+            </div>
+            <div
+              class="bcgov-bluegrey-content"
+            >
+              <span
+                class="bcgov-content-style"
+              >
+                <p>
+                  When directed by the court, an order will be processed on an urgent(rush) basis. The registry will consider specific reasons for processing an order on an urgent(rush) basis.
+                </p>
+                <p>
+                  <b>
+                    Only request processing on an urgent(rush) basis in exceptional circumstances.
+                  </b>
+                </p>
+                <p>
+                  <span
+                    class="file-href"
+                  >
+                    Learn more about rejected documents.
+                  </span>
+                </p>
+              </span>
+            </div>
+          </section>
+        </div>
+      </div>
       <div
         class="bcgov-wide-dashboard-spacing"
         style="position: relative;"

--- a/src/frontend/efiling-frontend/src/domain/payment/__tests__/__snapshots__/Payment.test.js.snap
+++ b/src/frontend/efiling-frontend/src/domain/payment/__tests__/__snapshots__/Payment.test.js.snap
@@ -1361,6 +1361,80 @@ exports[`Payment Component On back click, it redirects back to the package confi
           <p />
           <section
             class="bcgov-bluegrey-container"
+            id="rejectedDocumentsCard"
+          >
+            <div
+              class="bcgov-container-background bcgov-bluegrey-heading"
+            >
+              <h2
+                class="bcgov-heading-style"
+              >
+                <div
+                  class="bcgov-side-card-row"
+                >
+                  <div
+                    class="bcgov-round-icon-wrapper"
+                  >
+                    <svg
+                      class="bcgov-side-card-icon"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="bcgov-side-card-title"
+                  >
+                    Rejected Documents
+                  </div>
+                </div>
+              </h2>
+            </div>
+            <div
+              class="bcgov-bluegrey-content"
+            >
+              <span
+                class="bcgov-content-style"
+              >
+                <p>
+                  When directed by the court, an order will be processed on an urgent(rush) basis. The registry will consider specific reasons for processing an order on an urgent(rush) basis.
+                </p>
+                <p>
+                  <b>
+                    Only request processing on an urgent(rush) basis in exceptional circumstances.
+                  </b>
+                </p>
+                <p>
+                  <span
+                    class="file-href"
+                  >
+                    Learn more about rejected documents.
+                  </span>
+                </p>
+              </span>
+            </div>
+          </section>
+        </div>
+      </div>
+      <div
+        class="bcgov-wide-dashboard-spacing"
+        style="position: relative;"
+      >
+        <div
+          class="col-12 pt-2"
+          style="position: relative;"
+        >
+          <p />
+          <section
+            class="bcgov-bluegrey-container"
             id="csoAccountDetailsCard"
           >
             <div

--- a/src/frontend/efiling-frontend/src/modules/helpers/sidecardData.js
+++ b/src/frontend/efiling-frontend/src/modules/helpers/sidecardData.js
@@ -115,12 +115,37 @@ const supremeCourtScheduling = () => ({
   icon: <MdInfoOutline className="bcgov-side-card-icon" />,
 });
 
+const rejectedDocuments = () => ({
+  heading: "Rejected Documents",
+  content: [
+    <p key="rjctdDcmnts">
+      When directed by the court, an order will be processed on an urgent(rush)
+      basis. The registry will consider specific reasons for processing an order
+      on an urgent(rush) basis.
+    </p>,
+    <p>
+      <b>
+        Only request processing on an urgent(rush) basis in exceptional
+        circumstances.
+      </b>
+    </p>,
+    <p>
+      <span className="file-href">Learn more about rejected documents.</span>
+    </p>,
+  ],
+  type: "bluegrey",
+  id: "rejectedDocumentsCard",
+  isWide: true,
+  icon: <MdInfoOutline className="bcgov-side-card-icon" />,
+});
+
 export function getSidecardData(setShowRush) {
   const aboutCsoCard = aboutCso();
   const csoAccountDetailsCard = csoAccountDetails();
   const rushSubmissionCard = rushSubmission(setShowRush);
   const amendmentsCard = amendments();
   const supremeCourtSchedulingCard = supremeCourtScheduling();
+  const rejectedDocumentsCard = rejectedDocuments();
 
   return {
     aboutCso: aboutCsoCard,
@@ -128,5 +153,6 @@ export function getSidecardData(setShowRush) {
     rushSubmission: rushSubmissionCard,
     amendments: amendmentsCard,
     supremeCourtScheduling: supremeCourtSchedulingCard,
+    rejectedDocuments: rejectedDocumentsCard,
   };
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

https://justice.gov.bc.ca/jira/browse/FLA-1381

Added Rejected Documents side card that matches UX when a document has status of "REJ". I suspect the text is wrong and can be updated in a separate PR.

Updated snapshots that include the sidecard.

![image](https://user-images.githubusercontent.com/55215368/132043875-970550d7-dfd4-4d8c-af00-8ccdf6c9ca08.png)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

yarn lint
yarn test -u

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
