### PR TITLE
Changed null check on package review page to fix POR error

### DIFF
--- a/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.js
@@ -177,7 +177,7 @@ export default function PackageReview() {
               },
               {
                 name: "Rush Processing:",
-                value: isRush ? `Yes` : `No`,
+                value: isRush || isProtectionOrder ? `Yes` : `No`,
                 isNameBold: false,
                 isValueBold: true,
               },
@@ -216,7 +216,7 @@ export default function PackageReview() {
               setIsProtectionOrder(protectionOrderFlag);
             }
 
-            if (response.data.rush.rushType) {
+            if (response.data.rush.reason) {
               setIsRush(true);
               const rushResponse = response.data.rush;
               setRushDetails([


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

FLA-1315
- Change what field of rush response is checked to see if a rush is on a package to fix error with POR documents

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Unit tests, manual testing.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
