### PR TITLE
Updated rush tab on package review screen

### DIFF
--- a/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.js
@@ -116,6 +116,7 @@ export default function PackageReview() {
   const [isProtectionOrder, setIsProtectionOrder] = useState(false);
   const [rushDetails, setRushDetails] = useState([]);
   const [supportingDocuments, setSupportingDocuments] = useState([]);
+  const [rushStatus, setRushStatus] = useState("");
   const [tabKey, setTabKey] = useState("");
   const aboutCsoSidecard = getSidecardData().aboutCso;
   const csoAccountDetailsSidecard = getSidecardData().csoAccountDetails;
@@ -251,8 +252,15 @@ export default function PackageReview() {
                   isNameBold: false,
                   isValueBold: true,
                 },
+                {
+                  name: "Registry Notice:",
+                  value: response.data.hasRegistryNotice ? "Yes" : "No",
+                  isNameBold: false,
+                  isValueBold: true,
+                },
               ]);
               setSupportingDocuments(rushResponse.supportingDocuments);
+              setRushStatus(rushResponse.status);
 
               if (tabKey === "") {
                 setTabKey(
@@ -428,6 +436,7 @@ export default function PackageReview() {
                   <SupportingDocumentList
                     packageId={packageId}
                     files={supportingDocuments}
+                    rushStatus={rushStatus}
                   />
                 </Tab>
                 <Tab eventKey="comments" title="Filing Comments">

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReviewService.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReviewService.js
@@ -64,3 +64,21 @@ export const downloadRegistryNotice = async (packageId) => {
   const fileUrl = URL.createObjectURL(fileData);
   FileSaver.saveAs(fileUrl, "RegistryNotice.pdf");
 };
+
+/**
+ * Retrieves the Rush Document from the backend API for the given packageId and documentId.
+ *
+ * @param {*} packageId id associated with the filing package.
+ * @param {*} documentId id associated with the document.
+ */
+export const downloadRushDocument = async (packageId, documentId) => {
+  const response = await api.get(
+    `/filingpackages/${packageId}/rushDocument/${documentId}`,
+    {
+      responseType: "blob",
+    }
+  );
+  const fileData = new Blob([response.data], { type: "application/pdf" });
+  const fileUrl = URL.createObjectURL(fileData);
+  FileSaver.saveAs(fileUrl, "RushDocument.pdf");
+};

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/SupportingDocumentList.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/SupportingDocumentList.js
@@ -4,16 +4,20 @@ import { MdDescription } from "react-icons/md";
 import { propTypes } from "../../../types/propTypes";
 import { Toast } from "../../../components/toast/Toast";
 import { isClick, isEnter } from "../../../modules/helpers/eventUtil";
-import { downloadSubmittedDocument } from "./PackageReviewService";
+import { downloadRushDocument } from "./PackageReviewService";
 
 const hash = require("object-hash");
 
-export default function SupportingDocumentList({ packageId, files }) {
+export default function SupportingDocumentList({
+  packageId,
+  files,
+  rushStatus,
+}) {
   const [showToast, setShowToast] = useState(false);
 
   const handleDownloadFileEvent = (e, document) => {
     if (isClick(e) || isEnter(e)) {
-      downloadSubmittedDocument(packageId, document).catch(() => {
+      downloadRushDocument(packageId, document.identifier).catch(() => {
         setShowToast(true);
       });
     }
@@ -23,8 +27,8 @@ export default function SupportingDocumentList({ packageId, files }) {
     <div className="ct-document-list">
       <div className="header">
         <span className="d-none d-lg-inline col-lg-4">File Name</span>
+        <span className="d-none d-lg-inline col-lg-4" />
         <span className="d-none d-lg-inline col-lg-4">Status</span>
-        <span className="d-none d-lg-inline col-lg-4">Registry Notice</span>
       </div>
       {showToast && (
         <Toast
@@ -34,7 +38,6 @@ export default function SupportingDocumentList({ packageId, files }) {
       )}
       <ul>
         {files.map((file) => (
-          // TODO: Fix the classname to be based on the document status when supporting document statuses are added
           <li key={hash(file)} className="SUB">
             <span className="label col-md-5 d-lg-none">File Name:</span>
             <span className="col-md-5 col-lg-4 file-cell">
@@ -50,10 +53,10 @@ export default function SupportingDocumentList({ packageId, files }) {
                 {file.fileName}
               </span>
             </span>
+            <span className="label col-md-5 d-lg-none" />
+            <span className="col-md-5 col-lg-4" />
             <span className="label col-md-5 d-lg-none">Status:</span>
-            <span className="col-md-5 col-lg-4">Submitted</span>
-            <span className="label col-md-5 d-lg-none">Registry Notice:</span>
-            <span className="col-md-5 col-lg-4">Registry notice goes here</span>
+            <span className="col-md-5 col-lg-4">{rushStatus}</span>
           </li>
         ))}
       </ul>
@@ -64,4 +67,5 @@ export default function SupportingDocumentList({ packageId, files }) {
 SupportingDocumentList.propTypes = {
   packageId: PropTypes.number.isRequired,
   files: PropTypes.arrayOf(propTypes.file.isRequired).isRequired,
+  rushStatus: PropTypes.string.isRequired,
 };

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/PackageReview.test.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/PackageReview.test.js
@@ -649,12 +649,52 @@ describe("PackageReview Component", () => {
     expect(rushTab).toHaveAttribute("aria-disabled", "true");
   });
 
+  test("Rush document downloads successfully", async () => {
+    const promise = Promise.resolve();
+    mock.onGet(apiRequest).reply(200, csoRedirectResponseWithRush);
+    mock
+      .onGet(
+        `/filingpackages/${packageId}/rushDocument/${supportingDocuments[0].identifier}`
+      )
+      .reply(200, {});
+
+    jest.mock("file-saver", () => ({ saveAs: jest.fn() }));
+    URL.createObjectURL = jest.fn();
+
+    const { getByText, queryByText, getAllByTestId } = render(
+      <PackageReview />
+    );
+
+    await act(() => promise);
+
+    const rushTab = getByText("Rush Details");
+    expect(rushTab).not.toHaveAttribute("aria-disabled", "false");
+    fireEvent.click(rushTab);
+
+    await act(() => promise);
+
+    expect(
+      getByText("Reason for requesting urgent (rush) filing:")
+    ).toBeInTheDocument();
+
+    const downloadButton = getAllByTestId("uploaded-file")[0];
+    fireEvent.click(downloadButton);
+
+    await act(() => promise);
+
+    expect(
+      queryByText("Something went wrong while trying to download your file.")
+    ).not.toBeInTheDocument();
+
+    expect(FileSaver.saveAs).toHaveBeenCalledTimes(1);
+  });
+
   test("An error is shown when rush tab supporting documents fail to download - click", async () => {
     const promise = Promise.resolve();
     mock.onGet(apiRequest).reply(200, csoRedirectResponseWithRush);
     mock
       .onGet(
-        `/filingpackages/${packageId}/document/${supportingDocuments[0].identifier}`
+        `/filingpackages/${packageId}/rushDocument/${supportingDocuments[0].identifier}`
       )
       .reply(400, {});
 
@@ -687,7 +727,7 @@ describe("PackageReview Component", () => {
     mock.onGet(apiRequest).reply(200, csoRedirectResponseWithRush);
     mock
       .onGet(
-        `/filingpackages/${packageId}/document/${supportingDocuments[0].identifier}`
+        `/filingpackages/${packageId}/rushDocument/${supportingDocuments[0].identifier}`
       )
       .reply(400, {});
 

--- a/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/__snapshots__/PackageReview.test.js.snap
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/__tests__/__snapshots__/PackageReview.test.js.snap
@@ -604,13 +604,11 @@ exports[`PackageReview Component Matches the snapshot 1`] = `
               </span>
               <span
                 class="d-none d-lg-inline col-lg-4"
-              >
-                Status
-              </span>
+              />
               <span
                 class="d-none d-lg-inline col-lg-4"
               >
-                Registry Notice
+                Status
               </span>
             </div>
             <ul />
@@ -1328,13 +1326,11 @@ exports[`PackageReview Component Reload 1`] = `
               </span>
               <span
                 class="d-none d-lg-inline col-lg-4"
-              >
-                Status
-              </span>
+              />
               <span
                 class="d-none d-lg-inline col-lg-4"
               >
-                Registry Notice
+                Status
               </span>
             </div>
             <ul />
@@ -2048,13 +2044,11 @@ exports[`PackageReview Component Withdraw document network error 1`] = `
               </span>
               <span
                 class="d-none d-lg-inline col-lg-4"
-              >
-                Status
-              </span>
+              />
               <span
                 class="d-none d-lg-inline col-lg-4"
               >
-                Registry Notice
+                Status
               </span>
             </div>
             <ul />


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

FLA-1315
- Removed registry notice column from supporting documents table
- Added registry notice Yes/No display on rush tab details
- Updated status column on supporting documents table to display API calculated value
- Added rush document download capability

![image](https://user-images.githubusercontent.com/55457785/143498161-9d2d5d08-8e53-487e-b837-3f80ac2371eb.png)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Manual testing, unit tests.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
