### PR TITLE
FLA-1304 Added Rush regression tests

### DIFF
--- a/src/frontend/efiling-frontend/src/components/page/home/__snapshots__/Home.test.js.snap
+++ b/src/frontend/efiling-frontend/src/components/page/home/__snapshots__/Home.test.js.snap
@@ -1188,6 +1188,7 @@ exports[`Home Component matches the snapshot when user cso account exists 1`] = 
       <br />
       <div
         class="bcgov-row"
+        data-testid="rushRadioOpts"
       >
         <span>
           Do you want to request that this submission be processed on a 

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/PackageConfirmation.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/PackageConfirmation.js
@@ -269,7 +269,7 @@ export default function PackageConfirmation({
           </span>
         </h4>
         <br />
-        <div className="bcgov-row">
+        <div className="bcgov-row" data-testId="rushRadioOpts">
           <span>
             Do you want to request that this submission be processed on a{" "}
             <b>rush basis?</b>

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__snapshots__/PackageConfirmation.stories.storyshot
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__snapshots__/PackageConfirmation.stories.storyshot
@@ -175,6 +175,7 @@ exports[`Storyshots PackageConfirmation Existing Account 1`] = `
       <br />
       <div
         class="bcgov-row"
+        data-testid="rushRadioOpts"
       >
         <span>
           Do you want to request that this submission be processed on a 
@@ -723,6 +724,7 @@ exports[`Storyshots PackageConfirmation Mobile 1`] = `
       <br />
       <div
         class="bcgov-row"
+        data-testid="rushRadioOpts"
       >
         <span>
           Do you want to request that this submission be processed on a 
@@ -1302,6 +1304,7 @@ exports[`Storyshots PackageConfirmation New Account 1`] = `
       <br />
       <div
         class="bcgov-row"
+        data-testid="rushRadioOpts"
       >
         <span>
           Do you want to request that this submission be processed on a 

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__tests__/__snapshots__/PackageConfirmation.test.js.snap
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__tests__/__snapshots__/PackageConfirmation.test.js.snap
@@ -175,6 +175,7 @@ exports[`PackageConfirmation Component Matches the existing account snapshot 1`]
       <br />
       <div
         class="bcgov-row"
+        data-testid="rushRadioOpts"
       >
         <span>
           Do you want to request that this submission be processed on a 
@@ -754,6 +755,7 @@ exports[`PackageConfirmation Component Matches the new account snapshot 1`] = `
       <br />
       <div
         class="bcgov-row"
+        data-testid="rushRadioOpts"
       >
         <span>
           Do you want to request that this submission be processed on a 
@@ -2020,6 +2022,7 @@ exports[`PackageConfirmation Component On keydown of Upload them now text, it re
       <br />
       <div
         class="bcgov-row"
+        data-testid="rushRadioOpts"
       >
         <span>
           Do you want to request that this submission be processed on a 

--- a/src/frontend/efiling-frontend/src/domain/payment/__tests__/__snapshots__/Payment.test.js.snap
+++ b/src/frontend/efiling-frontend/src/domain/payment/__tests__/__snapshots__/Payment.test.js.snap
@@ -1204,6 +1204,7 @@ exports[`Payment Component On back click, it redirects back to the package confi
       <br />
       <div
         class="bcgov-row"
+        data-testid="rushRadioOpts"
       >
         <span>
           Do you want to request that this submission be processed on a 

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/RunCucumberTest.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/RunCucumberTest.java
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.ComponentScan;
          features = {"src/test/resources"},
          glue ={"ca.bc.gov.open.jag.efiling"},
          monochrome = true,
+//         tags = "@current", // uncomment to run specific tests
          plugin = {
                  "pretty",
                  "html:target/cucumber-reports/cucumber-pretty",

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/page/PackageConfirmationPage.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/page/PackageConfirmationPage.java
@@ -31,6 +31,9 @@ public class PackageConfirmationPage extends BasePage {
     @FindBy(xpath = "//span[@data-test-id='uploaded-file']")
     private List<WebElement> uploadedFiles;
 
+    @FindBy(xpath = "//label[@for='Yes']")
+    private WebElement rushYesRadioBtn;
+
     //Actions:
     public boolean verifyContinuePaymentBtnIsEnabled() {
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//button[@data-testid='continue-btn']")));
@@ -44,6 +47,11 @@ public class PackageConfirmationPage extends BasePage {
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//button[@data-testid='continue-btn']")));
         continuePaymentBtn.click();
     }
+
+    /** Clicks the Yes radio button for the label "Do you want to request that this submission be processed on a rush basis?" */
+	public void selectRushYesOption() {
+		rushYesRadioBtn.click();
+	}
 
     public String getInitialDocumentName() {
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//span[@data-test-id='uploaded-file']")));
@@ -83,9 +91,21 @@ public class PackageConfirmationPage extends BasePage {
     	return elements != null && !elements.isEmpty();
 	}
     
+    /** Returns true if the "rush basis" radio options exist. */ 
+    public boolean rushRadioOptionsExist() { 
+    	List<WebElement> elements = driver.findElements(By.xpath("//div[@data-testid='rushRadioOpts']")); 
+    	return elements != null && !elements.isEmpty();
+	}
+    
+    /** Returns true if the Rush sidecard is visible. */ 
+    public boolean rushSideCardExist() { 
+    	List<WebElement> elements = driver.findElements(By.id("rushSubmissionCard")); 
+    	return elements != null && !elements.isEmpty();
+	}
+    
     /** Returns true if the duplicate banner exists. */ 
     public boolean duplicateBannerExists() { 
-    	List<WebElement> elements = driver.findElements(By.xpath("//div[@data-testId='duplicateDocMsg']")); 
+    	List<WebElement> elements = driver.findElements(By.xpath("//div[@data-testid='duplicateDocMsg']")); 
     	return elements != null && !elements.isEmpty();
 	}
     

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/AuthenticateAndRedirectToEfilingHubSD.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/AuthenticateAndRedirectToEfilingHubSD.java
@@ -22,6 +22,7 @@ import ca.bc.gov.open.jag.efiling.services.GenerateUrlService;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class AuthenticateAndRedirectToEfilingHubSD {
 
@@ -87,6 +88,11 @@ public class AuthenticateAndRedirectToEfilingHubSD {
 		}
 	}
 
+	@When("Rush radio option Yes is selected")
+	public void rushRadioYesIsSelected() {
+		packageConfirmationPage.selectRushYesOption();
+	}
+	
     @Then("Package information is displayed")
     public void verifyPackageInformation() {
         assertEquals(Keys.EFILE_SUBMISSION_PAGE_TITLE, this.packageConfirmationPage.verifyPageTitle());
@@ -94,7 +100,21 @@ public class AuthenticateAndRedirectToEfilingHubSD {
 
         assertEquals(Keys.TEST_DOCUMENT_PDF, this.packageConfirmationPage.getInitialDocumentName());
         logger.info("Actual document name matches the uploaded document name");
-
+    }
+    
+    @And("Rush radio options are available")
+    public void rushRadioOptionsAvailable() {
+    	assertTrue(packageConfirmationPage.rushRadioOptionsExist());
+    }
+    
+    @And("Rush sidecard is visible")
+    public void rushSidecardIsVisible() {
+    	assertTrue(packageConfirmationPage.rushSideCardExist());
+    }
+    
+    @And("Rush sidecard is not visible")
+    public void rushSidecardIsNotVisible() {
+    	assertFalse(packageConfirmationPage.rushSideCardExist());
     }
     
     @And("Rejected Document banner exists")

--- a/tests/src/test/resources/features/rushProcessing.feature
+++ b/tests/src/test/resources/features/rushProcessing.feature
@@ -1,0 +1,18 @@
+# new feature
+# Tags: optional
+
+@frontend
+Feature: Rush processing screen
+
+  Scenario: Verify the rush option appears on the Package Confirmation screen
+    Given User uploads a successful document from parent app
+    And Package information is displayed
+    Then Rush radio options are available
+    And Rush sidecard is not visible
+
+  Scenario: Verify the rush sidecard appears on the Package Confirmation screen
+    Given User uploads a successful document from parent app
+    And Package information is displayed
+    When Rush radio option Yes is selected
+    Then Rush sidecard is visible
+    


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

[FLA-1304](https://justice.gov.bc.ca/jira/browse/FLA-1304)

Initial set of tests to confirm Rush processing.
This PR is just to add 2 test scenarios.  I added a test-id to the frontend to expose the rush radio button group, which needed to have the snapshots updated.

  **Scenario**: Verify the rush option appears on the Package Confirmation screen
    **Given** User uploads a successful document from parent app
    **And** Package information is displayed
    **Then** Rush radio options are available
    **And** Rush sidecard is not visible

  **Scenario**: Verify the rush sidecard appears on the Package Confirmation screen
    **Given** User uploads a successful document from parent app
    **And** Package information is displayed
    **When** Rush radio option Yes is selected
    **Then** Rush sidecard is visible

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change
- [x] Tests

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn verify

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
