### PR TITLE
Updated validation logic on upload screen

### DIFF
--- a/src/frontend/efiling-frontend/src/components/page/upload/Upload.js
+++ b/src/frontend/efiling-frontend/src/components/page/upload/Upload.js
@@ -23,18 +23,7 @@ let filesToUpload = {
 };
 
 const checkValidityOfUploadedFiles = () => {
-  const isValid = (currentValue) =>
-    Object.prototype.hasOwnProperty.call(currentValue, "isAmendment") &&
-    Object.prototype.hasOwnProperty.call(
-      currentValue,
-      "isSupremeCourtScheduling"
-    );
-
-  if (
-    filesToUpload.documents.length > 1 &&
-    filesToUpload.documents.every(isValid)
-  )
-    return true;
+  if (filesToUpload.documents.length >= 1) return true;
   return false;
 };
 

--- a/src/frontend/efiling-frontend/src/components/page/upload/Upload.test.js
+++ b/src/frontend/efiling-frontend/src/components/page/upload/Upload.test.js
@@ -384,6 +384,37 @@ describe("Upload Component", () => {
     expect(queryByText(container, "ping.json")).not.toBeInTheDocument();
   });
 
+  test("Continue button is only enabled if there is more than one document", async () => {
+    const ui = <Upload upload={upload} />;
+    const { container } = render(ui);
+    const dropzone = container.querySelector('[data-testid="dropdownzone"]');
+
+    const file = new File([JSON.stringify({ ping: true })], "ping.json", {
+      type: "application/json",
+    });
+    const data = mockData([file]);
+
+    await waitFor(() => {});
+    await flushPromises(ui, container);
+
+    const button = getByText(container, "Continue");
+
+    expect(button).toBeDisabled();
+
+    dispatchEvt(dropzone, "drop", data);
+
+    await waitFor(() => {});
+    await flushPromises(ui, container);
+
+    expect(button).toBeEnabled();
+
+    const removeIcon = getByTestId(container, "remove-icon");
+
+    fireEvent.click(removeIcon);
+
+    expect(button).toBeDisabled();
+  });
+
   test("files with same name (duplicates) uploaded shows error message", async () => {
     const ui = <Upload upload={upload} />;
     const { container } = render(ui);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

FLA-1463
- Updated file upload logic to only require at least one file uploaded

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Unit tests, manual testing.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
