### PR TITLE
Fix package confirmation rush status display

### DIFF
--- a/src/frontend/efiling-frontend/src/components/page/rush/Rush.js
+++ b/src/frontend/efiling-frontend/src/components/page/rush/Rush.js
@@ -35,7 +35,7 @@ export default function Rush({
   payment,
   setShowRush,
   setIsRush,
-  setCompletedRushRequest,
+  setHasRushInfo,
 }) {
   const isValidPhoneNumber = (phoneNumber, country) => {
     // Size restriction on CSO database column
@@ -167,7 +167,7 @@ export default function Rush({
     submitRush(payment.submissionId, req)
       .then(() => {
         sessionStorage.setItem("validRushExit", true);
-        setCompletedRushRequest(true);
+        setHasRushInfo(true);
         setShowRush(false);
       })
       .catch((err) => {
@@ -214,7 +214,6 @@ export default function Rush({
       contactMethod: contactMethods.filter((list) => list[0] === e && list)[0],
       phoneNumber: "",
       email: "",
-      surname: "",
     });
     setEmailError(null);
     setPhoneError(null);
@@ -683,5 +682,5 @@ Rush.propTypes = {
   payment: PropTypes.object.isRequired,
   setShowRush: PropTypes.func.isRequired,
   setIsRush: PropTypes.func.isRequired,
-  setCompletedRushRequest: PropTypes.func.isRequired,
+  setHasRushInfo: PropTypes.func.isRequired,
 };

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__tests__/PackageConfirmation.test.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__tests__/PackageConfirmation.test.js
@@ -372,6 +372,29 @@ describe("PackageConfirmation Component", () => {
     expect(rushStatus).toBeInTheDocument();
   });
 
+  test("When package has rush, the screen updates accordingly", async () => {
+    const rush = {
+      rushType: "test",
+    };
+
+    mock
+      .onGet(apiRequest)
+      .reply(200, { documents, court, submissionFeeAmount, rush });
+
+    const { getByText, queryByTestId } = render(
+      <PackageConfirmation
+        packageConfirmation={packageConfirmation}
+        csoAccountStatus={csoAccountStatus}
+      />
+    );
+
+    await waitFor(() => {});
+
+    expect(getByText("Yes")).toBeInTheDocument();
+
+    expect(queryByTestId("rushRadioOpts")).not.toBeInTheDocument();
+  });
+
   test("take user directly to payment page when coming from bambora redirect", async () => {
     sessionStorage.setItem("isBamboraRedirect", true);
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

FLA-1458 and 1459.
- Fixes tracking of the rush state to use the API return value on package confirmation
- Fixes issue where changing the method of contact field cleared the surname field as well

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Unit tests, manual testing.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
