### PR TITLE
Fix uploading files with same name as rush supporting documents

### DIFF
--- a/src/frontend/efiling-frontend/src/components/page/upload/Upload.js
+++ b/src/frontend/efiling-frontend/src/components/page/upload/Upload.js
@@ -260,8 +260,7 @@ export const uploadDocuments = (
   acceptedFiles,
   setShowUpload,
   setShowLoader,
-  setContinueBtnEnabled,
-  setRefreshFiles
+  setContinueBtnEnabled
 ) => {
   axios
     .post(
@@ -279,7 +278,6 @@ export const uploadDocuments = (
             documents: [],
           };
           setShowUpload(false);
-          setRefreshFiles(true);
         })
         .catch((error) =>
           handleError(error, setShowLoader, setContinueBtnEnabled)
@@ -315,7 +313,6 @@ export default function Upload({
     submissionId,
     courtData,
     setShowUpload,
-    setRefreshFiles,
     files: previouslyUploadedFiles,
   },
 }) {
@@ -430,8 +427,7 @@ export default function Upload({
                 acceptedFiles,
                 setShowUpload,
                 setShowLoader,
-                setContinueBtnEnabled,
-                setRefreshFiles
+                setContinueBtnEnabled
               );
             }}
             styling="bcgov-normal-blue btn"
@@ -454,7 +450,6 @@ Upload.propTypes = {
     submissionId: PropTypes.string.isRequired,
     courtData: PropTypes.object.isRequired,
     setShowUpload: PropTypes.func.isRequired,
-    setRefreshFiles: PropTypes.func.isRequired,
     files: PropTypes.arrayOf(propTypes.file.isRequired).isRequired,
   }).isRequired,
 };

--- a/src/frontend/efiling-frontend/src/components/page/upload/Upload.test.js
+++ b/src/frontend/efiling-frontend/src/components/page/upload/Upload.test.js
@@ -58,14 +58,12 @@ describe("Upload Component", () => {
   const submissionFeeAmount = 25.5;
   const setShowLoader = jest.fn();
   const setShowUpload = jest.fn();
-  const setRefreshFiles = jest.fn();
   const files = getJsonDocumentsData();
 
   const upload = {
     submissionId,
     courtData: court,
     setShowUpload,
-    setRefreshFiles,
     files,
   };
 

--- a/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__tests__/PackageConfirmation.test.js
+++ b/src/frontend/efiling-frontend/src/domain/package/package-confirmation/__tests__/PackageConfirmation.test.js
@@ -375,6 +375,16 @@ describe("PackageConfirmation Component", () => {
   test("When package has rush, the screen updates accordingly", async () => {
     const rush = {
       rushType: "test",
+      supportingDocuments: [
+        {
+          fileName: "test-support1.pdf",
+          identifier: null,
+        },
+        {
+          fileName: "test-support2.pdf",
+          identifier: null,
+        },
+      ],
     };
 
     mock


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

FLA-1453
- Fixes issue where users could upload additional documents that had the same file names as documents in the rush supporting documents
- Cleans up use PackageConfirmation code to not require a separate state to determine whether to do an API call or not

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Unit tests, manual testing.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
