### PR TITLE
Moved protection order check outside of rush check

### DIFF
--- a/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-review/PackageReview.js
@@ -207,74 +207,72 @@ export default function PackageReview() {
           setSubmissionHistoryLink(response.data.links.packageHistoryUrl);
           setHasRegistryNotice(response.data.hasRegistryNotice);
 
-          if (rushTabFeatureFlag === "true") {
-            let protectionOrderFlag = isProtectionOrder;
-            if (response.data.documents) {
-              protectionOrderFlag = determineIfProtectionOrder(
-                response.data.documents
+          let protectionOrderFlag = isProtectionOrder;
+          if (response.data.documents) {
+            protectionOrderFlag = determineIfProtectionOrder(
+              response.data.documents
+            );
+            setIsProtectionOrder(protectionOrderFlag);
+          }
+
+          if (response.data.rush.reason && rushTabFeatureFlag === "true") {
+            setIsRush(true);
+            const rushResponse = response.data.rush;
+            setRushDetails([
+              {
+                name: "Reason for requesting urgent (rush) filing:",
+                value: rushResponse.reason,
+                isNameBold: false,
+                isValueBold: true,
+              },
+              {
+                name: "Contact Name:",
+                value: rushResponse.firstName
+                  .concat(" ")
+                  .concat(rushResponse.lastName),
+                isNameBold: false,
+                isValueBold: true,
+              },
+              {
+                name: "Phone Number:",
+                value: rushResponse.phoneNumber,
+                isNameBold: false,
+                isValueBold: true,
+              },
+              {
+                name: "Email:",
+                value: rushResponse.email,
+                isNameBold: false,
+                isValueBold: true,
+              },
+              {
+                name: "Urgent (Rush) Request Status:",
+                value: rushResponse.status,
+                isNameBold: false,
+                isValueBold: true,
+              },
+              {
+                name: "Registry Notice:",
+                value: response.data.hasRegistryNotice ? "Yes" : "No",
+                isNameBold: false,
+                isValueBold: true,
+              },
+            ]);
+            setSupportingDocuments(rushResponse.supportingDocuments);
+            setRushStatus(rushResponse.status);
+
+            if (tabKey === "") {
+              setTabKey(
+                determineDefaultTabKey(defaultTab, true, protectionOrderFlag)
               );
-              setIsProtectionOrder(protectionOrderFlag);
             }
+          } else {
+            setIsRush(false);
 
-            if (response.data.rush.reason) {
-              setIsRush(true);
-              const rushResponse = response.data.rush;
-              setRushDetails([
-                {
-                  name: "Reason for requesting urgent (rush) filing:",
-                  value: rushResponse.reason,
-                  isNameBold: false,
-                  isValueBold: true,
-                },
-                {
-                  name: "Contact Name:",
-                  value: rushResponse.firstName
-                    .concat(" ")
-                    .concat(rushResponse.lastName),
-                  isNameBold: false,
-                  isValueBold: true,
-                },
-                {
-                  name: "Phone Number:",
-                  value: rushResponse.phoneNumber,
-                  isNameBold: false,
-                  isValueBold: true,
-                },
-                {
-                  name: "Email:",
-                  value: rushResponse.email,
-                  isNameBold: false,
-                  isValueBold: true,
-                },
-                {
-                  name: "Urgent (Rush) Request Status:",
-                  value: rushResponse.status,
-                  isNameBold: false,
-                  isValueBold: true,
-                },
-                {
-                  name: "Registry Notice:",
-                  value: response.data.hasRegistryNotice ? "Yes" : "No",
-                  isNameBold: false,
-                  isValueBold: true,
-                },
-              ]);
-              setSupportingDocuments(rushResponse.supportingDocuments);
-              setRushStatus(rushResponse.status);
-
-              if (tabKey === "") {
-                setTabKey(
-                  determineDefaultTabKey(defaultTab, true, protectionOrderFlag)
-                );
-              }
-            } else {
-              setIsRush(false);
-
-              if (tabKey === "") {
-                setTabKey(
-                  determineDefaultTabKey(defaultTab, false, protectionOrderFlag)
-                );
-              }
+            if (tabKey === "") {
+              setTabKey(
+                determineDefaultTabKey(defaultTab, false, protectionOrderFlag)
+              );
             }
           }
         } catch (err) {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

FLA-1315
- Fix for protection order to show the rush status as Yes on the package review screen for protection orders

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Unit tests.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
