### PR TITLE
FLA-1395 Added test for duplicate doc from parent app

### DIFF
--- a/src/frontend/efiling-frontend/src/components/toast/Toast.js
+++ b/src/frontend/efiling-frontend/src/components/toast/Toast.js
@@ -1,8 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-export const Toast = ({ content, setShow }) => (
-  <div className="alert alert-danger alert-dismissible fade show" role="alert">
+export const Toast = ({ content, setShow, testId }) => (
+  <div
+    className="alert alert-danger alert-dismissible fade show"
+    role="alert"
+    data-testId={testId}
+  >
     {content}
     <button
       type="button"
@@ -20,4 +24,9 @@ export const Toast = ({ content, setShow }) => (
 Toast.propTypes = {
   content: PropTypes.string.isRequired,
   setShow: PropTypes.func.isRequired,
+  testId: PropTypes.string,
+};
+
+Toast.defaultProps = {
+  testId: "",
 };

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/PackageConfirmation.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/PackageConfirmation.js
@@ -219,7 +219,13 @@ export default function PackageConfirmation({
           </>
         )}
         <h1>Package Confirmation</h1>
-        {showToast && <Toast content={toastMessage} setShow={setShowToast} />}
+        {showToast && (
+          <Toast
+            testId="duplicateDocMsg"
+            content={toastMessage}
+            setShow={setShowToast}
+          />
+        )}
         <span>
           Review your package for accuracy and upload any additional or
           supporting documents.

--- a/src/frontend/efiling-frontend/src/domain/submission/submission-history/__snapshots__/SubmissionHistory.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/domain/submission/submission-history/__snapshots__/SubmissionHistory.stories.storyshot
@@ -35,6 +35,7 @@ exports[`Storyshots SubmissionHistory Default 1`] = `
       </button>
       <div
         class="alert alert-danger alert-dismissible fade show"
+        data-testid=""
         role="alert"
       >
         Something went wrong while trying to retrieve your submissions.

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/helpers/PayloadHelper.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/helpers/PayloadHelper.java
@@ -1,40 +1,53 @@
 package ca.bc.gov.open.jag.efiling.helpers;
 
+import ca.bc.gov.open.jag.efiling.models.FileSpec;
+
 public class PayloadHelper {
 
     private PayloadHelper() {
     }
 
-    public static String generateUrlPayload(String documentName, String actionStatus) {
+    public static String generateUrlPayload(FileSpec... fileSpecs) {
 
-        return "{\n" +
-                "    \"navigationUrls\": {\n" +
-                "        \"success\": \"http//somewhere.com\",\n" +
-                "        \"error\": \"http//somewhere.com\",\n" +
-                "        \"cancel\": \"http//somewhere.com\"\n" +
-                "    },\n" +
-                "    \"clientAppName\": \"my app\",\n" +
-                "    \"filingPackage\": {\n" +
-                "       \"packageIdentifier\": 1,\n" +
-                "        \"court\": {\n" +
-                "            \"location\": \"1211\",\n" +
-                "            \"level\": \"P\",\n" +
-                "            \"courtClass\": \"F\",\n" +
-                "            \"fileNumber\": \"1\"\n" +
-                "        },\n" +
-                "        \"documents\": [\n" +
-                "            {\n" +
-                "                \"name\": \"" + documentName + "\",\n" +
-                "                \"type\": \"AFF\",\n" +
-                "                \"statutoryFeeAmount\": 0,\n" +
-                "                \"data\": {},\n" +
-                "                \"md5\": \"string\", \n" +
-                "                \"actionDocument\": {\n" +
-                "                   \"id\": 2,\n" +
-                "                   \"status\": \"" + actionStatus + "\",\n" +
-                "                   \"type\": \"F\"\n" +
-                "               }\n" +
-                "            }\n" +
+    	StringBuffer sb = new StringBuffer();
+        sb.append(
+        		"{\n" +
+		        "    \"navigationUrls\": {\n" +
+		        "        \"success\": \"http//somewhere.com\",\n" +
+		        "        \"error\": \"http//somewhere.com\",\n" +
+		        "        \"cancel\": \"http//somewhere.com\"\n" +
+		        "    },\n" +
+		        "    \"clientAppName\": \"my app\",\n" +
+		        "    \"filingPackage\": {\n" +
+		        "       \"packageIdentifier\": 1,\n" +
+		        "        \"court\": {\n" +
+		        "            \"location\": \"1211\",\n" +
+		        "            \"level\": \"P\",\n" +
+		        "            \"courtClass\": \"F\",\n" +
+		        "            \"fileNumber\": \"1\"\n" +
+		        "        },\n" +
+		        "        \"documents\": [\n");
+        
+        for (int i = 0; i < fileSpecs.length; i++) {
+            if (i > 0) {
+            	sb.append(",");
+            }
+            sb.append(
+	            "            {\n" +
+	            "                \"name\": \"" + fileSpecs[i].getFilename() + "\",\n" +
+	            "                \"type\": \"AFF\",\n" +
+	            "                \"statutoryFeeAmount\": 0,\n" +
+	            "                \"data\": {},\n" +
+	            "                \"md5\": \"string\", \n" +
+	            "                \"actionDocument\": {\n" +
+	            "                   \"id\": 2,\n" +
+	            "                   \"status\": \"" + fileSpecs[i].getActionStatus() + "\",\n" +
+	            "                   \"type\": \"F\"\n" +
+	            "               }\n" +
+	            "            }\n");
+		}
+        
+        sb.append(
                 "        ],\n" +
                 "        \"parties\": [\n" +
                 "            {\n" +
@@ -46,7 +59,9 @@ public class PayloadHelper {
                 "            }\n" +
                 "        ]\n" +
                 "    }\n" +
-                "}";
+                "}");
+        
+    	return sb.toString();
 
     }
 

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/models/FileSpec.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/models/FileSpec.java
@@ -1,0 +1,29 @@
+package ca.bc.gov.open.jag.efiling.models;
+
+public class FileSpec {
+
+	private String filename;
+	private String actionStatus;
+	
+	public FileSpec(String filename, String actionStatus) {
+		this.filename = filename;
+		this.actionStatus = actionStatus;
+	}
+	
+	public String getFilename() {
+		return filename;
+	}
+	
+	public void setFilename(String filename) {
+		this.filename = filename;
+	}
+	
+	public String getActionStatus() {
+		return actionStatus;
+	}
+	
+	public void setActionStatus(String actionStatus) {
+		this.actionStatus = actionStatus;
+	}
+	
+}

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/page/PackageConfirmationPage.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/page/PackageConfirmationPage.java
@@ -83,6 +83,12 @@ public class PackageConfirmationPage extends BasePage {
     	return elements != null && !elements.isEmpty();
 	}
     
+    /** Returns true if the duplicate banner exists. */ 
+    public boolean duplicateBannerExists() { 
+    	List<WebElement> elements = driver.findElements(By.xpath("//div[@data-testId='duplicateDocMsg']")); 
+    	return elements != null && !elements.isEmpty();
+	}
+    
     /** Returns true if the rejected sidecard exists. */ 
     public boolean rejectedSidecardExists() { 
     	List<WebElement> elements = driver.findElements(By.id("rejectedDocumentsCard")); 

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/services/GenerateUrlService.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/services/GenerateUrlService.java
@@ -1,20 +1,22 @@
 package ca.bc.gov.open.jag.efiling.services;
 
-import ca.bc.gov.open.jag.efiling.Keys;
-import ca.bc.gov.open.jag.efiling.error.EfilingTestException;
-import ca.bc.gov.open.jag.efiling.helpers.SubmissionHelper;
-import ca.bc.gov.open.jag.efiling.models.UserIdentity;
-import io.restassured.path.json.JsonPath;
-import io.restassured.response.Response;
-import io.restassured.specification.MultiPartSpecification;
+import java.io.File;
+import java.io.IOException;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.core.io.ClassPathResource;
 
-import java.io.File;
-import java.io.IOException;
-import java.text.MessageFormat;
-import java.util.UUID;
+import ca.bc.gov.open.jag.efiling.helpers.SubmissionHelper;
+import ca.bc.gov.open.jag.efiling.models.FileSpec;
+import ca.bc.gov.open.jag.efiling.models.UserIdentity;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.Response;
+import io.restassured.specification.MultiPartSpecification;
 
 public class GenerateUrlService {
 
@@ -31,26 +33,20 @@ public class GenerateUrlService {
         actualTransactionId = UUID.randomUUID();
     }
 
-    public String getGeneratedUrl(String actionDocumentStatus) {
+    public String getGeneratedUrl(FileSpec... filespecs) throws IOException {
 
         UserIdentity actualUserIdentity = oauthService.getUserIdentity();
 
         logger.info("Submitting document upload request");
 
-        File resource = null;
-
-        try {
-            resource = new ClassPathResource(
-                    MessageFormat.format("data/{0}", Keys.TEST_DOCUMENT_PDF)).getFile();
-        } catch (IOException e) {
-            logger.error("Exception while getting test file");
-            throw new EfilingTestException("Exception while getting test file", e);
-        }
-
-        MultiPartSpecification fileSpec = SubmissionHelper.fileSpecBuilder(resource, Keys.TEST_DOCUMENT_PDF, "text/application.pdf");
+        List<MultiPartSpecification> multiPartSpecifications = new ArrayList<MultiPartSpecification>();
+        for (FileSpec fileSpec : filespecs) {
+            File resource = new ClassPathResource(MessageFormat.format("data/{0}", fileSpec.getFilename())).getFile();
+            multiPartSpecifications.add(SubmissionHelper.fileSpecBuilder(resource, fileSpec.getFilename(), "text/application.pdf"));
+		}
 
         Response actualDocumentResponse = submissionService.documentUploadResponse(actualUserIdentity.getAccessToken(), actualTransactionId,
-                actualUserIdentity.getUniversalId(), fileSpec);
+                actualUserIdentity.getUniversalId(), multiPartSpecifications.toArray(new MultiPartSpecification[0]));
 
         logger.info("Api response status code: {}", Integer.valueOf(actualDocumentResponse.getStatusCode()));
         logger.info("Api response: {}", actualDocumentResponse.asString());
@@ -59,7 +55,7 @@ public class GenerateUrlService {
         String actualSubmissionId = submissionService.getSubmissionId(actualDocumentResponse);
 
         Response actualGenerateUrlResponse = submissionService.generateUrlResponse(actualTransactionId, actualUserIdentity.getUniversalId(),
-                actualUserIdentity.getAccessToken(), actualSubmissionId, actionDocumentStatus);
+                actualUserIdentity.getAccessToken(), actualSubmissionId, filespecs);
 
         logger.info("Api response status code: {}", Integer.valueOf(actualDocumentResponse.getStatusCode()));
         logger.info("Api response: {}", actualDocumentResponse.asString());

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/services/SubmissionService.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/services/SubmissionService.java
@@ -4,6 +4,8 @@ import ca.bc.gov.open.jag.efiling.Keys;
 import ca.bc.gov.open.jag.efiling.error.EfilingTestException;
 import ca.bc.gov.open.jag.efiling.helpers.PayloadHelper;
 import ca.bc.gov.open.jag.efiling.helpers.SubmissionHelper;
+import ca.bc.gov.open.jag.efiling.models.FileSpec;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -31,15 +33,19 @@ public class SubmissionService {
 
     private final Logger logger = LoggerFactory.getLogger(SubmissionService.class);
 
-    public Response documentUploadResponse(String accessToken, UUID transactionId, String universalId, MultiPartSpecification fileSpec) {
+    public Response documentUploadResponse(String accessToken, UUID transactionId, String universalId, MultiPartSpecification... fileSpecs) {
 
         logger.info("Submitting document upload request to the host {}", eFilingHost);
 
         RequestSpecification request = RestAssured.given().auth().preemptive()
                 .oauth2(accessToken)
                 .header(Keys.X_TRANSACTION_ID, transactionId)
-                .header(Keys.X_USER_ID, universalId)
-                .multiPart(fileSpec);
+                .header(Keys.X_USER_ID, universalId);
+        
+        // Add a fileSpec for each file.
+        for (MultiPartSpecification fileSpec : fileSpecs) {
+        	request = request.multiPart(fileSpec);
+		}
 
         return request.when().post(MessageFormat.format("{0}/{1}", eFilingHost, Keys.SUBMISSION_DOCUMENTS_PATH))
                 .then()
@@ -49,6 +55,11 @@ public class SubmissionService {
 
     public Response generateUrlResponse(UUID transactionId, String universalId, String accessToken,
                                          String submissionId, String actionStatus) {
+    	return generateUrlResponse(transactionId, universalId, accessToken, submissionId, new FileSpec(Keys.TEST_DOCUMENT_PDF, actionStatus));
+    }
+    
+    public Response generateUrlResponse(UUID transactionId, String universalId, String accessToken,
+                                         String submissionId, FileSpec... filespecs) {
 
         logger.info("Requesting to generate Url");
 
@@ -60,7 +71,7 @@ public class SubmissionService {
                 .contentType(ContentType.JSON)
                 .header(Keys.X_TRANSACTION_ID, transactionId)
                 .header(Keys.X_USER_ID, universalId)
-                .body(PayloadHelper.generateUrlPayload(Keys.TEST_DOCUMENT_PDF, actionStatus));
+                .body(PayloadHelper.generateUrlPayload(filespecs));
 
         return request
                 .when()

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/AuthenticateAndRedirectToEfilingHubSD.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/AuthenticateAndRedirectToEfilingHubSD.java
@@ -1,11 +1,11 @@
 
 package ca.bc.gov.open.jag.efiling.stepDefinitions;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
 
-import java.io.FileNotFoundException;
+import java.io.IOException;
 
 import org.junit.Assert;
 import org.slf4j.Logger;
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Value;
 
 import ca.bc.gov.open.jag.efiling.Keys;
 import ca.bc.gov.open.jag.efiling.error.EfilingTestException;
+import ca.bc.gov.open.jag.efiling.models.FileSpec;
 import ca.bc.gov.open.jag.efiling.page.AuthenticationPage;
 import ca.bc.gov.open.jag.efiling.page.EfilingAdminHomePage;
 import ca.bc.gov.open.jag.efiling.page.PackageConfirmationPage;
@@ -43,18 +44,32 @@ public class AuthenticateAndRedirectToEfilingHubSD {
     }
 
     @Given("User uploads a successful document from parent app")
-    public void userUploadsSuccessfulDocument() throws FileNotFoundException {
-    	userUploadsDocumentFromParentApp(Keys.ACTION_STATUS_SUB);
+    public void userUploadsSuccessfulDocument() throws IOException {
+    	userUploadsDocumentFromParentApp(new FileSpec(Keys.TEST_DOCUMENT_PDF, Keys.ACTION_STATUS_SUB));
     }
 
     @Given("User uploads a rejected document from parent app")
-    public void userUploadsRejectedDocument() throws FileNotFoundException {
-    	userUploadsDocumentFromParentApp(Keys.ACTION_STATUS_REJ);
+    public void userUploadsRejectedDocument() throws IOException {
+    	userUploadsDocumentFromParentApp(new FileSpec(Keys.TEST_DOCUMENT_PDF, Keys.ACTION_STATUS_REJ));
+    }
+
+    @Given("User uploads duplicate documents from parent app")
+    public void userUploadsDuplicateDocuments() throws IOException {
+    	userUploadsDocumentFromParentApp(
+    			new FileSpec(Keys.TEST_DOCUMENT_PDF, Keys.ACTION_STATUS_SUB),
+    			new FileSpec(Keys.TEST_DOCUMENT_PDF, Keys.ACTION_STATUS_SUB));
+    }
+
+    @Given("User uploads different documents from parent app")
+    public void userUploadsDifferentDocuments() throws IOException {
+    	userUploadsDocumentFromParentApp(
+    			new FileSpec(Keys.TEST_DOCUMENT_PDF, Keys.ACTION_STATUS_SUB),
+    			new FileSpec(Keys.SECOND_DOCUMENT_PDF, Keys.ACTION_STATUS_SUB));
     }
     
-	private void userUploadsDocumentFromParentApp(String actionDocumentStatus) throws FileNotFoundException {
+	private void userUploadsDocumentFromParentApp(FileSpec... fileSpecs) throws IOException {
 		if (this.authenticationPage.getName().equalsIgnoreCase("keycloak")) {
-			String generatedUrl = this.generateUrlService.getGeneratedUrl(actionDocumentStatus);
+			String generatedUrl = this.generateUrlService.getGeneratedUrl(fileSpecs);
 			if (generatedUrl == null)
 				throw new EfilingTestException("Redirect url is not generated.");
 			this.efilingAdminHomePage.goTo(generatedUrl);
@@ -90,6 +105,16 @@ public class AuthenticateAndRedirectToEfilingHubSD {
     @And("Rejected Document banner doesn't exist")
     public void verifyRejectedBannerNotExists() {
     	assertFalse(packageConfirmationPage.rejectedBannerExists());
+    }
+    
+    @And("Duplicate Document banner exists")
+    public void verifyDuplicateDocumentBannerExists() {
+    	assertTrue(packageConfirmationPage.duplicateBannerExists());
+    }
+    
+    @And("Duplicate Document banner doesn't exist")
+    public void verifyDuplicateDocumentNotBannerExists() {
+    	assertFalse(packageConfirmationPage.duplicateBannerExists());
     }
     
     @And("Rejected Document sidecard exists")

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/GenerateUrlSD.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/GenerateUrlSD.java
@@ -77,7 +77,7 @@ public class GenerateUrlSD {
         logger.info("Asserting document upload response");
 
         JsonPath jsonPath = new JsonPath(actualDocumentResponse.asString());
-        Assert.assertEquals(Integer.valueOf(1), jsonPath.get("received"));
+        Assert.assertTrue(((Integer) jsonPath.get("received")).intValue() >= 1);
 
         actualSubmissionId = submissionService.getSubmissionId(actualDocumentResponse);
 

--- a/tests/src/test/resources/features/packageConfirmationDupDoc.feature
+++ b/tests/src/test/resources/features/packageConfirmationDupDoc.feature
@@ -1,0 +1,15 @@
+# new feature
+# Tags: optional
+
+@frontend
+Feature: User uploads files with the same name from parent app
+
+  Scenario: User uploads files with the same name from parent app
+    Given User uploads duplicate documents from parent app
+    Then Package information is displayed
+    And Duplicate Document banner exists
+
+  Scenario: User uploads files with different names from parent app
+    Given User uploads different documents from parent app
+    Then Package information is displayed
+    And Duplicate Document banner doesn't exist

--- a/tests/src/test/resources/features/uploadRejectedDocuments.feature
+++ b/tests/src/test/resources/features/uploadRejectedDocuments.feature
@@ -1,7 +1,6 @@
 # new feature
 # Tags: optional
 
-@current
 @frontend
 Feature: Rejected documents uploaded from Parent App show rejected banner/sidecard
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

[FLA-1395](https://justice.gov.bc.ca/jira/browse/FLA-1395)

Added regression tests to confirm documents with the same name uploaded via the parent app produces an error message on the Package Confirmation screen.

- refactored tests to accept multiple files instead of just one
- added a data-testId to frontend Toast to isolate and test the existence of the `<div />`, updated snapshots

![image](https://user-images.githubusercontent.com/55215368/132595522-c282c53f-2561-4c94-8321-2447dd054fab.png)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
