### PR TITLE
FLA-1378 Added Rejected Documents banner

### DIFF
--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/PackageConfirmation.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/PackageConfirmation.js
@@ -15,6 +15,7 @@ import { propTypes } from "../../../types/propTypes";
 import { onBackButtonEvent } from "../../../modules/helpers/handleBackEvent";
 import { generateFileSummaryData } from "../../../modules/helpers/generateFileSummaryData";
 import { isClick, isEnter } from "../../../modules/helpers/eventUtil";
+import { checkRejectedFiles } from "../../../util/FileUtil";
 
 import "./PackageConfirmation.scss";
 import Payment from "../../payment/Payment";
@@ -55,18 +56,6 @@ const getFilingPackageData = (
       );
       setShowToast(true);
     });
-};
-
-const checkRejectedFiles = (files, setHasRejectedDocuments) => {
-  let hasRejectedDoc = false;
-  if (files && files.length > 0) {
-    files.forEach((file) => {
-      if (file.actionDocument && file.actionDocument.status === "REJ") {
-        hasRejectedDoc = true;
-      }
-    });
-  }
-  setHasRejectedDocuments(hasRejectedDoc);
 };
 
 const checkDuplicateFileNames = (files, setShowToast, setToastMessage) => {

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__tests__/__snapshots__/PackageConfirmation.test.js.snap
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__tests__/__snapshots__/PackageConfirmation.test.js.snap
@@ -1292,6 +1292,42 @@ exports[`PackageConfirmation Component On click of Continue button, it redirects
       <h1>
         Package Submission Details
       </h1>
+      <div
+        class="bcgov-display-box bcgov-success-background bcgov-no-padding-bottom rejectedMsg"
+      >
+        <div
+          class="bcgov-display-icon"
+        >
+          <div
+            style="color: rgb(46, 133, 64);"
+          >
+            <svg
+              fill="currentColor"
+              height="32"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 24 24"
+              width="32"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="bcgov-display-right-element"
+        >
+          <p>
+            Your rejected document(s) will be 
+            <b>
+              resubmitted
+            </b>
+            , and will be reviewed by the registry.
+          </p>
+        </div>
+      </div>
       <p>
         Your package will be filed to:
       </p>
@@ -2558,6 +2594,42 @@ exports[`PackageConfirmation Component take user directly to payment page when c
       <h1>
         Package Submission Details
       </h1>
+      <div
+        class="bcgov-display-box bcgov-success-background bcgov-no-padding-bottom rejectedMsg"
+      >
+        <div
+          class="bcgov-display-icon"
+        >
+          <div
+            style="color: rgb(46, 133, 64);"
+          >
+            <svg
+              fill="currentColor"
+              height="32"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 24 24"
+              width="32"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="bcgov-display-right-element"
+        >
+          <p>
+            Your rejected document(s) will be 
+            <b>
+              resubmitted
+            </b>
+            , and will be reviewed by the registry.
+          </p>
+        </div>
+      </div>
       <p>
         Your package will be filed to:
       </p>

--- a/src/frontend/efiling-frontend/src/domain/payment/Payment.js
+++ b/src/frontend/efiling-frontend/src/domain/payment/Payment.js
@@ -17,6 +17,8 @@ import { getJWTData } from "../../modules/helpers/authentication-helper/authenti
 import { propTypes } from "../../types/propTypes";
 import PackageConfirmation from "../package/package-confirmation/PackageConfirmation";
 import { generateFileSummaryData } from "../../modules/helpers/generateFileSummaryData";
+import { checkRejectedFiles } from "../../util/FileUtil";
+import { rejectedDocumentsAlert } from "../../modules/helpers/alerts";
 
 import "./Payment.scss";
 
@@ -126,6 +128,7 @@ export default function Payment({
   const [showRush, setShowRush] = useState(false);
   const [showLoader, setShowLoader] = useState(false);
   const [showToast, setShowToast] = useState(false);
+  const [hasRejectedDocuments, setHasRejectedDocuments] = useState(false);
 
   const aboutCsoSidecard = getSidecardData().aboutCso;
   const csoAccountDetailsSidecard = getSidecardData().csoAccountDetails;
@@ -170,6 +173,10 @@ export default function Payment({
     checkSubmitEnabled(paymentAgreed, setSubmitBtnEnabled, submissionFee);
   }, [paymentAgreed, submissionFee]);
 
+  useEffect(() => {
+    checkRejectedFiles(files, setHasRejectedDocuments);
+  }, [files]);
+
   if (showPackageConfirmation) {
     return (
       <PackageConfirmation
@@ -199,6 +206,7 @@ export default function Payment({
         {hasSubmissionFee(submissionFee) && paymentSectionElement}
         <br />
         <h1>Package Submission Details</h1>
+        {hasRejectedDocuments && rejectedDocumentsAlert}
         <p>Your package will be filed to:</p>
         <div className="court-half-width">
           <Table elements={generateCourtDataTable(courtData)} />

--- a/src/frontend/efiling-frontend/src/domain/payment/Payment.scss
+++ b/src/frontend/efiling-frontend/src/domain/payment/Payment.scss
@@ -23,6 +23,13 @@
     user-select: none; /* Standard */
   }
 
+  .rejectedMsg {
+    margin-bottom: 20px;
+    svg {
+      color: #A84441;
+    }
+  }
+
   @media (max-width: 576px) {
     .button-container {
       justify-content: space-between;

--- a/src/frontend/efiling-frontend/src/domain/payment/__snapshots__/Payment.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/domain/payment/__snapshots__/Payment.stories.storyshot
@@ -165,6 +165,42 @@ exports[`Storyshots Payment Mobile 1`] = `
       <h1>
         Package Submission Details
       </h1>
+      <div
+        class="bcgov-display-box bcgov-success-background bcgov-no-padding-bottom rejectedMsg"
+      >
+        <div
+          class="bcgov-display-icon"
+        >
+          <div
+            style="color: rgb(46, 133, 64);"
+          >
+            <svg
+              fill="currentColor"
+              height="32"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 24 24"
+              width="32"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="bcgov-display-right-element"
+        >
+          <p>
+            Your rejected document(s) will be 
+            <b>
+              resubmitted
+            </b>
+            , and will be reviewed by the registry.
+          </p>
+        </div>
+      </div>
       <p>
         Your package will be filed to:
       </p>
@@ -681,6 +717,42 @@ exports[`Storyshots Payment With Fees 1`] = `
       <h1>
         Package Submission Details
       </h1>
+      <div
+        class="bcgov-display-box bcgov-success-background bcgov-no-padding-bottom rejectedMsg"
+      >
+        <div
+          class="bcgov-display-icon"
+        >
+          <div
+            style="color: rgb(46, 133, 64);"
+          >
+            <svg
+              fill="currentColor"
+              height="32"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 24 24"
+              width="32"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="bcgov-display-right-element"
+        >
+          <p>
+            Your rejected document(s) will be 
+            <b>
+              resubmitted
+            </b>
+            , and will be reviewed by the registry.
+          </p>
+        </div>
+      </div>
       <p>
         Your package will be filed to:
       </p>

--- a/src/frontend/efiling-frontend/src/domain/payment/__tests__/__snapshots__/Payment.test.js.snap
+++ b/src/frontend/efiling-frontend/src/domain/payment/__tests__/__snapshots__/Payment.test.js.snap
@@ -165,6 +165,42 @@ exports[`Payment Component Matches the snapshot with existing credit card 1`] = 
       <h1>
         Package Submission Details
       </h1>
+      <div
+        class="bcgov-display-box bcgov-success-background bcgov-no-padding-bottom rejectedMsg"
+      >
+        <div
+          class="bcgov-display-icon"
+        >
+          <div
+            style="color: rgb(46, 133, 64);"
+          >
+            <svg
+              fill="currentColor"
+              height="32"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 24 24"
+              width="32"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="bcgov-display-right-element"
+        >
+          <p>
+            Your rejected document(s) will be 
+            <b>
+              resubmitted
+            </b>
+            , and will be reviewed by the registry.
+          </p>
+        </div>
+      </div>
       <p>
         Your package will be filed to:
       </p>
@@ -680,6 +716,42 @@ exports[`Payment Component Matches the snapshot with no credit card 1`] = `
       <h1>
         Package Submission Details
       </h1>
+      <div
+        class="bcgov-display-box bcgov-success-background bcgov-no-padding-bottom rejectedMsg"
+      >
+        <div
+          class="bcgov-display-icon"
+        >
+          <div
+            style="color: rgb(46, 133, 64);"
+          >
+            <svg
+              fill="currentColor"
+              height="32"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 24 24"
+              width="32"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="bcgov-display-right-element"
+        >
+          <p>
+            Your rejected document(s) will be 
+            <b>
+              resubmitted
+            </b>
+            , and will be reviewed by the registry.
+          </p>
+        </div>
+      </div>
       <p>
         Your package will be filed to:
       </p>

--- a/src/frontend/efiling-frontend/src/modules/helpers/alerts.js
+++ b/src/frontend/efiling-frontend/src/modules/helpers/alerts.js
@@ -1,0 +1,17 @@
+import React from "react";
+import { Alert } from "shared-components";
+import { MdError } from "react-icons/md";
+
+export const rejectedDocumentsAlert = (
+  <Alert
+    icon={<MdError size={32} />}
+    type="success"
+    styling="bcgov-success-background bcgov-no-padding-bottom rejectedMsg"
+    element={
+      <p>
+        Your rejected document(s) will be <b>resubmitted</b>, and will be
+        reviewed by the registry.
+      </p>
+    }
+  />
+);

--- a/src/frontend/efiling-frontend/src/util/FileUtil.js
+++ b/src/frontend/efiling-frontend/src/util/FileUtil.js
@@ -1,0 +1,11 @@
+export const checkRejectedFiles = (files, setHasRejectedDocuments) => {
+  let hasRejectedDoc = false;
+  if (files && files.length > 0) {
+    files.forEach((file) => {
+      if (file.actionDocument && file.actionDocument.status === "REJ") {
+        hasRejectedDoc = true;
+      }
+    });
+  }
+  setHasRejectedDocuments(hasRejectedDoc);
+};


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

[FLA-1378](https://justice.gov.bc.ca/jira/browse/FLA-1378)

Added a rejected document(s) banner on the Payments screen (aka Package Submission Details screen) whenever any of the supplied documents has a status of "REJ" that matches UX.

- moved checkRejectedFiles to common util file.
- updated snapshots

![image](https://user-images.githubusercontent.com/55215368/132400600-d7c52072-40d5-449b-a7f1-548a7fb7b64e.png)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

yarn lint
yarn test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
