### PR TITLE
FLA-1399 Added regression tests for Rejected Documents (banner and sidecard)

### DIFF
--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/Keys.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/Keys.java
@@ -44,4 +44,10 @@ public class Keys {
     public static final String COUNTRIES_PATH = "countries";
     public static final String RUSH_PROCESSING_PATH = "rushProcessing";
 
+    /** Action Document 'Submitted' status */
+    public static final String ACTION_STATUS_SUB = "SUB";
+
+    /** Action Document 'Rejected' status */
+    public static final String ACTION_STATUS_REJ = "REJ";
+    
 }

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/helpers/PayloadHelper.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/helpers/PayloadHelper.java
@@ -5,7 +5,7 @@ public class PayloadHelper {
     private PayloadHelper() {
     }
 
-    public static String generateUrlPayload(String documentName) {
+    public static String generateUrlPayload(String documentName, String actionStatus) {
 
         return "{\n" +
                 "    \"navigationUrls\": {\n" +
@@ -31,7 +31,7 @@ public class PayloadHelper {
                 "                \"md5\": \"string\", \n" +
                 "                \"actionDocument\": {\n" +
                 "                   \"id\": 2,\n" +
-                "                   \"status\": \"SUB\",\n" +
+                "                   \"status\": \"" + actionStatus + "\",\n" +
                 "                   \"type\": \"F\"\n" +
                 "               }\n" +
                 "            }\n" +

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/page/PackageConfirmationPage.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/page/PackageConfirmationPage.java
@@ -76,4 +76,17 @@ public class PackageConfirmationPage extends BasePage {
         }
         return UploadedFileList;
     }
+    
+    /** Returns true if the rejected banner exists. */ 
+    public boolean rejectedBannerExists() { 
+    	List<WebElement> elements = driver.findElements(By.className("rejectedMsg")); 
+    	return elements != null && !elements.isEmpty();
+	}
+    
+    /** Returns true if the rejected sidecard exists. */ 
+    public boolean rejectedSidecardExists() { 
+    	List<WebElement> elements = driver.findElements(By.id("rejectedDocumentsCard")); 
+    	return elements != null && !elements.isEmpty();
+	}
+    
 }

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/services/GenerateUrlService.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/services/GenerateUrlService.java
@@ -31,7 +31,7 @@ public class GenerateUrlService {
         actualTransactionId = UUID.randomUUID();
     }
 
-    public String getGeneratedUrl() {
+    public String getGeneratedUrl(String actionDocumentStatus) {
 
         UserIdentity actualUserIdentity = oauthService.getUserIdentity();
 
@@ -59,7 +59,7 @@ public class GenerateUrlService {
         String actualSubmissionId = submissionService.getSubmissionId(actualDocumentResponse);
 
         Response actualGenerateUrlResponse = submissionService.generateUrlResponse(actualTransactionId, actualUserIdentity.getUniversalId(),
-                actualUserIdentity.getAccessToken(), actualSubmissionId);
+                actualUserIdentity.getAccessToken(), actualSubmissionId, actionDocumentStatus);
 
         logger.info("Api response status code: {}", Integer.valueOf(actualDocumentResponse.getStatusCode()));
         logger.info("Api response: {}", actualDocumentResponse.asString());

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/services/SubmissionService.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/services/SubmissionService.java
@@ -48,7 +48,7 @@ public class SubmissionService {
     }
 
     public Response generateUrlResponse(UUID transactionId, String universalId, String accessToken,
-                                         String submissionId) {
+                                         String submissionId, String actionStatus) {
 
         logger.info("Requesting to generate Url");
 
@@ -60,7 +60,7 @@ public class SubmissionService {
                 .contentType(ContentType.JSON)
                 .header(Keys.X_TRANSACTION_ID, transactionId)
                 .header(Keys.X_USER_ID, universalId)
-                .body(PayloadHelper.generateUrlPayload(Keys.TEST_DOCUMENT_PDF));
+                .body(PayloadHelper.generateUrlPayload(Keys.TEST_DOCUMENT_PDF, actionStatus));
 
         return request
                 .when()

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/AddRushProcessingSD.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/AddRushProcessingSD.java
@@ -59,9 +59,8 @@ public class AddRushProcessingSD {
         String actualSubmissionId = submissionService.getSubmissionId(actualDocumentResponse);
 
         // Generate Url Response
-        submissionService.generateUrlResponse(actualTransactionId, actualUserIdentity.getUniversalId(),
-                actualUserIdentity.getAccessToken(), actualSubmissionId);
-
+		submissionService.generateUrlResponse(actualTransactionId, actualUserIdentity.getUniversalId(),
+				actualUserIdentity.getAccessToken(), actualSubmissionId, Keys.ACTION_STATUS_SUB);
 
         actualRushProcessResponse = submissionService.addRushProcessingResponse(actualUserIdentity.getAccessToken(), actualTransactionId,
                 actualSubmissionId, Keys.RUSH_PROCESSING_PATH);

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/CreatePaymentServiceSD.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/CreatePaymentServiceSD.java
@@ -61,8 +61,7 @@ public class CreatePaymentServiceSD {
 
         // Generate Url Response
         submissionService.generateUrlResponse(actualTransactionId, actualUserIdentity.getUniversalId(),
-                actualUserIdentity.getAccessToken(), actualSubmissionId);
-
+                actualUserIdentity.getAccessToken(), actualSubmissionId, Keys.ACTION_STATUS_SUB);
 
         actualSubmitResponse = submissionService.createPaymentServiceResponse(actualUserIdentity.getAccessToken(), actualTransactionId,
                 actualSubmissionId, Keys.SUBMIT_PATH);

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/GenerateUrlSD.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/GenerateUrlSD.java
@@ -89,7 +89,7 @@ public class GenerateUrlSD {
     public void userRequestASubmissionUrl() {
 
         actualGenerateUrlResponse = submissionService.generateUrlResponse(actualTransactionId, actualUserIdentity.getUniversalId(),
-                actualUserIdentity.getAccessToken(), actualSubmissionId);
+                actualUserIdentity.getAccessToken(), actualSubmissionId, Keys.ACTION_STATUS_SUB);
 
         logger.info("Api response status code: {}", Integer.valueOf(actualGenerateUrlResponse.getStatusCode()));
 

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/GetFileNameSD.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/GetFileNameSD.java
@@ -60,8 +60,7 @@ public class GetFileNameSD {
 
         // Generate Url Response
         submissionService.generateUrlResponse(actualTransactionId, actualUserIdentity.getUniversalId(),
-                actualUserIdentity.getAccessToken(), actualSubmissionId);
-
+                actualUserIdentity.getAccessToken(), actualSubmissionId, Keys.ACTION_STATUS_SUB);
 
         actualFileNameResponse = submissionService.getSubmissionDetailsResponse(actualUserIdentity.getAccessToken(),actualTransactionId,
                 actualSubmissionId, Keys.FILE_NAME_PATH);

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/GetFilingPackageSD.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/GetFilingPackageSD.java
@@ -60,8 +60,7 @@ public class GetFilingPackageSD {
 
         // Generate Url Response
         submissionService.generateUrlResponse(actualTransactionId, actualUserIdentity.getUniversalId(),
-                                                    actualUserIdentity.getAccessToken(), actualSubmissionId);
-
+                                                    actualUserIdentity.getAccessToken(), actualSubmissionId, Keys.ACTION_STATUS_SUB);
 
         actualFilingPackageResponse = submissionService.getSubmissionDetailsResponse(actualUserIdentity.getAccessToken(),actualTransactionId,
                 actualSubmissionId, Keys.FILING_PACKAGE_PATH);

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/GetSubmissionConfigSD.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/GetSubmissionConfigSD.java
@@ -59,8 +59,7 @@ public class GetSubmissionConfigSD {
 
         // Generate Url Response
        submissionService.generateUrlResponse(actualTransactionId, actualUserIdentity.getUniversalId(),
-                actualUserIdentity.getAccessToken(), actualSubmissionId);
-
+                actualUserIdentity.getAccessToken(), actualSubmissionId, Keys.ACTION_STATUS_SUB);
 
         actualSubmissionDetailsResponse = submissionService.getSubmissionDetailsResponse(actualUserIdentity.getAccessToken(),actualTransactionId,
                 actualSubmissionId, Keys.CONFIG_PATH);

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/UpdateDocumentPropertiesSD.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/UpdateDocumentPropertiesSD.java
@@ -62,7 +62,7 @@ public class UpdateDocumentPropertiesSD {
 
         // Generate Url Response
         submissionService.generateUrlResponse(actualTransactionId, actualUserIdentity.getUniversalId(),
-                actualUserIdentity.getAccessToken(), actualSubmissionId);
+                actualUserIdentity.getAccessToken(), actualSubmissionId, Keys.ACTION_STATUS_SUB);
 
         actualUpdatedDocumentPropertiesResponse = submissionService.updateDocumentPropertiesResponse(actualUserIdentity.getAccessToken(), actualTransactionId,
                 actualSubmissionId, Keys.UPDATE_DOCUMENTS_PATH);

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/UploadAdditionalDocumentSD.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/UploadAdditionalDocumentSD.java
@@ -61,7 +61,7 @@ public class UploadAdditionalDocumentSD {
 
         // Generate Url Response
         submissionService.generateUrlResponse(actualTransactionId, actualUserIdentity.getUniversalId(),
-                actualUserIdentity.getAccessToken(), actualSubmissionId);
+                actualUserIdentity.getAccessToken(), actualSubmissionId, Keys.ACTION_STATUS_SUB);
 
         actualAdditionalDocumentResponse = submissionService.additionalDocumentUploadResponse(actualUserIdentity.getAccessToken(), actualTransactionId,
                 actualSubmissionId, Keys.DOCUMENTS_PATH);

--- a/tests/src/test/resources/features/authenticateAndRedirectToEfilingHub.feature
+++ b/tests/src/test/resources/features/authenticateAndRedirectToEfilingHub.feature
@@ -5,6 +5,6 @@ Feature: User account is validated and redirected to E-Filing hub
 
   @frontend
   Scenario: Validate user with valid BCEID or BCSC and CSO accounts is redirected E-Filing hub
-    Given user is on the eFiling submission page
+    Given User uploads a successful document from parent app
     Then Package information is displayed
     And continue to payment button is enabled

--- a/tests/src/test/resources/features/uploadDocumentUsingUploadLink.feature
+++ b/tests/src/test/resources/features/uploadDocumentUsingUploadLink.feature
@@ -5,7 +5,7 @@
 Feature: Additional documents can be uploaded from EFiling hub
 
   Background:
-    Given user is on the eFiling submission page
+    Given User uploads a successful document from parent app
   
   Scenario: Verify documents can be uploaded using the upload link
     When user uploads an additional document

--- a/tests/src/test/resources/features/uploadRejectedDocuments.feature
+++ b/tests/src/test/resources/features/uploadRejectedDocuments.feature
@@ -1,0 +1,18 @@
+# new feature
+# Tags: optional
+
+@current
+@frontend
+Feature: Rejected documents uploaded from Parent App show rejected banner/sidecard
+
+  Scenario: Verify rejected banner and sidecard shows
+    Given User uploads a rejected document from parent app
+    Then Package information is displayed
+    And Rejected Document banner exists
+    And Rejected Document sidecard exists
+
+  Scenario: Verify rejected banner and sidecard doesn't shows
+    Given User uploads a successful document from parent app
+    Then Package information is displayed
+    And Rejected Document banner doesn't exist
+    And Rejected Document sidecard doesn't exist


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

https://justice.gov.bc.ca/jira/browse/FLA-1399, 1400

Added regression tests to confirm the Rejected Document banner and side card shows when appropriate.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change
- [x] Tests

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn verify

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
