### PR TITLE
Hide rush radio buttons and set rush display to Yes when POR document is in the package

### DIFF
--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/PackageConfirmation.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/PackageConfirmation.js
@@ -85,6 +85,14 @@ const checkDuplicateFileNames = (files, setShowToast, setToastMessage) => {
   }
 };
 
+const checkPorDocument = (files, setHasPorDocument) => {
+  files.forEach((file) => {
+    if (file.documentProperties.type === "POR") {
+      setHasPorDocument(true);
+    }
+  });
+};
+
 export default function PackageConfirmation({
   packageConfirmation: { confirmationPopup, submissionId },
   csoAccountStatus: { isNew },
@@ -100,6 +108,7 @@ export default function PackageConfirmation({
   const [showRush, setShowRush] = useState(false);
   const [showModal, setShowModal] = useState(false);
   const [isRush, setIsRush] = useState(false);
+  const [hasPorDocument, setHasPorDocument] = useState(false);
   const aboutCsoSidecard = getSidecardData().aboutCso;
   const csoAccountDetailsSidecard = getSidecardData().csoAccountDetails;
   const rushSubmissionSidecard = getSidecardData().rushSubmission;
@@ -153,6 +162,7 @@ export default function PackageConfirmation({
 
     checkDuplicateFileNames(files, setShowToast, setToastMessage);
     checkRejectedFiles(files, setHasRejectedDocuments);
+    checkPorDocument(files, setHasPorDocument);
   }, [files, submissionId, showUpload, refreshFiles]);
 
   function handleUploadFile(e) {
@@ -272,7 +282,7 @@ export default function PackageConfirmation({
             Upload them now.
           </span>
         </h4>
-        {rushFeatureFlag === "true" && (
+        {rushFeatureFlag === "true" && hasPorDocument === false && (
           <>
             <br />
             <div className="bcgov-row" data-testId="rushRadioOpts">
@@ -302,7 +312,13 @@ export default function PackageConfirmation({
         <div className="near-half-width">
           <Table
             elements={
-              generateFileSummaryData(isRush, files, submissionFee, false).data
+              generateFileSummaryData(
+                isRush,
+                files,
+                submissionFee,
+                false,
+                hasPorDocument
+              ).data
             }
           />
         </div>

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__tests__/PackageConfirmation.test.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__tests__/PackageConfirmation.test.js
@@ -3,11 +3,13 @@ import React from "react";
 import axios from "axios";
 import FileSaver from "file-saver";
 import MockAdapter from "axios-mock-adapter";
+import { act } from "react-dom/test-utils";
 import { render, waitFor, fireEvent, getByText } from "@testing-library/react";
 import { getTestData } from "../../../../modules/test-data/confirmationPopupTestData";
 import {
   getDocumentsData,
   getDuplicateDocumentsData,
+  getPorDocumentsData,
 } from "../../../../modules/test-data/documentTestData";
 import { getCourtData } from "../../../../modules/test-data/courtTestData";
 import { generateJWTToken } from "../../../../modules/helpers/authentication-helper/authenticationHelper";
@@ -22,6 +24,7 @@ describe("PackageConfirmation Component", () => {
   const csoAccountStatus = { isNew: false };
   const documents = getDocumentsData();
   const duplicateDocuments = getDuplicateDocumentsData();
+  const porDocuments = getPorDocumentsData();
 
   const file = {
     documentProperties: {
@@ -319,6 +322,29 @@ describe("PackageConfirmation Component", () => {
 
     // assert here what was being done in callback
     expect(getByText(container, "Package Confirmation")).toBeInTheDocument();
+  });
+
+  test("Rush is set to yes and radio buttons are hidden when a POR document is in the package", async () => {
+    const promise = Promise.resolve();
+    mock
+      .onGet(apiRequest)
+      .reply(200, { documents: porDocuments, court, submissionFeeAmount });
+
+    const { getByText, queryByTestId } = render(
+      <PackageConfirmation
+        packageConfirmation={packageConfirmation}
+        csoAccountStatus={csoAccountStatus}
+      />
+    );
+
+    await act(() => promise);
+
+    const rushRadioButtons = queryByTestId("rushRadioOpts");
+
+    const rushStatus = getByText("Yes");
+
+    expect(rushRadioButtons).not.toBeInTheDocument();
+    expect(rushStatus).toBeInTheDocument();
   });
 
   test("take user directly to payment page when coming from bambora redirect", async () => {

--- a/src/frontend/efiling-frontend/src/modules/helpers/generateFileSummaryData.js
+++ b/src/frontend/efiling-frontend/src/modules/helpers/generateFileSummaryData.js
@@ -28,7 +28,8 @@ function generateTableContent(
   isRush,
   numDocuments,
   totalStatFee,
-  submissionFee
+  submissionFee,
+  hasPorDocument
 ) {
   const rushFeatureFlag = window.env
     ? window.env.REACT_APP_RUSH_TAB_FEATURE_FLAG
@@ -37,15 +38,16 @@ function generateTableContent(
     return [
       {
         name: "Rush Processing:",
-        value: isRush ? (
-          <span style={{ color: "red" }}>
-            <b>Yes</b>
-          </span>
-        ) : (
-          <span>
-            <b>No</b>
-          </span>
-        ),
+        value:
+          isRush || hasPorDocument ? (
+            <span style={{ color: "red" }}>
+              <b>Yes</b>
+            </span>
+          ) : (
+            <span>
+              <b>No</b>
+            </span>
+          ),
         isValueBold: true,
       },
       {
@@ -92,7 +94,8 @@ export function generateFileSummaryData(
   isRush,
   files,
   submissionFee,
-  withTotal
+  withTotal,
+  hasPorDocument
 ) {
   const totalStatFee = calculateTotalStatFee(files);
   const totalOverallFee = calculateTotalFee(totalStatFee, submissionFee);
@@ -101,7 +104,8 @@ export function generateFileSummaryData(
     isRush,
     numDocuments,
     totalStatFee,
-    submissionFee
+    submissionFee,
+    hasPorDocument
   );
 
   if (withTotal) {

--- a/src/frontend/efiling-frontend/src/modules/test-data/documentTestData.js
+++ b/src/frontend/efiling-frontend/src/modules/test-data/documentTestData.js
@@ -73,6 +73,39 @@ const jsonDocuments = [
   },
 ];
 
+const porDocuments = [
+  {
+    description: "file description 1",
+    documentProperties: {
+      name: "file name 1",
+      type: "POR",
+    },
+    name: "file name 1",
+    isAmendment: null,
+    isSupremeCourtScheduling: null,
+    mimeType: "application/pdf",
+    statutoryFeeAmount: 40,
+    actionDocument: {
+      status: "SUB",
+    },
+  },
+  {
+    description: "file description 2",
+    documentProperties: {
+      name: "file name 2",
+      type: "POR",
+    },
+    name: "file name 2",
+    isAmendment: false,
+    isSupremeCourtScheduling: true,
+    mimeType: "application/pdf",
+    statutoryFeeAmount: 0,
+    actionDocument: {
+      status: "REJ",
+    },
+  },
+];
+
 export function getDocumentsData() {
   return documents;
 }
@@ -83,4 +116,8 @@ export function getDuplicateDocumentsData() {
 
 export function getJsonDocumentsData() {
   return jsonDocuments;
+}
+
+export function getPorDocumentsData() {
+  return porDocuments;
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

FLA-1409
- When there is a document with type "POR", hide the rush radio buttons and set the rush status to Yes in the details display

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Unit tests, manual testing.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
