### PR TITLE
FLA-1379 Added Rejected Document sidecard

### DIFF
--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/PackageConfirmation.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/PackageConfirmation.js
@@ -15,6 +15,7 @@ import { propTypes } from "../../../types/propTypes";
 import { onBackButtonEvent } from "../../../modules/helpers/handleBackEvent";
 import { generateFileSummaryData } from "../../../modules/helpers/generateFileSummaryData";
 import { isClick, isEnter } from "../../../modules/helpers/eventUtil";
+import { checkRejectedFiles } from "../../../util/FileUtil";
 
 import "./PackageConfirmation.scss";
 import Payment from "../../payment/Payment";
@@ -55,18 +56,6 @@ const getFilingPackageData = (
       );
       setShowToast(true);
     });
-};
-
-const checkRejectedFiles = (files, setHasRejectedDocuments) => {
-  let hasRejectedDoc = false;
-  if (files && files.length > 0) {
-    files.forEach((file) => {
-      if (file.actionDocument && file.actionDocument.status === "REJ") {
-        hasRejectedDoc = true;
-      }
-    });
-  }
-  setHasRejectedDocuments(hasRejectedDoc);
 };
 
 const checkDuplicateFileNames = (files, setShowToast, setToastMessage) => {

--- a/src/frontend/efiling-frontend/src/util/FileUtil.js
+++ b/src/frontend/efiling-frontend/src/util/FileUtil.js
@@ -1,0 +1,11 @@
+export const checkRejectedFiles = (files, setHasRejectedDocuments) => {
+  let hasRejectedDoc = false;
+  if (files && files.length > 0) {
+    files.forEach((file) => {
+      if (file.actionDocument && file.actionDocument.status === "REJ") {
+        hasRejectedDoc = true;
+      }
+    });
+  }
+  setHasRejectedDocuments(hasRejectedDoc);
+};


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

[FLA-1379](https://justice.gov.bc.ca/jira/browse/FLA-1379)

Added Rejected Documents sidecard to Payments screen (aka Package Submission Details screen) whenever any of the supplied documents has a status of "REJ". Actual text TBD.
- updated test snapshots.

![image](https://user-images.githubusercontent.com/55215368/132403224-54255e5e-7341-4cb3-a845-ea136628f10d.png)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

yarn lint
yarn test -u

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
