### PR TITLE
FLA-1304 added regression test

### DIFF
--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/page/PackageConfirmationPage.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/page/PackageConfirmationPage.java
@@ -1,7 +1,9 @@
 package ca.bc.gov.open.jag.efiling.page;
 
 
-import ca.bc.gov.open.jag.efiling.error.EfilingTestException;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
@@ -11,8 +13,7 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
+import ca.bc.gov.open.jag.efiling.error.EfilingTestException;
 
 public class PackageConfirmationPage extends BasePage {
 
@@ -20,7 +21,7 @@ public class PackageConfirmationPage extends BasePage {
 
     //Page Objects:
     @FindBy(xpath = "//button[@data-testid='continue-btn']")
-    private WebElement continuePaymentBtn;
+    private WebElement continueBtn;
 
     @FindBy(xpath = "//*[@data-test-id='upload-link']")
     private WebElement uploadLink;
@@ -33,19 +34,22 @@ public class PackageConfirmationPage extends BasePage {
 
     @FindBy(xpath = "//label[@for='Yes']")
     private WebElement rushYesRadioBtn;
+    
+    @FindBy(xpath = "//div[contains(@class, 'modal-header')]/button[@class='close']")
+    private WebElement rushModalCloseBtn;
 
     //Actions:
     public boolean verifyContinuePaymentBtnIsEnabled() {
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//button[@data-testid='continue-btn']")));
 
-        if (!continuePaymentBtn.isDisplayed())
+        if (!continueBtn.isDisplayed())
             throw new EfilingTestException("User may not have a CSO account created");
-        return continuePaymentBtn.isEnabled();
+        return continueBtn.isEnabled();
     }
 
-    public void clickContinuePaymentBtn() {
+    public void clickContinueBtn() {
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//button[@data-testid='continue-btn']")));
-        continuePaymentBtn.click();
+        continueBtn.click();
     }
 
     /** Clicks the Yes radio button for the label "Do you want to request that this submission be processed on a rush basis?" */
@@ -86,33 +90,51 @@ public class PackageConfirmationPage extends BasePage {
     }
     
     /** Returns true if the rejected banner exists. */ 
-    public boolean rejectedBannerExists() { 
+    public boolean verifyRejectedBannerExists() { 
     	List<WebElement> elements = driver.findElements(By.className("rejectedMsg")); 
     	return elements != null && !elements.isEmpty();
 	}
     
     /** Returns true if the "rush basis" radio options exist. */ 
-    public boolean rushRadioOptionsExist() { 
+    public boolean verifyRushRadioOptionsExist() { 
     	List<WebElement> elements = driver.findElements(By.xpath("//div[@data-testid='rushRadioOpts']")); 
     	return elements != null && !elements.isEmpty();
 	}
     
     /** Returns true if the Rush sidecard is visible. */ 
-    public boolean rushSideCardExist() { 
+    public boolean verifyRushSideCardExist() { 
     	List<WebElement> elements = driver.findElements(By.id("rushSubmissionCard")); 
     	return elements != null && !elements.isEmpty();
 	}
     
     /** Returns true if the duplicate banner exists. */ 
-    public boolean duplicateBannerExists() { 
+    public boolean verifyDuplicateBannerExists() { 
     	List<WebElement> elements = driver.findElements(By.xpath("//div[@data-testid='duplicateDocMsg']")); 
     	return elements != null && !elements.isEmpty();
 	}
     
     /** Returns true if the rejected sidecard exists. */ 
-    public boolean rejectedSidecardExists() { 
+    public boolean verifyRejectedSidecardExists() { 
     	List<WebElement> elements = driver.findElements(By.id("rejectedDocumentsCard")); 
     	return elements != null && !elements.isEmpty();
 	}
+
+    /** Returns true if the Rush modal is visible. */ 
+    public boolean verifyRushModalIsDisplayed() {  	
+    	List<WebElement> elements = driver.findElements(By.xpath("//div[contains(@class, 'modal-header')]/div/h2[text()='Rush Documents']"));
+    	return elements != null && !elements.isEmpty();
+    }
+
+    /** Returns true if the Rush modal is visible. */ 
+    public void clickCloseOnRushModal() {  	
+    	rushModalCloseBtn.click();
+    }
+
+	public boolean verifyRushDetailsScreenIsDisplayed() {
+    	List<WebElement> elements = driver.findElements(By.xpath("//div[contains(@class, 'ct-rush')]")); // the main Rush div
+    	return elements != null && !elements.isEmpty();
+	}
+    
+    
     
 }

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/page/PackageConfirmationPage.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/page/PackageConfirmationPage.java
@@ -125,16 +125,14 @@ public class PackageConfirmationPage extends BasePage {
     	return elements != null && !elements.isEmpty();
     }
 
-    /** Returns true if the Rush modal is visible. */ 
-    public void clickCloseOnRushModal() {  	
-    	rushModalCloseBtn.click();
+    /** Returns true if the Rush modal is visible. */
+    public void clickCloseOnRushModal() {
+        rushModalCloseBtn.click();
     }
 
-	public boolean verifyRushDetailsScreenIsDisplayed() {
-    	List<WebElement> elements = driver.findElements(By.xpath("//div[contains(@class, 'ct-rush')]")); // the main Rush div
-    	return elements != null && !elements.isEmpty();
-	}
-    
-    
-    
+    public boolean verifyRushDetailsScreenIsDisplayed() {
+        List<WebElement> elements = driver.findElements(By.xpath("//div[contains(@class, 'ct-rush')]")); // the main Rush div
+        return elements != null && !elements.isEmpty();
+    }
+
 }

--- a/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/AuthenticateAndRedirectToEfilingHubSD.java
+++ b/tests/src/test/java/ca/bc/gov/open/jag/efiling/stepDefinitions/AuthenticateAndRedirectToEfilingHubSD.java
@@ -92,6 +92,11 @@ public class AuthenticateAndRedirectToEfilingHubSD {
 	public void rushRadioYesIsSelected() {
 		packageConfirmationPage.selectRushYesOption();
 	}
+    
+	@When("Rush model is closed")
+    public void rushModelIsClosed() {
+    	packageConfirmationPage.clickCloseOnRushModal();
+    }
 	
     @Then("Package information is displayed")
     public void verifyPackageInformation() {
@@ -104,52 +109,68 @@ public class AuthenticateAndRedirectToEfilingHubSD {
     
     @And("Rush radio options are available")
     public void rushRadioOptionsAvailable() {
-    	assertTrue(packageConfirmationPage.rushRadioOptionsExist());
+    	assertTrue(packageConfirmationPage.verifyRushRadioOptionsExist());
     }
     
     @And("Rush sidecard is visible")
     public void rushSidecardIsVisible() {
-    	assertTrue(packageConfirmationPage.rushSideCardExist());
+    	assertTrue(packageConfirmationPage.verifyRushSideCardExist());
     }
     
     @And("Rush sidecard is not visible")
     public void rushSidecardIsNotVisible() {
-    	assertFalse(packageConfirmationPage.rushSideCardExist());
+    	assertFalse(packageConfirmationPage.verifyRushSideCardExist());
     }
     
     @And("Rejected Document banner exists")
     public void verifyRejectedBannerExists() {
-    	assertTrue(packageConfirmationPage.rejectedBannerExists());
+    	assertTrue(packageConfirmationPage.verifyRejectedBannerExists());
     }
     
     @And("Rejected Document banner doesn't exist")
     public void verifyRejectedBannerNotExists() {
-    	assertFalse(packageConfirmationPage.rejectedBannerExists());
+    	assertFalse(packageConfirmationPage.verifyRejectedBannerExists());
     }
     
     @And("Duplicate Document banner exists")
     public void verifyDuplicateDocumentBannerExists() {
-    	assertTrue(packageConfirmationPage.duplicateBannerExists());
+    	assertTrue(packageConfirmationPage.verifyDuplicateBannerExists());
     }
     
     @And("Duplicate Document banner doesn't exist")
     public void verifyDuplicateDocumentNotBannerExists() {
-    	assertFalse(packageConfirmationPage.duplicateBannerExists());
+    	assertFalse(packageConfirmationPage.verifyDuplicateBannerExists());
     }
     
     @And("Rejected Document sidecard exists")
     public void verifyRejectedSideCardExists() {
-    	assertTrue(packageConfirmationPage.rejectedSidecardExists());
+    	assertTrue(packageConfirmationPage.verifyRejectedSidecardExists());
     }
     
     @And("Rejected Document sidecard doesn't exist")
     public void verifyRejectedSideCardNotExists() {
-    	assertFalse(packageConfirmationPage.rejectedSidecardExists());
+    	assertFalse(packageConfirmationPage.verifyRejectedSidecardExists());
     }
 
-    @And("continue to payment button is enabled")
+    @And("Continue to payment button is enabled")
     public void verifyContinueToPaymentButtonIsEnabled() {
         Assert.assertTrue(this.packageConfirmationPage.verifyContinuePaymentBtnIsEnabled());
         logger.info("Continue payment button is enabled");
+    }
+
+    @And("User clicks Continue")
+    public void userClicksContinue() {
+        Assert.assertTrue(packageConfirmationPage.verifyContinuePaymentBtnIsEnabled());
+        packageConfirmationPage.clickContinueBtn();
+    }
+
+    @Then("Rush modal is displayed")
+    public void rushModalIsDisplayed() {
+        Assert.assertTrue(packageConfirmationPage.verifyRushModalIsDisplayed());
+    }
+    
+    @And("Rush Details screen is displayed")
+    public void rushDetailsScreenIsDisplayed() {
+        Assert.assertTrue(packageConfirmationPage.verifyRushDetailsScreenIsDisplayed());
     }
 }

--- a/tests/src/test/resources/features/authenticateAndRedirectToEfilingHub.feature
+++ b/tests/src/test/resources/features/authenticateAndRedirectToEfilingHub.feature
@@ -7,4 +7,4 @@ Feature: User account is validated and redirected to E-Filing hub
   Scenario: Validate user with valid BCEID or BCSC and CSO accounts is redirected E-Filing hub
     Given User uploads a successful document from parent app
     Then Package information is displayed
-    And continue to payment button is enabled
+    And Continue to payment button is enabled

--- a/tests/src/test/resources/features/rushProcessing.feature
+++ b/tests/src/test/resources/features/rushProcessing.feature
@@ -16,3 +16,13 @@ Feature: Rush processing screen
     When Rush radio option Yes is selected
     Then Rush sidecard is visible
     
+  Scenario: Proceed to Rush Processing from Package Confirmation screen
+    Given User uploads a successful document from parent app
+    And Package information is displayed
+    And Rush radio option Yes is selected
+    And Continue to payment button is enabled
+    When User clicks Continue
+    Then Rush modal is displayed
+    Then Rush model is closed
+    And Rush Details screen is displayed
+    


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

[FLA-1304](https://justice.gov.bc.ca/jira/browse/FLA-1304)

Added regression test to confirm rush modal appears and Rush screen is shown when modal is closed.
A little renaming of methods to be consistent.

```
  Scenario: Proceed to Rush Processing from Package Confirmation screen
    Given User uploads a successful document from parent app
    And Package information is displayed
    And Rush radio option Yes is selected
    And Continue to payment button is enabled
    When User clicks Continue
    Then Rush modal is displayed
    Then Rush model is closed
    And Rush Details screen is displayed
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change
- [x] Tests

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn verify

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
